### PR TITLE
Don't install clevis tpm2 pin if the tpm2 tools aren't available

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,12 +8,16 @@ EXTRA_DIST = COPYING
 dist_man1_MANS = \
     doc/clevis-encrypt-tang.1 \
     doc/clevis-encrypt-http.1 \
-    doc/clevis-encrypt-tpm2.1 \
     doc/clevis-encrypt-sss.1 \
     doc/clevis-luks-unlock.1 \
     doc/clevis-luks-bind.1 \
     doc/clevis-decrypt.1 \
     doc/clevis.1
+
+if HAVE_TPM2_TOOLS
+    dist_man1_MANS += \
+    doc/clevis-encrypt-tpm2.1
+endif
 
 dist_man7_MANS = \
     doc/clevis-luks-unlockers.7

--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,17 @@ fi
 
 AC_SUBST(SD_ACTIVATE)
 
+for ac_prog in createprimary pcrlist createpolicy create load unseal; do
+    unset TPM2_TOOLS
+    unset ac_cv_prog_TPM2_TOOLS
+    AC_CHECK_PROG([TPM2_TOOLS], [tpm2_$ac_prog], [yes])
+    test -z "$TPM2_TOOLS" && break
+done
+
+test -n "$TPM2_TOOLS" || AC_MSG_WARN([tpm2_$ac_prog not found, tpm2 pin won't be installed])
+
+AM_CONDITIONAL([HAVE_TPM2_TOOLS], [test -n "$TPM2_TOOLS"])
+
 AC_ARG_ENABLE([user],
               AS_HELP_STRING([--enable-user=USER],
                              [Set unprivileged user (default: root)]),

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -17,15 +17,19 @@ bin_PROGRAMS = \
 dist_bin_SCRIPTS = \
     clevis-encrypt-http \
     clevis-encrypt-tang \
-    clevis-encrypt-tpm2 \
     clevis-decrypt-http \
     clevis-decrypt-tang \
-    clevis-decrypt-tpm2 \
     clevis-bind-luks \
     clevis-luks-unlock \
     clevis-luks-bind \
     clevis-decrypt \
     clevis
+
+if HAVE_TPM2_TOOLS
+    dist_bin_SCRIPTS += \
+    clevis-encrypt-tpm2 \
+    clevis-decrypt-tpm2
+endif
 
 clevis_encrypt_sss_SOURCES = clevis-encrypt-sss.c sss.c sss.h
 clevis_decrypt_sss_SOURCES = clevis-decrypt-sss.c sss.c sss.h

--- a/src/dracut/module-setup.sh.in
+++ b/src/dracut/module-setup.sh.in
@@ -28,6 +28,8 @@ cmdline() {
 }
 
 install() {
+    local ret=0
+
     cmdline > "${initdir}/etc/cmdline.d/99clevis.conf"
 
     inst_hook initqueue/online 60 "$moddir/clevis-hook.sh"
@@ -36,13 +38,9 @@ install() {
     inst_multiple /etc/services \
         clevis-decrypt-http \
         clevis-decrypt-tang \
-        clevis-decrypt-tpm2 \
         clevis-decrypt-sss \
         @libexecdir@/clevis-luks-askpass \
         clevis-decrypt \
-        tpm2_createprimary \
-        tpm2_unseal \
-        tpm2_load \
         luksmeta \
         clevis \
         mktemp \
@@ -50,10 +48,26 @@ install() {
         jose \
         nc
 
+    for cmd in clevis-decrypt-tpm2 \
+	tpm2_createprimary \
+	tpm2_unseal \
+	tpm2_load; do
+
+	if ! find_binary "$cmd" &>/dev/null; then
+	    ((ret++))
+	fi
+    done
+
+    if (($ret == 0)); then
+	inst_multiple clevis-decrypt-tpm2 \
+	    tpm2_createprimary \
+	    tpm2_unseal \
+	    tpm2_load
+    fi
+
     dracut_need_initqueue
 }
 
 installkernel() {
     hostonly='' instmods =drivers/char/tpm
 }
-


### PR DESCRIPTION
The tpm2-tools may not be available on some systems, so it shouldn't be
installed unconditionally. Check for the tools before attempting to add
support for the clevis tpm2 pin, both in the system and the initramfs.

Fixes: #26

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>