### PR TITLE
Revert "[clevis-luks-unbind simplify] luksmeta: Use slot during parsi…

### DIFF
--- a/src/luks/clevis-luks-unbind.in
+++ b/src/luks/clevis-luks-unbind.in
@@ -92,7 +92,7 @@ if [ "$luks_type" == "luks1" ]; then
         exit 1
     fi
 
-    read -r slot state uuid < <(luksmeta show -d "$DEV" -s "$SLT")
+    read -r slot state uuid < <(luksmeta show -d "$DEV" | grep "^$SLT *")
 
     if [ "$uuid" == "empty" ]; then
         echo "The LUKSMeta slot $SLT on device $DEV is already empty." >&2


### PR DESCRIPTION
…ng, not grep"

This reverts commit 9552c4c522b304c14cfd55327b9025c6d962dc8d.

Using slot during parsing, the only information we obtain from LUKSmeta
is the UUID:

luksmeta show -d luks1-device -s 1
cb6e8904-81ff-40da-a84a-07ab9ab5715e

Since we also need the state of the slot, I am reverting the mentioned
commit and we go back to grepping and obtaining the full line:

luksmeta show -d luks1-device | grep "^1 *"
1   active cb6e8904-81ff-40da-a84a-07ab9ab5715e

This fixes an issue with unbinding LUKS1 devices, as we would not
correctly identify the LUKSmeta slot state and hence, would not run
cryptsetup luksKillSlot during the unbind process.