### PR TITLE
Don't execute clevis-luks-unlock while loop in a subshell

### DIFF
--- a/src/clevis-luks-unlock
+++ b/src/clevis-luks-unlock
@@ -54,7 +54,7 @@ fi
 
 NAME=${NAME:-luks-`cryptsetup luksUUID $DEV`}
 
-luksmeta show -d "$DEV" | while read -r slot state uuid; do
+while read -r slot state uuid; do
     [ "$state" != "active" ] && continue
     [ "$uuid" != "$UUID" ] && continue
 
@@ -62,6 +62,6 @@ luksmeta show -d "$DEV" | while read -r slot state uuid; do
         echo -n "$pt" | cryptsetup open -d- "$DEV" "$NAME"
         exit 0
     fi
-done
+done <<< $(luksmeta show -d "$DEV")
 
 exit 1


### PR DESCRIPTION
The loop that tries to open the dm-crypt devices using the pins in the
luksmeta header is executed in a subshell. So on success it calls exit
to exit the subshell.

But then clevis-luks-unlock has no way to know if the encrypted device
was opened correctly or not. So run the loop in the main shell process
and return 0 as exit status if the operation was successful.

Fixes: #36

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>