### PR TITLE
Add support for tpm2-tools 4.0

### DIFF
--- a/src/luks/systemd/dracut/clevis-pin-tpm2/module-setup.sh.in
+++ b/src/luks/systemd/dracut/clevis-pin-tpm2/module-setup.sh.in
@@ -18,34 +18,19 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+check() {
+    require_binaries clevis-decrypt-tpm2 tpm2_createprimary tpm2_pcrlist tpm2_unseal tpm2_load || return 1
+    return 0
+}
+
 depends() {
     echo clevis
     return 0
 }
 
 install() {
-    local ret=0
-
-    for cmd in clevis-decrypt-tpm2 \
-	tpm2_createprimary \
-	tpm2_pcrlist \
-	tpm2_unseal \
-	tpm2_load; do
-
-	if ! find_binary "$cmd" &>/dev/null; then
-	    ((ret++))
-	fi
-    done
-
-    if (($ret == 0)); then
-	inst_multiple \
-	    clevis-decrypt-tpm2 \
-	    tpm2_createprimary \
-	    tpm2_pcrlist \
-	    tpm2_unseal \
-	    tpm2_load
-	inst_libdir_file "libtss2-tcti-device.so*"
-    fi
+    inst_multiple clevis-decrypt-tpm2 tpm2_createprimary tpm2_pcrlist tpm2_unseal tpm2_load
+    inst_libdir_file "libtss2-tcti-device.so*"
 }
 
 installkernel() {

--- a/src/luks/systemd/dracut/clevis-pin-tpm2/module-setup.sh.in
+++ b/src/luks/systemd/dracut/clevis-pin-tpm2/module-setup.sh.in
@@ -19,7 +19,8 @@
 #
 
 check() {
-    require_binaries clevis-decrypt-tpm2 tpm2_createprimary tpm2_pcrlist tpm2_unseal tpm2_load || return 1
+    require_binaries clevis-decrypt-tpm2 tpm2_createprimary tpm2_unseal tpm2_load || return 1
+    require_any_binary tpm2_pcrread tpm2_pcrlist || return 1
     return 0
 }
 
@@ -29,7 +30,8 @@ depends() {
 }
 
 install() {
-    inst_multiple clevis-decrypt-tpm2 tpm2_createprimary tpm2_pcrlist tpm2_unseal tpm2_load
+    inst_multiple clevis-decrypt-tpm2 tpm2_createprimary tpm2_unseal tpm2_load
+    inst_multiple -o tpm2_pcrread tpm2_pcrlist
     inst_libdir_file "libtss2-tcti-device.so*"
 }
 

--- a/src/pins/tpm2/clevis-decrypt-tpm2
+++ b/src/pins/tpm2/clevis-decrypt-tpm2
@@ -39,13 +39,16 @@ if [ -t 0 ]; then
     exit 2
 fi
 
-TPM2TOOLS_INFO="$(tpm2_pcrlist -v)"
+TPM2TOOLS_INFO="$(tpm2_createprimary -v)"
 
-if [[ $TPM2TOOLS_INFO != *version=\"3.* ]]; then
-    echo "The tpm2 pin requires tpm2-tools version 3" >&2
+match='version="(.)\.'
+[[ $TPM2TOOLS_INFO =~ $match ]] && TPM2TOOLS_VERSION="${BASH_REMATCH[1]}"
+if [[ $TPM2TOOLS_VERSION != 3 ]] && [[ $TPM2TOOLS_VERSION != 4 ]]; then
+    echo "The tpm2 pin requires tpm2-tools version 3 or 4" >&2
     exit 1
 fi
 
+# Old environment variables for tpm2-tools 3.0
 export TPM2TOOLS_TCTI_NAME=device
 export TPM2TOOLS_DEVICE_FILE=
 for dev in /dev/tpmrm?; do
@@ -53,6 +56,9 @@ for dev in /dev/tpmrm?; do
     TPM2TOOLS_DEVICE_FILE="$dev"
     break
 done
+
+# New environment variable for tpm2-tools >= 3.1
+export TPM2TOOLS_TCTI="$TPM2TOOLS_TCTI_NAME:$TPM2TOOLS_DEVICE_FILE"
 
 if [ -z "$TPM2TOOLS_DEVICE_FILE" ]; then
     echo "A TPM2 device with the in-kernel resource manager is needed!" >&2
@@ -105,10 +111,10 @@ trap 'on_exit' EXIT
 
 pcr_ids="$(jose fmt -j- -Og clevis -g tpm2 -g pcr_ids -Su- <<< "$jhd")" || true
 
-policy_options=()
+pcr_spec=''
 if [ -n "$pcr_ids" ]; then
     pcr_bank="$(jose fmt -j- -Og clevis -g tpm2 -g pcr_bank -Su- <<< "$jhd")"
-    policy_options+=(-L "$pcr_bank:$pcr_ids")
+    pcr_spec="$pcr_bank:$pcr_ids"
 fi
 
 if ! jose b64 dec -i- -O "$TMP"/jwk.pub <<< "$jwk_pub"; then
@@ -121,19 +127,34 @@ if ! jose b64 dec -i- -O "$TMP"/jwk.priv <<< "$jwk_priv"; then
     exit 1
 fi
 
-if ! tpm2_createprimary -Q -H "$auth" -g "$hash" -G "$key" \
-     -C "$TMP"/primary.context 2>/dev/null; then
+case "$TPM2TOOLS_VERSION" in
+    3) tpm2_createprimary -Q -H "$auth" -g "$hash" -G "$key" -C "$TMP"/primary.context || fail=$?;;
+    4) tpm2_createprimary -Q -C "$auth" -g "$hash" -G "$key" -c "$TMP"/primary.context || fail=$?;;
+    *) fail=1;;
+esac
+if [ -n "$fail" ]; then
     echo "Creating TPM2 primary key failed!" >&2
     exit 1
 fi
 
-if ! tpm2_load -Q -c "$TMP"/primary.context -u "$TMP"/jwk.pub -r "$TMP"/jwk.priv \
-     -C "$TMP"/load.context 2>/dev/null; then
+case "$TPM2TOOLS_VERSION" in
+    3) tpm2_load -Q -c "$TMP"/primary.context -u "$TMP"/jwk.pub -r "$TMP"/jwk.priv \
+                 -C "$TMP"/load.context || fail=$?;;
+    4) tpm2_load -Q -C "$TMP"/primary.context -u "$TMP"/jwk.pub -r "$TMP"/jwk.priv \
+                 -c "$TMP"/load.context || fail=$?;;
+    *) fail=1;;
+esac
+if [ -n "$fail" ]; then
     echo "Loading jwk to TPM2 failed!" >&2
     exit 1
 fi
 
-if ! jwk="$(tpm2_unseal -c "$TMP"/load.context "${policy_options[@]}" 2>/dev/null)"; then
+case "$TPM2TOOLS_VERSION" in
+    3) jwk="$(tpm2_unseal -c "$TMP"/load.context ${pcr_spec:+-L $pcr_spec})" || fail=$?;;
+    4) jwk="$(tpm2_unseal -c "$TMP"/load.context ${pcr_spec:+-p pcr:$pcr_spec})" || fail=$?;;
+    *) fail=1;;
+esac
+if [ -n "$fail" ]; then
     echo "Unsealing jwk from TPM failed!" >&2
     exit 1
 fi

--- a/src/pins/tpm2/clevis-encrypt-tpm2
+++ b/src/pins/tpm2/clevis-encrypt-tpm2
@@ -24,7 +24,7 @@ auth="o"
 # Algorithm type must be keyedhash for object with user provided sensitive data.
 alg_create_key="keyedhash"
 # Attributes for the created TPM2 object with the JWK as sensitive data.
-obj_attr="fixedtpm|fixedparent|sensitivedataorigin|noda|adminwithpolicy"
+obj_attr="fixedtpm|fixedparent|noda|adminwithpolicy"
 
 function on_exit() {
     if [ ! -d "$TMP" ] || ! rm -rf "$TMP"; then
@@ -138,6 +138,8 @@ if [ -n "$pcr_ids" ]; then
     fi
 
     policy_options+=(-L "$TMP/pcr.policy")
+else
+    obj_attr="$obj_attr|userwithauth"
 fi
 
 if ! tpm2_create -Q -g "$hash" -G "$alg_create_key" -c "$TMP"/primary.context -u "$TMP"/jwk.pub \

--- a/src/pins/tpm2/clevis-encrypt-tpm2
+++ b/src/pins/tpm2/clevis-encrypt-tpm2
@@ -61,13 +61,16 @@ if [ -t 0 ]; then
     exit 2
 fi
 
-TPM2TOOLS_INFO="$(tpm2_pcrlist -v)"
+TPM2TOOLS_INFO="$(tpm2_createprimary -v)"
 
-if [[ $TPM2TOOLS_INFO != *version=\"3.* ]]; then
-    echo "The tpm2 pin requires tpm2-tools version 3" >&2
+match='version="(.)\.'
+[[ $TPM2TOOLS_INFO =~ $match ]] && TPM2TOOLS_VERSION="${BASH_REMATCH[1]}"
+if [[ $TPM2TOOLS_VERSION != 3 ]] && [[ $TPM2TOOLS_VERSION != 4 ]]; then
+    echo "The tpm2 pin requires tpm2-tools version 3 or 4" >&2
     exit 1
 fi
 
+# Old environment variables for tpm2-tools 3.0
 export TPM2TOOLS_TCTI_NAME=device
 export TPM2TOOLS_DEVICE_FILE=
 for dev in /dev/tpmrm?; do
@@ -75,6 +78,9 @@ for dev in /dev/tpmrm?; do
     TPM2TOOLS_DEVICE_FILE="$dev"
     break
 done
+
+# New environment variable for tpm2-tools >= 3.1
+export TPM2TOOLS_TCTI="$TPM2TOOLS_TCTI_NAME:$TPM2TOOLS_DEVICE_FILE"
 
 if [ -z "$TPM2TOOLS_DEVICE_FILE" ]; then
     echo "A TPM2 device with the in-kernel resource manager is needed!" >&2
@@ -113,7 +119,12 @@ fi
 
 trap 'on_exit' EXIT
 
-if ! tpm2_createprimary -Q -H "$auth" -g "$hash" -G "$key" -C "$TMP"/primary.context; then
+case "$TPM2TOOLS_VERSION" in
+    3) tpm2_createprimary -Q -H "$auth" -g "$hash" -G "$key" -C "$TMP"/primary.context || fail=$?;;
+    4) tpm2_createprimary -Q -C "$auth" -g "$hash" -G "$key" -c "$TMP"/primary.context || fail=$?;;
+    *) fail=1;;
+esac
+if [ -n "$fail" ]; then
     echo "Creating TPM2 primary key failed!" >&2
     exit 1
 fi
@@ -121,7 +132,12 @@ fi
 policy_options=()
 if [ -n "$pcr_ids" ]; then
     if [ -z "$pcr_digest" ]; then
-        if ! tpm2_pcrlist -Q -L "$pcr_bank":"$pcr_ids" -o "$TMP"/pcr.digest; then
+        case "$TPM2TOOLS_VERSION" in
+            3) tpm2_pcrlist -Q -L "$pcr_bank":"$pcr_ids" -o "$TMP"/pcr.digest || fail=$?;;
+            4) tpm2_pcrread -Q "$pcr_bank":"$pcr_ids" -o "$TMP"/pcr.digest || fail=$?;;
+            *) fail=1;;
+        esac
+        if [ -n "$fail" ]; then
             echo "Creating PCR hashes file failed!" >&2
             exit 1
         fi
@@ -132,7 +148,14 @@ if [ -n "$pcr_ids" ]; then
         fi
     fi
 
-    if ! tpm2_createpolicy -Q -g "$hash" -P -L "$pcr_bank":"$pcr_ids" -F "$TMP"/pcr.digest -f "$TMP"/pcr.policy; then
+    case "$TPM2TOOLS_VERSION" in
+        3) tpm2_createpolicy -Q -g "$hash" -P -L "$pcr_bank":"$pcr_ids" \
+                             -F "$TMP"/pcr.digest -f "$TMP"/pcr.policy || fail=$?;;
+        4) tpm2_createpolicy -Q -g "$hash" --policy-pcr -l "$pcr_bank":"$pcr_ids" \
+                             -f "$TMP"/pcr.digest -L "$TMP"/pcr.policy || fail=$?;;
+        *) fail=1;;
+    esac
+    if [ -n "$fail" ]; then
         echo "create policy fail, please check the environment or parameters!"
         exit 1
     fi
@@ -142,8 +165,14 @@ else
     obj_attr="$obj_attr|userwithauth"
 fi
 
-if ! tpm2_create -Q -g "$hash" -G "$alg_create_key" -c "$TMP"/primary.context -u "$TMP"/jwk.pub \
-     -r "$TMP"/jwk.priv -A "$obj_attr" "${policy_options[@]}" -I- <<< "$jwk"; then
+case "$TPM2TOOLS_VERSION" in
+    3) tpm2_create -Q -g "$hash" -G "$alg_create_key" -c "$TMP"/primary.context -u "$TMP"/jwk.pub \
+                   -r "$TMP"/jwk.priv -A "$obj_attr" "${policy_options[@]}" -I- <<< "$jwk" || fail=$?;;
+    4) tpm2_create -Q -g "$hash" -C "$TMP"/primary.context -u "$TMP"/jwk.pub \
+                   -r "$TMP"/jwk.priv -a "$obj_attr" "${policy_options[@]}" -i- <<< "$jwk" || fail=$?;;
+    *) fail=1;;
+esac
+if [ -n "$fail" ]; then
     echo "Creating TPM2 object for jwk failed!" >&2
     exit 1
 fi

--- a/src/pins/tpm2/meson.build
+++ b/src/pins/tpm2/meson.build
@@ -1,8 +1,9 @@
-cmds = ['createprimary', 'pcrlist', 'createpolicy', 'create', 'load', 'unseal']
+cmds = ['tpm2_createprimary', ['tpm2_pcrread', 'tpm2_pcrlist'],
+        'tpm2_createpolicy', 'tpm2_create', 'tpm2_load', 'tpm2_unseal']
 
 all = true
 foreach cmd : cmds
-  all = all and find_program('tpm2_' + cmd, required: false).found()
+  all = all and find_program(cmd, required: false).found()
 endforeach
 
 if all


### PR DESCRIPTION
A first [release candiate](https://github.com/tpm2-software/tpm2-tools/releases/tag/4.0-rc0) for tpm2-tools 4.0 has been tagged. This is a major release that contains many [backwards-incompatible option name changes and tool renames](https://github.com/tpm2-software/tpm2-tools/blob/c02b68d56f1ce7a67b1be580b7efe128d26447bf/CHANGELOG.md#40-rc0---2019-08-19). This PR adds support for the new version while retaining backwards compatibility with tpm2-tools 3.X by parsing the tpm2-tools version output and switching accordingly.

Closes: #56
Fixes: #117