### PR TITLE
Exit with code 1 when given a unknown sub-command

### DIFF
--- a/src/clevis
+++ b/src/clevis
@@ -53,3 +53,5 @@ for f in $0-*; do
 done
 
 echo >&2
+
+exit 1


### PR DESCRIPTION
So that things don't silently fail when packages are missing.

Fixes #42