### PR TITLE
added support for output from 'cryptsetup luksAddKey' for v2.0.2 of cryptsetup

### DIFF
--- a/src/luks/clevis-luks-bind.in
+++ b/src/luks/clevis-luks-bind.in
@@ -139,12 +139,18 @@ esac
 if [ -n "$SLT" ]; then
     cryptsetup luksAddKey --key-slot "$SLT" "$DEV"
 else
-    SLT="$(cryptsetup luksAddKey -v "$DEV" \
-        | sed -rn 's|^Key slot ([0-9]+) created\.$|\1|p')"
-fi < <(echo "$old"; echo -n "$key")
+    SLT=$(cryptsetup luksAddKey -v "$DEV" < <(echo "$old"; echo -n "$key") \
+	    | sed -rn 's|^Key slot ([0-9]+) (unlocked\|created)\.$|\1|p' | head -1)
+fi
 if [ $? -ne 0 ]; then
     echo "Error while adding new key to LUKS header!" >&2
     exit 1
+fi
+
+if [ -z $SLT ]
+then
+	echo "SLT is blank - Error while adding new key to LUKS header! - exiting" >&2
+	exit 1
 fi
 
 if [ "$luks_type" == "luks1" ]; then


### PR DESCRIPTION
In testing it was found the output of `cryptsetup luksAddKey` when running cryptsetup v2.0.2 is as follows:

`$ cryptsetup --version
cryptsetup 2.0.2

$ sudo cryptsetup luksAddKey -v /dev/vol_grp1/logical_vol1  < <(echo "myPassphrase"; echo -n "newKey")
Key slot 0 unlocked.
Key slot 0 unlocked.
Command successful.
`

Note the multiple lines of output plus the use of 'unlocked' in place of 'created'.  Therefore this change is meant to be inclusive of the output of cryptsetup v2.0.2.  This was tested on Ubuntu 18.04 LTS.

Additionally it was found that the error code is not always assigned at line 142, therefore I added the extra catch for the lack of $SLT being assigned.