### PR TITLE
pins/tang: check that key derivation key is available

### DIFF
--- a/src/pins/tang/clevis-encrypt-tang
+++ b/src/pins/tang/clevis-encrypt-tang
@@ -115,7 +115,11 @@ elif [ "$thp" != "any" ] && \
 fi
 
 ### Perform encryption
-enc="$(jose jwk use -i- -r -u deriveKey -o- <<< "$jwks")"
+if ! enc="$(jose jwk use -i- -r -u deriveKey -o- <<< "$jwks")"; then
+    echo "Key derivation key not available!" >&2
+    exit 1
+fi
+
 jose fmt -j "$enc" -Og keys -A || enc="{\"keys\":[$enc]}"
 
 if ! jwk="$(jose fmt -j- -Og keys -Af- <<< "$enc")"; then


### PR DESCRIPTION
Sometimes, tang may not generate an advertisement with 'deriveKey' [1],
so let's check whether we have the key derivation key before proceeding
to encryption.

Original patch by D. Kopecek.

[1] Related to https://github.com/latchset/tang/issues/23