### PR TITLE
stop acquisition on schema violations

### DIFF
--- a/src/clevis.h
+++ b/src/clevis.h
@@ -30,17 +30,29 @@ typedef struct clevis_acquire_f clevis_acquire_f;
 typedef struct clevis_buf_f clevis_buf_f;
 typedef struct clevis_pin_f clevis_pin_f;
 
+typedef struct clevis_decrypt_result_t clevis_decrypt_result_t;
 typedef struct clevis_pwd_t clevis_pwd_t;
 typedef struct clevis_buf_t clevis_buf_t;
 
 typedef bool clevis_pwd_vfy(const clevis_buf_t *pwd, clevis_pwd_t *misc);
+
+enum decrypt_result {
+  DECRYPT_SUCCESS,
+  DECRYPT_FAIL_STOP,
+  DECRYPT_FAIL_TRYAGAIN
+};
+
+struct clevis_decrypt_result_t {
+  enum decrypt_result result;
+  clevis_buf_t *pt;
+};
 
 struct clevis_provision_f {
   json_t *(*encrypt)(const clevis_buf_t *key, const clevis_buf_t *pt);
 };
 
 struct clevis_acquire_f {
-  clevis_buf_t *(*decrypt)(const clevis_buf_t *key, const json_t *ct);
+  clevis_decrypt_result_t (*decrypt)(const clevis_buf_t *key, const json_t *ct);
   bool (*password)(bool lcl, clevis_pwd_vfy *vfy, clevis_pwd_t *misc);
 };
 

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -29,5 +29,5 @@ crypto_set_kdf_time(const char *str);
 json_t *
 crypto_encrypt(const clevis_buf_t *key, const clevis_buf_t *pt);
 
-clevis_buf_t *
+clevis_decrypt_result_t
 crypto_decrypt(const clevis_buf_t *key, const json_t *ct);

--- a/src/pin_http.c
+++ b/src/pin_http.c
@@ -259,7 +259,7 @@ acquire(const clevis_acquire_f *funcs, const json_t *data)
   if (!okey)
     goto error;
 
-  ikey = funcs->decrypt(okey, json_object_get(data, "ct"));
+  ikey = funcs->decrypt(okey, json_object_get(data, "ct")).pt;
 
 error:
   curl_slist_free_all(headers);

--- a/src/pin_pwd.c
+++ b/src/pin_pwd.c
@@ -32,8 +32,10 @@ struct clevis_pwd_t {
 static bool
 verify(const clevis_buf_t *pwd, clevis_pwd_t *arg)
 {
-  arg->out = arg->funcs->decrypt(pwd, arg->data);
-  return arg->out != NULL;
+  clevis_decrypt_result_t result = arg->funcs->decrypt(pwd, arg->data);
+  if (result.result == DECRYPT_SUCCESS)
+    arg->out = result.pt;
+  return result.result != DECRYPT_FAIL_TRYAGAIN;
 }
 
 static json_t *

--- a/src/pin_sss.c
+++ b/src/pin_sss.c
@@ -429,10 +429,10 @@ egress:
     acq_free(acq);
 
   if (key) {
-    clevis_buf_t *tmp = NULL;
-    tmp = funcs->decrypt(key, json_object_get(data, "ct"));
+    clevis_decrypt_result_t result =
+      funcs->decrypt(key, json_object_get(data, "ct"));
     clevis_buf_free(key);
-    key = tmp;
+    key = result.pt;
   }
 
   clevis_buf_free(prime);


### PR DESCRIPTION
Currently there is no way to distinguish between "incorrect
passphrase" and obvious metadata schema violations such as missing
keys, invalid/unsupported algorithms, or invalid base64-encoded
data.  Acquisition loops forever in these scenarios.

Add the `decrypt_result` enum and `clevis_decrypt_result_t` type to
distinguish success, unrecoverable errors and potentially
recoverable errors in the result of `crypto_decrypt`.

Note that corrupted "iter", "ct" and "salt" values that are still
valid integer or base64 data will not be detected even after this
change.
