### PR TITLE
Fix decryption of http with jwk+json type

### DIFF
--- a/src/clevis-decrypt-http
+++ b/src/clevis-decrypt-http
@@ -51,7 +51,7 @@ fi
 
 case $typ in
 application/jwk+json)
-    if ! rep=`curl -sfg -H "Accept: $typ" "$url" \
+    if ! jwk=`curl -sfg -H "Accept: $typ" "$url" \
             | jose fmt -j- -Og kty -q oct -EUUo-`; then
         echo "Key transfer failed!" >&2
         exit 1

--- a/tests/pin-http
+++ b/tests/pin-http
@@ -23,6 +23,11 @@ e=`echo -n hi | clevis encrypt http "$cfg"`
 d=`echo -n "$e" | clevis decrypt`
 test "$d" == "hi"
 
+cfg=`jose fmt -j "$cfg" -Oj '"jwk+json"' -s type -U -Oo-`
+e=`echo -n ho | clevis encrypt http "$cfg"`
+d=`echo -n "$e" | clevis decrypt`
+test "$d" == "ho"
+
 kill $PID
 ! wait $PID
 


### PR DESCRIPTION
The expected "jwk" variable wasn't set in this case and the actual
decryption would fail with "Invalid key!".