### PR TITLE
fix for different output from 'luksAddKey' command w/cryptsetup v2.0.2

### DIFF
--- a/src/luks/clevis-luks-bind.in
+++ b/src/luks/clevis-luks-bind.in
@@ -143,13 +143,13 @@ if [ -n "$SLT" ]; then
         <(echo -n "$existing_key") "$DEV"
 else
     if [ $luks_type == "luks2" ]; then
-        readarray -t usedSlotsBeforeAddKey < <(cryptsetup luksDump "${DEV}" \ 
+        readarray -t usedSlotsBeforeAddKey < <(cryptsetup luksDump "${DEV}" \
             | sed -rn 's|^\s+([0-9]+): luks2$|\1|p')
     else
         readarray -t usedSlotsBeforeAddKey < <(cryptsetup luksDump "${DEV}" \
             | sed -rn 's|^Key Slot ([0-7]): ENABLED$|\1|p')
     fi
-    cryptsetup luksAddKey --key-file <(echo -n "${existing_key}") "$DEV" 
+    cryptsetup luksAddKey --key-file <(echo -n "${existing_key}") "$DEV"
 fi < <(echo -n "${key}")
 if [ $? -ne 0 ]; then
     echo "Error while adding new key to LUKS header!" >&2

--- a/src/luks/clevis-luks-bind.in
+++ b/src/luks/clevis-luks-bind.in
@@ -28,6 +28,7 @@ function luks2_supported() {
     return @OLD_CRYPTSETUP@
 }
 
+
 function usage() {
     exec >&2
     echo
@@ -135,24 +136,47 @@ case "$KEY" in
  *) ! IFS= read -rd '' existing_key < "$KEY";;
 esac
 
-# Add the new key
+
+if [ -z $SLT ]; then
+    if [ luks_type == "luks2" ]; then
+            readarray -t usedSlotsBeforeAddKey < <(cryptsetup luksDump "${DEV}" | sed -rn 's|^\s+([0-9]+): luks2$|\1|p')
+    else
+            readarray -t usedSlotsBeforeAddKey < <(cryptsetup luksDump "${DEV}" | sed -rn 's|^Key Slot ([0-7]): ENABLED$|\1|p')
+    fi
+fi
+
+#Add the new key
 if [ -n "$SLT" ]; then
     cryptsetup luksAddKey --key-slot "$SLT" --key-file \
         <(echo -n "$existing_key") "$DEV"
 else
-    SLT="$(cryptsetup luksAddKey \
-        --key-file <(echo -n "${existing_key}") -v "$DEV" \
-        | sed -rn 's|^Key slot ([0-9]+) created\.$|\1|p')"
+    cryptsetup luksAddKey --key-file <(echo -n "${existing_key}") -v "$DEV" 
 fi < <(echo -n "${key}")
 if [ $? -ne 0 ]; then
     echo "Error while adding new key to LUKS header!" >&2
     exit 1
 fi
 
+#Find slot used if not defined previously
+if [ -z $SLT ]; then
+    if [ luks_type == "luks2" ]; then
+            readarray -t usedSlotsAfterAddKey < <(cryptsetup luksDump "${DEV}" | sed -rn 's|^\s+([0-9]+): luks2$|\1|p')
+    else
+            readarray -t usedSlotsAfterAddKey < <(cryptsetup luksDump "${DEV}" | sed -rn 's|^Key Slot ([0-7]): ENABLED$|\1|p')
+    fi
+    for i in "${usedSlotsAfterAddKey[@]}"; do
+            if [[ ! " ${usedSlotsBeforeAddKey[@]} " =~ " ${i} " ]]; then
+                    SLT=$i
+                    break
+            fi
+    done
+fi
+
 if [ -z $SLT ]; then
 	echo "Error while adding new key to LUKS header! Key slot is undefined." >&2
 	exit 1
 fi
+
 
 if [ "$luks_type" == "luks1" ]; then
     echo -n "$jwe" | luksmeta save -d "$DEV" -u "$UUID" -s "$SLT" 2>/dev/null

--- a/src/luks/clevis-luks-bind.in
+++ b/src/luks/clevis-luks-bind.in
@@ -149,6 +149,11 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+if [ -z $SLT ]; then
+	echo "Error while adding new key to LUKS header! Key slot is undefined." >&2
+	exit 1
+fi
+
 if [ "$luks_type" == "luks1" ]; then
     echo -n "$jwe" | luksmeta save -d "$DEV" -u "$UUID" -s "$SLT" 2>/dev/null
 else

--- a/src/luks/clevis-luks-bind.in
+++ b/src/luks/clevis-luks-bind.in
@@ -137,38 +137,39 @@ case "$KEY" in
 esac
 
 
-if [ -z $SLT ]; then
-    if [ luks_type == "luks2" ]; then
-            readarray -t usedSlotsBeforeAddKey < <(cryptsetup luksDump "${DEV}" | sed -rn 's|^\s+([0-9]+): luks2$|\1|p')
-    else
-            readarray -t usedSlotsBeforeAddKey < <(cryptsetup luksDump "${DEV}" | sed -rn 's|^Key Slot ([0-7]): ENABLED$|\1|p')
-    fi
-fi
-
 #Add the new key
 if [ -n "$SLT" ]; then
     cryptsetup luksAddKey --key-slot "$SLT" --key-file \
         <(echo -n "$existing_key") "$DEV"
 else
-    cryptsetup luksAddKey --key-file <(echo -n "${existing_key}") -v "$DEV" 
+    if [ $luks_type == "luks2" ]; then
+        readarray -t usedSlotsBeforeAddKey < <(cryptsetup luksDump "${DEV}" \ 
+            | sed -rn 's|^\s+([0-9]+): luks2$|\1|p')
+    else
+        readarray -t usedSlotsBeforeAddKey < <(cryptsetup luksDump "${DEV}" \
+            | sed -rn 's|^Key Slot ([0-7]): ENABLED$|\1|p')
+    fi
+    cryptsetup luksAddKey --key-file <(echo -n "${existing_key}") "$DEV" 
 fi < <(echo -n "${key}")
 if [ $? -ne 0 ]; then
     echo "Error while adding new key to LUKS header!" >&2
     exit 1
 fi
 
-#Find slot used if not defined previously
+#Determine slot used by new key if a desired slot was not specified
 if [ -z $SLT ]; then
-    if [ luks_type == "luks2" ]; then
-            readarray -t usedSlotsAfterAddKey < <(cryptsetup luksDump "${DEV}" | sed -rn 's|^\s+([0-9]+): luks2$|\1|p')
+    if [ $luks_type == "luks2" ]; then
+        readarray -t usedSlotsAfterAddKey < <(cryptsetup luksDump "${DEV}" \
+            | sed -rn 's|^\s+([0-9]+): luks2$|\1|p')
     else
-            readarray -t usedSlotsAfterAddKey < <(cryptsetup luksDump "${DEV}" | sed -rn 's|^Key Slot ([0-7]): ENABLED$|\1|p')
+        readarray -t usedSlotsAfterAddKey < <(cryptsetup luksDump "${DEV}" \
+            | sed -rn 's|^Key Slot ([0-7]): ENABLED$|\1|p')
     fi
     for i in "${usedSlotsAfterAddKey[@]}"; do
-            if [[ ! " ${usedSlotsBeforeAddKey[@]} " =~ " ${i} " ]]; then
-                    SLT=$i
-                    break
-            fi
+        if [[ ! " ${usedSlotsBeforeAddKey[@]} " =~ " ${i} " ]]; then
+            SLT=$i
+            break
+        fi
     done
 fi
 
@@ -176,7 +177,6 @@ if [ -z $SLT ]; then
 	echo "Error while adding new key to LUKS header! Key slot is undefined." >&2
 	exit 1
 fi
-
 
 if [ "$luks_type" == "luks1" ]; then
     echo -n "$jwe" | luksmeta save -d "$DEV" -u "$UUID" -s "$SLT" 2>/dev/null

--- a/src/luks/clevis-luks-bind.in
+++ b/src/luks/clevis-luks-bind.in
@@ -157,8 +157,8 @@ if [ $? -ne 0 ]; then
 fi
 
 #Determine slot used by new key if a desired slot was not specified
-if [ -z $SLT ]; then
-    if [ $luks_type == "luks2" ]; then
+if [ -z "$SLT" ]; then
+    if [ "$luks_type" == "luks2" ]; then
         readarray -t usedSlotsAfterAddKey < <(cryptsetup luksDump "${DEV}" \
             | sed -rn 's|^\s+([0-9]+): luks2$|\1|p')
     else
@@ -173,7 +173,7 @@ if [ -z $SLT ]; then
     done
 fi
 
-if [ -z $SLT ]; then
+if [ -z "$SLT" ]; then
 	echo "Error while adding new key to LUKS header! Key slot is undefined." >&2
 	exit 1
 fi


### PR DESCRIPTION
Below is the output of the `cryptsetup luksAddKey` command on Ubuntu 18.04 running cryptsetup v2.0.2:

`$ cryptsetup --version
cryptsetup 2.0.2`

`$ sudo cryptsetup luksAddKey -v /dev/vg1/lv1  < <(echo "myPassphrase"; echo -n "newKey")`
`Key slot 0 unlocked.`
`Key slot 0 unlocked.`
`Command successful.`

My change accommodates the use of '`unlocked`' vs, '`created`' as well as the fact that two identical lines are output.  
Additionally, errors can occur at line 142 without being passed on, therefore, I've added a 2nd if/then catch for a case when `SLT` does not get properly assigned a value by this point.