### PR TITLE
Set set-user-ID for clevis-luks-udisks2

### DIFF
--- a/src/udisks2/Makefile.am
+++ b/src/udisks2/Makefile.am
@@ -24,3 +24,6 @@ EXTRA_DIST=clevis-luks-udisks2.desktop.in
 	$(AM_V_GEN)$(SED) \
 		-e 's,@libexecdir\@,$(libexecdir),g' \
 		$(srcdir)/$@.in > $@
+
+install-exec-hook:
+	chmod u+s $(DESTDIR)$(libexecdir)/clevis-luks-udisks2


### PR DESCRIPTION
The clevis-luks-udisks2 program expects to be run as root. But since it's
executed from a Desktop Application Autostart file, it's run by the user
that started the session. So in order to allow it to be run as root, set
the SETUID bit to the executable during the make install target.

This is safe since clevis-luks-udisks2 drops its privileges, and sets the
process credentials to the clevis user for key recovering and to the user
that executed the binary for the unlocking. So the root privilege is only
used to read the LUKS metadata from the encrypted volume.

Fixes: #28

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>