### PR TITLE
clevis-luks-askpass: replace nc by ncat

### DIFF
--- a/src/luks/systemd/clevis-luks-askpass
+++ b/src/luks/systemd/clevis-luks-askpass
@@ -84,7 +84,7 @@ while true; do
                 metadata=true
 
                 if pt="$(luks1_decrypt -d "$d" -s "$slot" -u "$UUID")"; then
-                    echo -n "+$pt" | nc -U -u --send-only "$s"
+                    echo -n "+$pt" | ncat -U -u --send-only "$s"
                     unlocked=true
                     break
                 fi
@@ -96,7 +96,7 @@ while true; do
                 metadata=true
 
                 if pt="$(echo -n "$jwe" | clevis decrypt)"; then
-                    echo -n "+$pt" | nc -U -u --send-only "$s"
+                    echo -n "+$pt" | ncat -U -u --send-only "$s"
                     unlocked=true
                     break
                 fi

--- a/src/luks/systemd/dracut/clevis/module-setup.sh.in
+++ b/src/luks/systemd/dracut/clevis/module-setup.sh.in
@@ -36,7 +36,7 @@ install() {
         clevis \
         mktemp \
         jose \
-        nc
+        ncat
 
     dracut_need_initqueue
 }


### PR DESCRIPTION
`nc` is assumed to be `ncat` from Nmap for the `--send-only` option to work. This assumption holds true on Fedora, where `nc` is a symbolic link to `ncat`, while other distributions only ship the binary with the original upstream name. Replacing the name makes it clearer which version of `nc` is expected and improves compatibility with other distributions while retaining compatibility with Fedora.

This is an alternative approach to #51, which replaces `nc` by `socat`. In contrast to #51, this PR does not require any dependency changes, see https://github.com/latchset/clevis/issues/74#issuecomment-428975197. `ncat` is available on Arch, Debian/Ubuntu, Fedora, openSUSE and possibly many other distributions I haven't checked (since it is the upstream binary name) and is much less ambiguous than `nc` for which many different implementations exist (GNU, OpenBSD, ...).

Fixes: #50
Closes: #51