### PR TITLE
Don't attempt to create temporary files in the user's home directory

### DIFF
--- a/src/clevis-decrypt-tpm2
+++ b/src/clevis-decrypt-tpm2
@@ -82,7 +82,7 @@ if ! jwk_priv=`jose fmt -j- -Og clevis -g tpm2 -g jwk_priv -Su- <<< "$jhd"`; the
     exit 1
 fi
 
-if ! TMP=`mktemp -d -p ~`; then
+if ! TMP=`mktemp -d`; then
     echo "Creating a temporary dir for TPM files failed!" >&2
     exit 1
 fi

--- a/src/clevis-encrypt-tpm2
+++ b/src/clevis-encrypt-tpm2
@@ -92,7 +92,7 @@ if ! jwk=`jose jwk gen -i '{"alg":"A256GCM"}'`; then
     exit 1
 fi
 
-if ! TMP=`mktemp -d -p ~`; then
+if ! TMP=`mktemp -d`; then
     echo "Creating a temporary dir for TPM files failed!" >&2
     exit 1
 fi


### PR DESCRIPTION
To use the tpm2 pin, some temporary files need to be created due how the
tpm2-tools work. Currently they are created in the user's home directory
but the commands can be executed by a user that doesn't have a home dir.

So it's better to just create the temporary directory in /tmp, which is
mktemp default. The mktemp default permissions are u+rwx anyways, so it
isn't less secure to have the temp dir at /tmp instead of the home dir.

Fixes: #30

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>