### PR TITLE
bugfix: set pcr_bank from pcr_bank not pcr_hash field

### DIFF
--- a/src/pins/tpm2/clevis-encrypt-tpm2
+++ b/src/pins/tpm2/clevis-encrypt-tpm2
@@ -88,7 +88,7 @@ hash=`jose fmt -j- -Og hash -u- <<< "$cfg"` || hash="sha256"
 
 key=`jose fmt -j- -Og key -u- <<< "$cfg"` || key="ecc"
 
-pcr_bank=`jose fmt -j- -Og pcr_hash -u- <<< "$cfg"` || pcr_bank="sha1"
+pcr_bank=`jose fmt -j- -Og pcr_bank -u- <<< "$cfg"` || pcr_bank="sha1"
 
 pcr_ids=`jose fmt -j- -Og pcr_ids -u- <<< "$cfg"` || true
 


### PR DESCRIPTION
% git grep pcr_hash
src/pins/tpm2/clevis-encrypt-tpm2:pcr_bank=`jose fmt -j- -Og pcr_hash -u- <<< "$cfg"` || pcr_bank="sha1"

So this is clearly typo and pcr_hash should be pcr_bank