### PR TITLE
Check if the LUKS on-disk format is v1

### DIFF
--- a/src/clevis-luks-bind
+++ b/src/clevis-luks-bind
@@ -71,8 +71,8 @@ if [ -z "$DEV" ]; then
     usage
 fi
 
-if ! cryptsetup isLuks "$DEV"; then
-    echo "$DEV is not a LUKS device!" >&2
+if ! cryptsetup isLuks --type luks1 "$DEV"; then
+    echo "$DEV is not a LUKSv1 device!" >&2
     exit 1
 fi
 

--- a/src/clevis-luks-unbind
+++ b/src/clevis-luks-unbind
@@ -55,8 +55,8 @@ if [ -z "$DEV" ]; then
     usage
 fi
 
-if ! cryptsetup isLuks "$DEV"; then
-    echo "$DEV is not a LUKS device!" >&2
+if ! cryptsetup isLuks --type luks1 "$DEV"; then
+    echo "$DEV is not a LUKSv1 device!" >&2
     exit 1
 fi
 


### PR DESCRIPTION
Clevis only supports the LUKSv1 on-disk format, so is not enough to check
if the device is a LUKS device. Also the format version has to be checked.

Suggested-by: Ondrej Kozina <okozina@redhat.com>
Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>