### PR TITLE
Add tests for LUKS binding and unbinding

### DIFF
--- a/src/luks/meson.build
+++ b/src/luks/meson.build
@@ -41,3 +41,6 @@ if libcryptsetup.found() and luksmeta.found() and pwmake.found()
 else
   warning('Will not install LUKS support due to missing dependencies!')
 endif
+
+# Tests.
+subdir('tests')

--- a/src/luks/tests/bind-luks1
+++ b/src/luks/tests/bind-luks1
@@ -1,0 +1,57 @@
+#!/bin/bash -ex
+# vim: set tabstop=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+TEST=$(basename "${0}")
+. tests-common-functions
+
+on_exit() {
+    [ -d "${TMP}" ] && rm -rf "${TMP}"
+}
+
+trap 'on_exit' EXIT
+trap 'exit' ERR
+
+TMP="$(mktemp -d)"
+
+ADV="${TMP}/adv.jws"
+create_tang_adv "${ADV}"
+CFG="$(printf '{"url":"foobar","adv":"%s"}' "$ADV")"
+
+# LUKS1.
+DEV="${TMP}/luks1-device"
+UUID="cb6e8904-81ff-40da-a84a-07ab9ab5715e"
+new_device "luks1" "${DEV}"
+
+if ! clevis luks bind -f -d "${DEV}" tang "${CFG}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: Binding is expected to succeed when given a correct (${DEFAULT_PASS}) password." >&2
+fi
+
+SLT=1
+if ! read -r _ state uuid < <(luksmeta show -d "${DEV}" | grep "^${SLT} *"); then
+    error "${TEST}: Error reading LUKSmeta info for slot ${SLT} of ${DEV}." >&2
+fi
+
+if [ "${state}" != "active" ]; then
+    error "${TEST}: state (${state}) is expected to be 'active'." >&2
+fi
+
+if [ "${uuid}" != "${UUID}" ]; then
+    error "${TEST}: UUID ($uuid) is expected to be '${UUID}'." >&2
+fi

--- a/src/luks/tests/bind-luks2
+++ b/src/luks/tests/bind-luks2
@@ -1,0 +1,48 @@
+#!/bin/bash -ex
+# vim: set tabstop=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+TEST=$(basename "${0}")
+. tests-common-functions
+
+on_exit() {
+    [ -d "${TMP}" ] && rm -rf "${TMP}"
+}
+
+trap 'on_exit' EXIT
+trap 'exit' ERR
+
+if ! luks2_supported; then
+    error "{TEST}: LUKS2 is not supported."
+fi
+
+TMP="$(mktemp -d)"
+
+ADV="${TMP}/adv.jws"
+create_tang_adv "${ADV}"
+CFG="$(printf '{"url":"foobar","adv":"%s"}' "$ADV")"
+
+# LUKS2.
+
+DEV="${TMP}/luks2-device"
+new_device "luks2" "${DEV}"
+
+if ! clevis luks bind -d "${DEV}" tang "${CFG}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: Binding is expected to succeed when given a correct (${DEFAULT_PASS}) password." >&2
+fi

--- a/src/luks/tests/bind-wrong-pass-luks1
+++ b/src/luks/tests/bind-wrong-pass-luks1
@@ -1,0 +1,56 @@
+#!/bin/bash -ex
+# vim: set tabstop=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+TEST=$(basename "${0}")
+. tests-common-functions
+
+on_exit() {
+    [ -d "${TMP}" ] && rm -rf "${TMP}"
+}
+
+trap 'on_exit' EXIT
+trap 'exit' ERR
+
+TMP="$(mktemp -d)"
+
+ADV="${TMP}/adv.jws"
+create_tang_adv "${ADV}"
+CFG="$(printf '{"url":"foobar","adv":"%s"}' "$ADV")"
+
+# LUKS1.
+DEV="${TMP}/luks1-device"
+new_device "luks1" "${DEV}"
+
+if clevis luks bind -f -d "${DEV}" tang "${CFG}" <<< "wrong-passphrase"; then
+    error "${TEST}: Binding is expected to fail when given a wrong password." >&2
+fi
+
+SLT=1
+if ! read -r _ state uuid < <(luksmeta show -d "${DEV}" | grep "^${SLT} *"); then
+    error "${TEST}: Error reading LUKSmeta info for slot ${SLT} of ${DEV}." >&2
+fi
+
+if [ "${state}" != "inactive" ]; then
+    error "${TEST}: state (${state}) is expected to be 'inactive'." >&2
+fi
+
+if [ "${uuid}" != "empty" ]; then
+    error "${TEST}: UUID ($uuid) is expected to be 'empty'." >&2
+fi

--- a/src/luks/tests/bind-wrong-pass-luks2
+++ b/src/luks/tests/bind-wrong-pass-luks2
@@ -1,0 +1,47 @@
+#!/bin/bash -ex
+# vim: set tabstop=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+TEST=$(basename "${0}")
+. tests-common-functions
+
+on_exit() {
+    [ -d "${TMP}" ] && rm -rf "${TMP}"
+}
+
+trap 'on_exit' EXIT
+trap 'exit' ERR
+
+if ! luks2_supported; then
+    error "{TEST}: LUKS2 is not supported."
+fi
+
+TMP="$(mktemp -d)"
+
+ADV="${TMP}/adv.jws"
+create_tang_adv "${ADV}"
+CFG="$(printf '{"url":"foobar","adv":"%s"}' "$ADV")"
+
+# LUKS2.
+DEV="${TMP}/luks2-device"
+new_device "luks2" "${DEV}"
+
+if clevis luks bind -d "${DEV}" tang "${CFG}" <<< "wrong-passphrase"; then
+    error "${TEST}: Binding is expected to fail when given a wrong password." >&2
+fi

--- a/src/luks/tests/meson.build
+++ b/src/luks/tests/meson.build
@@ -1,0 +1,33 @@
+common_functions = configure_file(input: 'tests-common-functions.in',
+  output: 'tests-common-functions',
+  configuration: luksmeta_data,
+  install: false
+)
+
+env = environment()
+env.prepend('PATH',
+  join_paths(meson.source_root(), 'src'),
+  join_paths(meson.source_root(), 'src', 'luks'),
+  join_paths(meson.source_root(), 'src', 'pins', 'tang'),
+  join_paths(meson.source_root(), 'src', 'pins', 'tpm2'),
+  meson.current_source_dir(),
+  meson.current_build_dir(),
+  join_paths(meson.build_root(), 'src'),
+  join_paths(meson.build_root(), 'src', 'luks'),
+  separator: ':'
+)
+
+test('bind-wrong-pass-luks1', find_program('bind-wrong-pass-luks1'), env: env)
+test('bind-luks1', find_program('bind-luks1'), env: env)
+test('unbind-unbound-slot-luks1', find_program('unbind-unbound-slot-luks1'), env: env)
+test('unbind-luks1', find_program('unbind-luks1'), env: env)
+
+# LUKS2 tests go here, and they get included if we get support for it, based
+# on the cryptsetup version.
+# Binding LUKS2 takes longer, so timeout is increased for a few tests.
+if luksmeta_data.get('OLD_CRYPTSETUP') == '0'
+  test('bind-wrong-pass-luks2', find_program('bind-wrong-pass-luks2'), env: env)
+  test('bind-luks2', find_program('bind-luks2'), env: env, timeout: 60)
+  test('unbind-unbound-slot-luks2', find_program('unbind-unbound-slot-luks2'), env: env)
+  test('unbind-luks2', find_program('unbind-luks2'), env: env, timeout: 60)
+endif

--- a/src/luks/tests/tests-common-functions.in
+++ b/src/luks/tests/tests-common-functions.in
@@ -1,0 +1,67 @@
+#!/bin/bash -ex
+# vim: set tabstop=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# We require cryptsetup >= 2.0.4 to fully support LUKSv2.
+# Support is determined at build time.
+luks2_supported() {
+    return @OLD_CRYPTSETUP@
+}
+
+# Creates a tang adv to be used in the test.
+create_tang_adv() {
+    local adv="${1}"
+    local SIG="${TMP}/sig.jwk"
+    jose jwk gen -i '{"alg":"ES512"}' > "${SIG}"
+
+    local EXC="${TMP}/exc.jwk"
+    jose jwk gen -i '{"alg":"ECMR"}' > "${EXC}"
+
+    local TEMPLATE='{"protected":{"cty":"jwk-set+json"}}'
+    jose jwk pub -s -i "${SIG}" -i "${EXC}" \
+        | jose jws sig -I- -s "${TEMPLATE}" -k "${SIG}" -o "${adv}"
+}
+
+
+# Creates a new LUKS1 or LUKS2 device to be used.
+new_device() {
+    local LUKS="${1}"
+    local DEV="${2}"
+
+    local DEV_CACHED="${TMP}/${LUKS}.cached"
+
+    # Let's reuse an existing device, if there is one.
+    if [ -f "${DEV_CACHED}" ]; then
+        echo "Reusing cached ${LUKS} device..."
+        cp -f "${DEV_CACHED}" "${DEV}"
+        return 0
+    fi
+
+    fallocate -l16M "${DEV}"
+    cryptsetup luksFormat --type "${LUKS}" --batch-mode --force-password "${DEV}" <<< "${DEFAULT_PASS}"
+    # Caching the just-formatted device for possible reuse.
+    cp -f "${DEV}" "${DEV_CACHED}"
+}
+
+error() {
+    echo "${1}" >&2
+    exit 1
+}
+
+export DEFAULT_PASS='just-some-test-password-here'

--- a/src/luks/tests/unbind-luks1
+++ b/src/luks/tests/unbind-luks1
@@ -1,0 +1,74 @@
+#!/bin/bash -ex
+# vim: set tabstop=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+TEST=$(basename "${0}")
+. tests-common-functions
+
+on_exit() {
+    [ -d "${TMP}" ] && rm -rf "${TMP}"
+}
+
+trap 'on_exit' EXIT
+trap 'exit' ERR
+
+TMP="$(mktemp -d)"
+ADV="${TMP}/adv.jws"
+create_tang_adv "${ADV}"
+CFG="$(printf '{"url":"foobar","adv":"%s"}' "$ADV")"
+
+# LUKS1.
+DEV="${TMP}/luks1-device"
+UUID="cb6e8904-81ff-40da-a84a-07ab9ab5715e"
+new_device "luks1" "${DEV}"
+
+# Bind, initially.
+if ! clevis luks bind -f -d "${DEV}" tang "${CFG}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: Binding is expected to succeed when given a correct (${DEFAULT_PASS}) password." >&2
+fi
+
+SLT=1
+if ! read -r _ state uuid < <(luksmeta show -d "${DEV}" | grep "^${SLT} *"); then
+    error "${TEST}: Error reading LUKSmeta info for slot ${SLT} of ${DEV}." >&2
+fi
+
+if [ "${state}" != "active" ]; then
+    error "${TEST}: state (${state}) is expected to be 'active'." >&2
+fi
+
+if [ "${uuid}" != "${UUID}" ]; then
+    error "${TEST}: UUID ($uuid) is expected to be '${UUID}'." >&2
+fi
+
+# Now unbind.
+if ! clevis luks unbind -f -d "${DEV}" -s "${SLT}"; then
+    error "${TEST}: Unbind is expected to succeed for device ${DEV} and slot ${SLT}" >&2
+fi
+
+if ! read -r _ state uuid < <(luksmeta show -d "${DEV}" | grep "^${SLT} *"); then
+    error "${TEST}: Error reading LUKSmeta info for slot ${SLT} of ${DEV}." >&2
+fi
+
+if [ "${state}" != "inactive" ]; then
+    error "${TEST}: state (${state}) is expected to be 'inactive'." >&2
+fi
+
+if [ "${uuid}" != "empty" ]; then
+    error "${TEST}: UUID ($uuid) is expected to be 'empty'." >&2
+fi

--- a/src/luks/tests/unbind-luks2
+++ b/src/luks/tests/unbind-luks2
@@ -1,0 +1,51 @@
+#!/bin/bash -ex
+# vim: set tabstop=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+TEST=$(basename "${0}")
+. tests-common-functions
+
+on_exit() {
+    [ -d "${TMP}" ] && rm -rf "${TMP}"
+}
+
+trap 'on_exit' EXIT
+trap 'exit' ERR
+
+if ! luks2_supported; then
+    error "{TEST}: LUKS2 is not supported."
+fi
+
+TMP="$(mktemp -d)"
+ADV="${TMP}/adv.jws"
+create_tang_adv "${ADV}"
+CFG="$(printf '{"url":"foobar","adv":"%s"}' "$ADV")"
+
+# LUKS2.
+DEV="${TMP}/luks2-device"
+new_device "luks2" "${DEV}"
+# Binding.
+if ! clevis luks bind -d "${DEV}" tang "${CFG}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: Binding is expected to succeed." >&2
+fi
+
+SLT=1
+if ! clevis luks unbind -f -d "${DEV}" -s "${SLT}"; then
+    error "${TEST}: Unbind is expected to succeed for device ${DEV} and slot ${SLT}" >&2
+fi

--- a/src/luks/tests/unbind-unbound-slot-luks1
+++ b/src/luks/tests/unbind-unbound-slot-luks1
@@ -1,0 +1,40 @@
+#!/bin/bash -ex
+# vim: set tabstop=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+TEST=$(basename "${0}")
+. tests-common-functions
+
+on_exit() {
+    [ -d "${TMP}" ] && rm -rf "${TMP}"
+}
+
+trap 'on_exit' EXIT
+trap 'exit' ERR
+
+TMP="$(mktemp -d)"
+
+# LUKS1.
+DEV="${TMP}/luks1-device"
+new_device "luks1" "${DEV}"
+
+SLT=2
+if clevis luks unbind -d "${DEV}" -s "${SLT}"; then
+    error "${TEST}: Unbind is expected to fail for device ${DEV} and slot ${SLT}" >&2
+fi

--- a/src/luks/tests/unbind-unbound-slot-luks2
+++ b/src/luks/tests/unbind-unbound-slot-luks2
@@ -1,0 +1,41 @@
+#!/bin/bash -ex
+# vim: set tabstop=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+TEST=$(basename "${0}")
+. tests-common-functions
+
+on_exit() {
+    [ -d "${TMP}" ] && rm -rf "${TMP}"
+}
+
+trap 'on_exit' EXIT
+trap 'exit' ERR
+
+if ! luks2_supported; then
+    error "{TEST}: LUKS2 is not supported."
+fi
+
+TMP="$(mktemp -d)"
+
+DEV="${TMP}/luks2-device"
+new_device "luks2" "${DEV}"
+if clevis luks unbind -d "${DEV}" -s "${SLT}"; then
+    error "${TEST}: Unbind is expected to fail for device ${DEV} and slot ${SLT}" >&2
+fi


### PR DESCRIPTION
Right now a couple of tests that includes binding fail when running
in a system with old (< 2.0.4) cryptsetup.

Once we have travis-ci integrated, it will be simpler to make sure
common cases are working.