### PR TITLE
Make clevis-luks commands to check if the device is LUKS

### DIFF
--- a/src/clevis-luks-bind
+++ b/src/clevis-luks-bind
@@ -71,6 +71,11 @@ if [ -z "$DEV" ]; then
     usage
 fi
 
+if ! cryptsetup isLuks "$DEV"; then
+    echo "$DEV is not a LUKS device!" >&2
+    exit 1
+fi
+
 if ! PIN=${@:$((OPTIND++)):1} || [ -z "$PIN" ]; then
     echo "Did not specify a pin!" >&2
     usage

--- a/src/clevis-luks-unbind
+++ b/src/clevis-luks-unbind
@@ -55,6 +55,11 @@ if [ -z "$DEV" ]; then
     usage
 fi
 
+if ! cryptsetup isLuks "$DEV"; then
+    echo "$DEV is not a LUKS device!" >&2
+    exit 1
+fi
+
 if [ -z "$SLT" ]; then
     echo "Did not specify a slot!" >&2
     usage


### PR DESCRIPTION
Currently the clevis luks commands don't check if the device passed by the
user is a LUKS device or not. So if a wrong dev is used, clevis will just
exit with a status of 1 without giving any indication what went wrong:

  $ sudo clevis luks bind -d /dev/sda2 tpm2 '{}'
  $ echo $?
  1

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>