### PR TITLE
Compat: Downgrade cryptsetup dependency to v2.0.2

### DIFF
--- a/src/luks/clevis-luks-bind.in
+++ b/src/luks/clevis-luks-bind.in
@@ -22,6 +22,12 @@
 SUMMARY="Binds a LUKS device using the specified policy"
 UUID=cb6e8904-81ff-40da-a84a-07ab9ab5715e
 
+# We require cryptsetup >= 2.0.4 to fully support LUKSv2.
+# Support is determined at build time.
+function luks2_supported() {
+    return @OLD_CRYPTSETUP@
+}
+
 function usage() {
     exec >&2
     echo
@@ -77,13 +83,17 @@ if ! CFG="${@:$((OPTIND++)):1}" || [ -z "$CFG" ]; then
     usage
 fi
 
-if cryptsetup isLuks --type luks1 "$DEV"; then
-    luks_type=luks1
-elif cryptsetup isLuks --type luks2 "$DEV";then
-    luks_type=luks2
+if luks2_supported; then
+    if cryptsetup isLuks --type luks1 "$DEV"; then
+        luks_type="luks1"
+    elif cryptsetup isLuks --type luks2 "$DEV";then
+        luks_type="luks2"
+    else
+        echo "$DEV is not a supported LUKS device!" >&2
+        exit 1
+    fi
 else
-    echo "$DEV is not a supported LUKS device!" >&2
-    exit 1
+    luks_type="luks1"
 fi
 
 if [ -n "$KEY" ]; then

--- a/src/luks/clevis-luks-unbind.in
+++ b/src/luks/clevis-luks-unbind.in
@@ -21,6 +21,12 @@
 SUMMARY="Unbinds a pin bound to a LUKS volume"
 UUID=cb6e8904-81ff-40da-a84a-07ab9ab5715e
 
+# We require cryptsetup >= 2.0.4 to fully support LUKSv2.
+# Support is determined at build time.
+function luks2_supported() {
+    return @OLD_CRYPTSETUP@
+}
+
 function usage() {
     exec >&2
     echo
@@ -67,13 +73,17 @@ if ! cryptsetup isLuks "$DEV"; then
     exit 1
 fi
 
-if cryptsetup isLuks --type luks1 "$DEV"; then
-    luks_type="luks1"
-elif cryptsetup isLuks --type luks2 "$DEV";then
-    luks_type="luks2"
+if luks2_supported; then
+    if cryptsetup isLuks --type luks1 "$DEV"; then
+        luks_type="luks1"
+    elif cryptsetup isLuks --type luks2 "$DEV";then
+        luks_type="luks2"
+    else
+        echo "$DEV is not a supported LUKS device!" >&2
+        exit 1
+    fi
 else
-    echo "$DEV is not a supported LUKS device!" >&2
-    exit 1
+    luks_type="luks1"
 fi
 
 if [ "$luks_type" == "luks1" ]; then

--- a/src/luks/clevis-luks-unlock.in
+++ b/src/luks/clevis-luks-unlock.in
@@ -21,6 +21,12 @@
 SUMMARY="Unlocks a LUKS volume"
 UUID=cb6e8904-81ff-40da-a84a-07ab9ab5715e
 
+# We require cryptsetup >= 2.0.4 to fully support LUKSv2.
+# Support is determined at build time.
+function luks2_supported() {
+    return @OLD_CRYPTSETUP@
+}
+
 function usage() {
     exec >&2
     echo
@@ -58,15 +64,18 @@ if ! cryptsetup isLuks "$DEV"; then
     exit 1
 fi
 
-if cryptsetup isLuks --type luks1 "$DEV"; then
-    luks_type="luks1"
-elif cryptsetup isLuks --type luks2 "$DEV";then
-    luks_type="luks2"
+if luks2_supported; then
+    if cryptsetup isLuks --type luks1 "$DEV"; then
+        luks_type="luks1"
+    elif cryptsetup isLuks --type luks2 "$DEV";then
+        luks_type="luks2"
+    else
+        echo "$DEV is not a supported LUKS device!" >&2
+        exit 1
+    fi
 else
-    echo "$DEV is not a supported LUKS device!" >&2
-    exit 1
+    luks_type="luks1"
 fi
-
 NAME="${NAME:-luks-"$(cryptsetup luksUUID "$DEV")"}"
 
 luks1_decrypt() {

--- a/src/luks/meson.build
+++ b/src/luks/meson.build
@@ -1,18 +1,40 @@
-libcryptsetup = dependency('libcryptsetup', version: '>=2.0.4', required: false)
+
+luksmeta_data = configuration_data()
 luksmeta = dependency('luksmeta', version: '>=8', required: false)
 pwmake = find_program('pwmake', required: false)
 
+libcryptsetup = dependency('libcryptsetup', version: '>=2.0.4', required: false)
+if libcryptsetup.found()
+    luksmeta_data.set('OLD_CRYPTSETUP', '0')
+else
+    libcryptsetup = dependency('libcryptsetup', version: '>=2.0.2', required: false)
+    if libcryptsetup.found()
+        luksmeta_data.set('OLD_CRYPTSETUP', '1')
+        warning('Old version of cryptsetup found, forcing use of luksmeta')
+    endif
+endif
+
+clevis_luks_bind = configure_file(input: 'clevis-luks-bind.in',
+               output: 'clevis-luks-bind',
+               configuration: luksmeta_data)
+
+clevis_luks_unbind = configure_file(input: 'clevis-luks-unbind.in',
+               output: 'clevis-luks-unbind',
+               configuration: luksmeta_data)
+clevis_luks_unlock = configure_file(input: 'clevis-luks-unlock.in',
+               output: 'clevis-luks-unlock',
+               configuration: luksmeta_data)
 if libcryptsetup.found() and luksmeta.found() and pwmake.found()
   subdir('systemd')
   subdir('udisks2')
 
-  bins += join_paths(meson.current_source_dir(), 'clevis-luks-unbind')
+  bins += clevis_luks_unbind
   mans += join_paths(meson.current_source_dir(), 'clevis-luks-unbind.1')
 
-  bins += join_paths(meson.current_source_dir(), 'clevis-luks-unlock')
+  bins += clevis_luks_unlock
   mans += join_paths(meson.current_source_dir(), 'clevis-luks-unlock.1')
 
-  bins += join_paths(meson.current_source_dir(), 'clevis-luks-bind')
+  bins += clevis_luks_bind
   mans += join_paths(meson.current_source_dir(), 'clevis-luks-bind.1')
 
   mans += join_paths(meson.current_source_dir(), 'clevis-luks-unlockers.7')


### PR DESCRIPTION
  * Ubuntu 18.04 LTS ships with v2.02, so by default builds of clevis on
    Ubuntu 18.04 will not configure the luks modules. Downgrading to
    2.02 doesn't seem to remove too much in the way of functionality and
    ensures that 18.04 can use clevis for automated disk unlocking.

  * Make use of LUKSv2 tokens conditional. In order to support older
    distrobutions (running cryptsetup < 2.0.4) stick with using
    luksv1/luksmeta unless v2.0.4 or higher is detected.


Re-opening due to github weirdness. 