### PR TITLE
Allow to use clevis without dracut

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,25 +5,29 @@ To build and install the Clevis software the following software packages
 are required. In many cases dependencies are platform specific and so the
 following sections describe them for the supported platforms.
 
-## Linux:
-* Autoconf
-* Autoconf archive
-* Automake
-* Libtool
-* C compiler
-* C Library Development Libraries and Header Files
-* [jose](https://github.com/latchset/jose)
-* [luksmeta](https://github.com/latchset/luksmeta)
-* [audit-libs](https://github.com/linux-audit/audit-userspace)
-* [udisks2](https://github.com/storaged-project/udisks)
-* [OpenSSL](https://github.com/openssl/openssl)
-* [desktop-file-utils](https://cgit.freedesktop.org/xdg/desktop-file-utils)
-* [pkg-config](https://cgit.freedesktop.org/pkg-config)
-* [systemd](https://github.com/systemd)
-* [dracut](https://github.com/dracutdevs/dracut)
-* [tang](https://github.com/latchset/tang)
-* [curl](https://github.com/curl/curl)
-* [tpm2-tools](https://github.com/tpm2-software/tpm2-tools)
+## Linux
+Autoconf, Autoconf archive, Automake, Libtool, C compiler, 
+C Library Development Libraries and Header Files
+
+* [José](https://github.com/latchset/jose) (JSON Web Signing and Encryption)
+* [LUKSMeta](https://github.com/latchset/luksmeta) (Adds metadata to LUKS volume)
+* [linux-audit](https://github.com/linux-audit/audit-userspace) (Userspace lib of Linux Auditing Framework)
+* [udisks2](https://github.com/storaged-project/udisks) (Storage management deamon, tools and libs)
+* [desktop-file-utils](https://cgit.freedesktop.org/xdg/desktop-file-utils) (Linux .desktop files / autostart)
+* [pkg-config](https://cgit.freedesktop.org/pkg-config) (Dependency discovery with Autotools)
+* [systemd](https://github.com/systemd) (Control clevis akspass service)
+
+PIN specific dependencies
+* [tang](https://github.com/latchset/tang) (required for pin **Tang**)
+* [curl](https://github.com/curl/curl) (required for pin **Tang** and pin **HTTP**)
+* [tpm2-tools](https://github.com/tpm2-software/tpm2-tools) (required for pin **TPM2**)
+* [OpenSSL](https://github.com/openssl/openssl) (required for pin **Shamir Secret Sharing**)
+
+To automatically decrypt rootfs, initramfs needs to be updated.
+* [dracut](https://github.com/dracutdevs/dracut) (default on Fedora)
+* initramfs-tools not yet supported (PR https://github.com/latchset/clevis/pull/35)
+
+Without updating initramfs, you need to trigger decryption manually.
 
 ### Fedora
 
@@ -33,6 +37,14 @@ used to make sure that the needed packages to compile from source are installed:
 ```
 $ sudo dnf builddep clevis
 ```
+
+### Debian
+
+Dependencies can be checked on Debian bases distributions, too.
+```
+apt build-dep clevis
+```
+Caution: Think twice about replacing initramfs-tools!
 
 # Building From Source
 
@@ -72,7 +84,8 @@ much won't be needed besides providing an alternative --prefix option at
 configure time, and maybe DESTDIR at install time if you're packaging for
 a distro.
 
-After is installed, the dracut and systemd hooks can be added to the
+## Updating initramfs
+After clevis is installed, the dracut and systemd hooks can be added to the
 initramfs with:
 
 ```

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,9 @@
 DISTCHECK_CONFIGURE_FLAGS = \
-    --with-systemdsystemunitdir=$$dc_install_base/$(systemdsystemunitdir) \
+    --with-systemdsystemunitdir=$$dc_install_base/$(systemdsystemunitdir)
+if HAVE_DRACUT
+DISTCHECK_CONFIGURE_FLAGS += \
     --with-dracutmodulesdir=$$dc_install_base/$(dracutmodulesdir)
+endif
 
 SUBDIRS = . src tests
 EXTRA_DIST = COPYING

--- a/configure.ac
+++ b/configure.ac
@@ -17,17 +17,22 @@ PKG_CHECK_MODULES([jansson], [jansson >= 2.10])
 PKG_CHECK_MODULES([udisks2], [udisks2])
 PKG_CHECK_MODULES([jose], [jose >= 8])
 PKG_CHECK_MODULES([systemd], [systemd])
-PKG_CHECK_MODULES([dracut], [dracut])
 PKG_CHECK_MODULES([audit], [audit >= 2.7.8])
 
-AC_CHECK_PROG([PWMAKE], [pwmake], [yes])
-test -n "$PWMAKE" || AC_MSG_ERROR([pwmake required!])
+AC_CHECK_PROG([PWMAKE_IN_PATH], [pwmake], [yes])
+test -n "$PWMAKE_IN_PATH" || AC_MSG_ERROR([pwmake required!])
 
-AC_ARG_WITH([dracutmodulesdir],
-	    [AS_HELP_STRING([--with-dracutmodulesdir=DIR], [Directory for dracut modules])],
-	    [],
-	    [with_dracutmodulesdir=$($PKG_CONFIG --variable=dracutmodulesdir dracut)])
-AC_SUBST([dracutmodulesdir], [$with_dracutmodulesdir])
+AC_CHECK_PROG([DRACUT_IN_PATH], [dracut], [yes])
+AM_CONDITIONAL([HAVE_DRACUT], [test -n "$DRACUT_IN_PATH"])
+if HAVE_DRACUT
+    AC_ARG_WITH([dracutmodulesdir],
+                [AS_HELP_STRING([--with-dracutmodulesdir=DIR], [Directory for dracut modules])],
+                [],
+                [with_dracutmodulesdir=$($PKG_CONFIG --variable=dracutmodulesdir dracut)])
+    AC_SUBST([dracutmodulesdir], [$with_dracutmodulesdir])
+else
+    AC_MSG_WARN([dracut not found: it is required to automatically decrypt rootfs. Configure continues without this feature!])
+fi
 
 AC_ARG_WITH([systemdsystemunitdir],
             [AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd unit files])],


### PR DESCRIPTION
Automatic decryption can be used for removable devices without having
an encrypted rootfs. Some systems still use other tools to generate
their initramfs and the package requirement to have dracut installed
blocks configure if you want to use clevis without dracut.

Signed-off-by: Michael Brandl <git@fineon.pw>