### PR TITLE
Update clevis-luks-askpass nc command line change for ubuntu compatibility

### DIFF
--- a/src/luks/systemd/clevis-luks-askpass
+++ b/src/luks/systemd/clevis-luks-askpass
@@ -59,7 +59,11 @@ while true; do
                 metadata=true
 
                 if pt="`luksmeta load -d $d -s $slot -u $UUID | clevis decrypt`"; then
-                    echo -n "+$pt" | nc -U -u --send-only "$s"
+                    if [ hash nc 2>/dev/null ]; then
+                        echo -n "+$pt" | nc -U -u -w2 "$s"
+                    elif [ hash socat 2>/dev/null ]; then
+                        echo -n "+$pt" | socat -U "UNIX:$s" -
+                    fi
                     unlocked=true
                     break
                 fi
@@ -72,7 +76,11 @@ while true; do
                 metadata=true
 
                 if pt=`echo -n "$jwe" | clevis decrypt`; then
-                    echo -n "+$pt" | nc -U -u --send-only "$s"
+                    if [ hash nc 2>/dev/null ]; then
+                        echo -n "+$pt" | nc -U -u -w2 "$s"
+                    elif [ hash socat 2>/dev/null ]; then
+                        echo -n "+$pt" | socat -U "UNIX:$s" -
+                    fi
                     unlocked=true
                     break
                 fi


### PR DESCRIPTION
Added additional compatibility check for nc and socat.

This is in reference to:
https://github.com/latchset/clevis/pull/51
https://github.com/latchset/clevis/pull/50

This is best practice for bash scripts according to:
https://stackoverflow.com/questions/592620/how-to-check-if-a-program-exists-from-a-bash-script