### PR TITLE
Support for initramfs-tools based unlocker (Debian/Ubuntu)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,17 @@ Upon reboot, you will be prompted to unlock the volume using a password. In
 the background, Clevis will attempt to unlock the volume automatically. If it
 succeeds, the password prompt will be cancelled and boot will continue.
 
+#### Unlocker: Initramfs-tools
+
+When using Clevis with initramfs-tools, in order to rebuild your
+initramfs you will need to run:
+
+```bash
+sudo update-initramfs -u -k 'all'
+```
+
+Upon reboot it will behave exactly as if using Dracut.
+
 #### Unlocker: UDisks2
 
 Our UDisks2 unlocker runs in your desktop session. You should not need to

--- a/src/initramfs-tools/hooks/clevis.in
+++ b/src/initramfs-tools/hooks/clevis.in
@@ -1,0 +1,90 @@
+#!/bin/bash
+#
+# Copyright (c) 2017 Shawn Rose
+# Author: Shawn Rose <shawnandrewrose@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+PREREQ="cryptroot"
+prereqs()
+{
+     echo "$PREREQ"
+}
+
+case $1 in
+prereqs)
+     prereqs
+     exit 0
+     ;;
+esac
+
+. @initramfstoolsdir@/hook-functions
+
+die() {
+    code="$1"
+    msg="$2"
+    echo "    (ERROR): $msg" >&2
+    exit $1
+}
+
+find_binary() {
+    bin_name="$1"
+    resolved=$(which ${bin_name})
+    [ -z "$resolved" ] && die 1 "Unable to find ${bin_name}"
+    echo "$resolved"
+}
+
+if [ -n "${FORCE_CLEVIS}" ] && [ "${FORCE_CLEVIS}" != "n" ]; then
+    for f in /sbin/cryptsetup /sbin/dmsetup /lib/cryptsetup/askpass; do
+        if [ ! -e "${DESTDIR}${f}" ]; then
+            die 2 "cryptsetup utility '$f' wasn't found in the generated ramdisk image. "
+        fi
+    done
+fi    
+
+
+copy_exec @bindir@/clevis-decrypt-tang || die 1 "@bindir@/clevis-decrypt-tang not found"
+copy_exec @bindir@/clevis-decrypt-sss || die 1 "@bindir@/clevis-decrypt-sss not found"
+copy_exec @bindir@/clevis-decrypt || die 1 "@bindir@/clevis-decrypt not found"
+if [ -x @bindir@/clevis-decrypt-tpm2 ]; then
+    copy_exec @bindir@/clevis-decrypt-tpm2 || die 1 "@bindir@/clevis-decrypt-tpm2 not found"
+    tpm2_creatprimary_bin=$(find_binary "tpm2_createprimary")
+    tpm2_unseal_bin=$(find_binary "tpm2_unseal")
+    tpm2_load_bin=$(find_binary "tpm2_load")
+    copy_exec "${tpm2_creatprimary_bin}" || die 1 "Unable to copy ${tpm2_creatprimary_bin}" 
+    copy_exec "${tpm2_unseal_bin}" || die 1 "Unable to copy ${tpm2_unseal_bin}"
+    copy_exec "${tpm2_load_bin}" || die 1 "Unable to copy ${tpm2_load_bin}"
+    for _LIBRARY in @libdir@/libtss2-tcti-device.so*; do
+        if [ -e "${_LIBRARY}" ]; then
+            copy_exec "${_LIBRARY}" || die 2 "Unable to copy ${_LIBRARY}"
+        fi
+    done
+fi
+
+
+luksmeta_bin=$(find_binary "luksmeta")
+jose_bin=$(find_binary "jose")
+copy_exec "${luksmeta_bin}" || die 2 "Unable to copy ${luksmeta_bin}"
+copy_exec "${jose_bin}" || die 2 "Unable to copy ${jose_bin}"
+
+
+copy_exec @bindir@/clevis || die 1 "@bindir@/clevis not found"
+curl_bin=$(find_binary "curl")
+awk_bin=$(find_binary "awk")
+bash_bin=$(find_binary "bash")
+copy_exec "${curl_bin}" || die 2 "Unable to copy ${curl_bin} to initrd image"
+copy_exec "${awk_bin}" || die 2 "Unable to copy ${awk_bin} to initrd image"
+copy_exec "${bash_bin}" || die 2 "Unable to copy ${bash_bin} to initrd image"

--- a/src/initramfs-tools/hooks/meson.build
+++ b/src/initramfs-tools/hooks/meson.build
@@ -1,0 +1,6 @@
+configure_file(
+  input: 'clevis.in',
+  output: 'clevis',
+  install_dir: initramfs_hooks_dir,
+  configuration: initramfs_data,
+)

--- a/src/initramfs-tools/meson.build
+++ b/src/initramfs-tools/meson.build
@@ -1,0 +1,16 @@
+initramfs_tools = find_program('update-initramfs', required: false)
+
+if initramfs_tools.found()
+  initramfstools_dir = '/usr/share/initramfs-tools'
+  initramfs_hooks_dir =  '/usr/share/initramfs-tools/hooks'
+  initramfs_scripts_dir = '/usr/share/initramfs-tools/scripts'
+  initramfs_data = configuration_data()
+  initramfs_data.merge_from(data)
+  initramfs_data.set('initramfstoolsdir', initramfstools_dir)
+  libdir = join_paths(get_option('prefix'), get_option('libdir'))
+  initramfs_data.set('libdir', libdir)
+  subdir('hooks')
+  subdir('scripts')
+else
+  warning('Will not install initramfs-tools module due to missing dependencies!')
+endif

--- a/src/initramfs-tools/scripts/local-bottom/clevis.in
+++ b/src/initramfs-tools/scripts/local-bottom/clevis.in
@@ -1,0 +1,49 @@
+#!/bin/sh
+#
+# Copyright (c) 2017 Shawn Rose
+#
+# Author: Shawn Rose <shawnandrewrose@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+PREREQ=""
+
+prereqs() {
+    echo "$PREREQ"
+}
+
+case "$1" in
+    prereqs)
+        prereqs
+        exit 0
+    ;;
+esac
+
+[ -s /run/clevis.pid ] || exit 0
+
+pid=$(cat /run/clevis.pid)
+ps -l | awk -v pid="$pid" '$4==pid { system("kill " $3) }'
+kill "$pid"
+
+# Not really worried about downing extra interfaces: they will come up
+# during the actual boot. Might make this configurable later if needed.
+
+for iface in /sys/class/net/*; do
+    if [ -e "$iface" ]; then
+        ip link  set   dev "$iface" down
+        ip addr  flush dev "$iface"
+        ip route flush dev "$iface"
+    fi
+done

--- a/src/initramfs-tools/scripts/local-bottom/meson.build
+++ b/src/initramfs-tools/scripts/local-bottom/meson.build
@@ -1,0 +1,6 @@
+configure_file(
+  input: 'clevis.in',
+  output: 'clevis',
+  install_dir: join_paths(initramfs_scripts_dir, 'local-bottom'),
+  configuration: initramfs_data,
+)

--- a/src/initramfs-tools/scripts/local-top/clevis.in
+++ b/src/initramfs-tools/scripts/local-top/clevis.in
@@ -1,0 +1,169 @@
+#!/bin/sh
+#
+# Copyright (c) 2017 Red Hat, Inc.
+# Copyright (c) 2017 Shawn Rose
+# Copyright (c) 2017 Guilhem Moulin
+#
+# Author: Harald Hoyer <harald@redhat.com>
+# Author: Nathaniel McCallum <npmccallum@redhat.com>
+# Author: Shawn Rose <shawnandrewrose@gmail.com>
+# Author: Guilhem Moulin <guilhem@guilhem.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+case $1 in
+prereqs) exit 0;;
+esac
+
+# Return 0 if $pid has a file descriptor pointing to $name, 1 otherwise
+in_fds() {
+    local  pid="$1" name="$2" fd
+    for fd in /proc/$pid/fd/*; do
+        if [ -e "$fd" ]; then
+            [ "$(readlink -f "$fd")" != "$name" ] || return 0
+        fi
+    done
+    return 1
+}
+
+# Print the PID of the askpass process with a file descriptor opened to
+# /lib/cryptsetup/passfifo if there is one.
+get_askpass_pid() {
+    psinfo=$(ps) # Doing this so I don't end up matching myself
+    echo "$psinfo" | awk "/$cryptkeyscript/ { print \$1 }" | \
+        while read -r pid; do
+        if in_fds "$pid" "$PASSFIFO"; then
+            echo "$pid"
+            break
+        fi
+    done
+}
+
+# Wait for askpass, and then try and decrypt immediately. Just in case
+# there are multiple devices that need decrypting, this will loop
+# infinitely (The local-bottom script will kill this after decryption)
+clevisloop()
+{
+    set -e
+
+    # Set the path how we want it (Probably not all needed)
+    PATH="/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin"
+
+    if [ -x /bin/plymouth ] && plymouth --ping; then
+        cryptkeyscript='plymouth ask-for-password'
+    else
+        # This has to be escaped for awk
+        cryptkeyscript='\/lib\/cryptsetup\/askpass'
+    fi
+
+    PASSFIFO='/lib/cryptsetup/passfifo'
+
+    OLD_CRYPTTAB_SOURCE=""
+
+    while true; do
+
+        pid=$(get_askpass_pid)
+
+        until [ "$pid" ] && [ -p "$PASSFIFO" ]; do
+            sleep .1
+            pid=$(get_askpass_pid)
+        done
+
+        # Import CRYPTTAB_SOURCE from the askpass process.
+        local "$(grep '^CRYPTTAB_SOURCE=' /proc/"$pid"/environ)"
+
+        # Make sure that CRYPTTAB_SOURCE is actually a block device
+        [ ! -b "$CRYPTTAB_SOURCE" ] && continue
+
+        # Make the source has changed if needed
+        [ "$CRYPTTAB_SOURCE" = "$OLD_CRYPTTAB_SOURCE" ] && continue
+
+        OLD_CRYPTTAB_SOURCE="$CRYPTTAB_SOURCE"
+
+        UUID=cb6e8904-81ff-40da-a84a-07ab9ab5715e
+        luksmeta show -d "$CRYPTTAB_SOURCE" | \
+            while read -r slot state uuid; do
+
+            [ "$state" != "active" ] && continue
+            [ "$uuid" != "$UUID" ] && continue
+            luksmeta load -d "$CRYPTTAB_SOURCE" -s "$slot" -u "$UUID" | \
+                clevis decrypt > "$PASSFIFO"
+            break
+        done
+
+        # Now that the current device has its password, let's sleep a
+        # bit. This gives cryptsetup time to actually decrypt the
+        # device and prompt for the next password if needed.
+        sleep .5
+    done
+}
+
+. /scripts/functions
+
+
+# This is a copy  of 'all_netbootable_devices/all_non_enslaved_devices' for
+# platforms that might not provide it.
+clevis_all_netbootable_devices() {
+    for device in /sys/class/net/* ; do
+            if [ ! -e "$device/flags" ]; then
+                    continue
+            fi
+
+            loop=$(($(cat "$device/flags") & 0x8 && 1 || 0))
+            bc=$(($(cat "$device/flags") & 0x2 && 1 || 0))
+            ptp=$(($(cat "$device/flags") & 0x10 && 1 || 0))
+
+            # Skip any device that is a loopback
+            if [ $loop = 1 ]; then
+                    continue
+            fi
+
+            # Skip any device that isn't a broadcast
+            # or point-to-point.
+            if [ $bc = 0 ] && [ $ptp = 0 ]; then
+                    continue
+            fi
+
+            # Skip any enslaved device (has "master" link
+            # attribute on it)
+            device=$(basename "$device")
+            ip -o link show "$device" | grep -q -w master && continue
+            DEVICE="$DEVICE $device"
+    done
+    echo "$DEVICE"
+}
+
+# Check if network is up before trying to configure it.
+eth_check() {
+    for device in $(clevis_all_netbootable_devices); do
+        ip link set dev "$device" up
+        sleep 1
+        ETH_HAS_CARRIER=$(cat /sys/class/net/"$device"/carrier)
+        if [ "$ETH_HAS_CARRIER" = '1' ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+if eth_check; then
+    # Make sure networking is set up: if booting via nfs, it already is
+    # Doesn't seem to work when added to clevisloop for some reason
+    [ "$boot" = nfs ] || configure_networking
+else
+    echo No Network Connection
+fi
+
+clevisloop &
+echo $! > /run/clevis.pid

--- a/src/initramfs-tools/scripts/local-top/meson.build
+++ b/src/initramfs-tools/scripts/local-top/meson.build
@@ -1,0 +1,6 @@
+configure_file(
+  input: 'clevis.in',
+  output: 'clevis',
+  install_dir: join_paths(initramfs_scripts_dir, 'local-top'),
+  configuration: initramfs_data,
+)

--- a/src/initramfs-tools/scripts/meson.build
+++ b/src/initramfs-tools/scripts/meson.build
@@ -1,0 +1,2 @@
+subdir('local-top')
+subdir('local-bottom')

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,6 +1,7 @@
 subdir('bash')
 subdir('luks')
 subdir('pins')
+subdir('initramfs-tools')
 
 bins += join_paths(meson.current_source_dir(), 'clevis-decrypt')
 mans += join_paths(meson.current_source_dir(), 'clevis-decrypt.1')


### PR DESCRIPTION
The original author of #35 hasn't responded to a ping on their request - I'd be happy to help push this along. These changes are based on #35 - rebased against the current master, and ported to meson. I haven't had a chance to test an Ubuntu system yet, but it seems to build.

I'm in the process of setting up a test environment, but I figured I would create the PR first to get some early feedback, should the author of the original PR resurface I'm happy to have this one closed/marked as dupe.

-----
Added ports to initramfs-tools based systems.

* src/initramfs-tools/hooks/clevis.in: New file.
* src/initramfs-tools/hooks/meson.build: New file.
* src/initramfs-tools/scripts/local-bottom/clevis.in: New file.
* src/initramfs-tools/scripts/local-bottom/meson.build: New file.
* src/initramfs-tools/scripts/local-top/clevis.in: New file.
* src/initramfs-tools/scripts/local-top/meson.build: New file.
* src/initramfs-tools/meson.build: New file.
  Currently uses find_prog() to search for 'update-initramfs' to
  determine whether or not initramfs-tools is installed on the system.
* README.md: Add how to use clevis with a system using initramfs.

Co-authored-by: Max Tottenham <mtottenh@gmail.com>
Co-authored-by: Manolis Ragkousis <manolis837@gmail.com>
Co-authored-by: blaufish <peter.sj.magnusson+github@gmail.com>
Signed-off-by: Manolis Ragkousis <manolis837@gmail.com>