### PR TITLE
Check for compatible tpm2-tools version

### DIFF
--- a/src/clevis-decrypt-tpm2
+++ b/src/clevis-decrypt-tpm2
@@ -37,6 +37,13 @@ if [ -t 0 ]; then
     exit 1
 fi
 
+TPM2TOOLS_INFO=`tpm2_pcrlist -v`
+
+if [[ $TPM2TOOLS_INFO != *version=\"3.* ]]; then
+    echo "The tpm2 pin requires tpm2-tools version 3" >&2
+    exit 1
+fi
+
 export TPM2TOOLS_TCTI_NAME=device
 export TPM2TOOLS_DEVICE_FILE=`ls /dev/tpmrm? 2>/dev/null`
 

--- a/src/clevis-encrypt-tpm2
+++ b/src/clevis-encrypt-tpm2
@@ -59,6 +59,13 @@ if [ -t 0 ]; then
     exit 1
 fi
 
+TPM2TOOLS_INFO=`tpm2_pcrlist -v`
+
+if [[ $TPM2TOOLS_INFO != *version=\"3.* ]]; then
+    echo "The tpm2 pin requires tpm2-tools version 3" >&2
+    exit 1
+fi
+
 export TPM2TOOLS_TCTI_NAME=device
 export TPM2TOOLS_DEVICE_FILE=`ls /dev/tpmrm? 2>/dev/null`
 


### PR DESCRIPTION
The tpm2 pin requires tpm2-tools version 3, so check if the correct
version was installed and exit with an error if that's not the case.

Fixes: #48

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>