### PR TITLE
trivial: fix non-obvious compilation problems on Ubuntu 19.04 (Fixes: #126)

### DIFF
--- a/src/luks/udisks2/meson.build
+++ b/src/luks/udisks2/meson.build
@@ -1,7 +1,8 @@
 audit = dependency('audit', version: '>=2.7.8', required: false)
 udisks2 = dependency('udisks2', required: false)
+gio = dependency('gio-2.0', required: false)
 
-if udisks2.found() and audit.found()
+if udisks2.found() and audit.found() and gio.found()
   autostartdir = join_paths(sysconfdir, 'xdg', 'autostart')
 
   configure_file(
@@ -16,4 +17,6 @@ if udisks2.found() and audit.found()
     install_dir: libexecdir,
     install: true,
   )
+else
+  warning('Will not build udisks2 support due to missing dependencies!')
 endif


### PR DESCRIPTION
Compilation in a minimal container fails with the non-helpful:
```
 include <udisks/udisks.h>
          ^~~~~~~~~~~~~~~~~
compilation terminated.
[5/8] Compiling C object 'src/pins/sss/1b1ef4e@@clevis-encrypt-sss@exe/sss.c.o'.
ninja: build stopped: subcommand failed.
```

This is a confusing message though because even installing `libudisks2-dev`
doesn't fix it.

It's actually `pkg-config` throwing up failures:
```
$ /usr/bin/pkg-config --cflags udisks2
Package gio-2.0 was not found in the pkg-config search path.
Perhaps you should add the directory containing `gio-2.0.pc'
to the PKG_CONFIG_PATH environment variable
Package 'gio-2.0', required by 'udisks2', not found
```

So the `gio-2.0` dependency is missing.  This can be fixed on Ubuntu or Debian
by installing `libglib2.0-dev`.

So make that a real dependency for compiling udisks2 support.