### PR TITLE
Speed up PBKDF

### DIFF
--- a/src/luks/clevis-luks-bind
+++ b/src/luks/clevis-luks-bind
@@ -127,9 +127,9 @@ esac
 
 # Add the new key
 if [ -n "$SLT" ]; then
-    cryptsetup luksAddKey --key-slot "$SLT" "$DEV"
+    cryptsetup luksAddKey --iter-time 1 --key-slot "$SLT" "$DEV"
 else
-    SLT="$(cryptsetup luksAddKey -v "$DEV" \
+    SLT="$(cryptsetup luksAddKey --iter-time 1 -v "$DEV" \
         | sed -rn 's|^Key slot ([0-9]+) created\.$|\1|p')"
 fi < <(echo "$old"; echo -n "$key")
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
From cryptsetup docs:
" A PBKDF is used for increasing dictionary and brute-force attack cost for keyslot passwords."

Rationale: $key and LUKS Master Key have the same entropy. Therefore the cost of attack on each is about the same and we do not need to waste time in PBKDF. This speeds up mount times by ~2 seconds.