### PR TITLE
README.md: Add a missing -d option to clevis-bind-luks example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ this key using Clevis, and store the output JWE inside the LUKS header using
 Here is an example where we bind `/dev/sda1` using the Tang ping:
 
 ```bash
-$ sudo clevis bind-luks /dev/sda1 tang '{"url": "http://tang.local"}'
+$ sudo clevis bind-luks -d /dev/sda1 tang '{"url": "http://tang.local"}'
 The advertisement is signed with the following keys:
         kWwirxc5PhkFIH0yE28nc-EvjDY
 


### PR DESCRIPTION
The clevis-bind-luks command has an -d option to specify the LUKS device
to bind to a pin, but it's missing in the README.md example.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>