### PR TITLE
Validate the pcr_ids and error out if parsing fails

### DIFF
--- a/src/pins/tpm2/clevis-decrypt-tpm2
+++ b/src/pins/tpm2/clevis-decrypt-tpm2
@@ -159,4 +159,8 @@ if [ -n "$fail" ]; then
     exit 1
 fi
 
+# The on_exit() trap will not be fired after exec, so let's clean up the temp
+# directory at this point.
+[ -d "${TMP}" ] && rm -rf "${TMP}"
+
 exec jose jwe dec -k- -i- < <(echo -n "$jwk$hdr."; /bin/cat)

--- a/src/pins/tpm2/clevis-encrypt-tpm2
+++ b/src/pins/tpm2/clevis-encrypt-tpm2
@@ -103,7 +103,29 @@ key="$(jose fmt -j- -Og key -u- <<< "$cfg")" || key="ecc"
 
 pcr_bank="$(jose fmt -j- -Og pcr_bank -u- <<< "$cfg")" || pcr_bank="sha1"
 
-pcr_ids="$(jose fmt -j- -Og pcr_ids -u- <<< "$cfg")" || true
+# Issue #103: We support passing pcr_ids using both a single string, as in
+# "1,3", as well as an actual JSON array, such as ["1,"3"]. Let's handle both
+# cases here.
+if [[ ${cfg// /} != '{}' ]] \
+    && ! pcr_ids="$(jose fmt -j- -Og pcr_ids -u- 2>/dev/null <<< "$cfg")"; then
+
+    # We failed to parse a string, so let's try to parse a JSON array instead.
+    if jose fmt -j- -Og pcr_ids -A 2>/dev/null <<< "${cfg}"; then
+        # OK, it is an array, so let's get the items and form a string.
+        pcr_ids=
+        for pcr in $(jose fmt -j- -Og pcr_ids -Af- <<< "${cfg}" \
+                     | tr -d '"'); do
+            pcr_ids=$(printf '%s,%s' "${pcr_ids}" "${pcr}")
+        done
+        # Now let's remove the leading comma.
+        pcr_ids=${pcr_ids/#,/}
+    else
+        # Not to add a policy that was not intended, in this case, no policy
+        # at all, let's report the issue and exit.
+        echo "Parsing the requested policy failed!" >&2
+        exit 1
+    fi
+fi
 
 pcr_digest="$(jose fmt -j- -Og pcr_digest -u- <<< "$cfg")" || true
 

--- a/src/pins/tpm2/clevis-encrypt-tpm2
+++ b/src/pins/tpm2/clevis-encrypt-tpm2
@@ -221,4 +221,8 @@ fi
 jwe="$(jose fmt -j "$jwe" -g protected -g clevis -g tpm2 -q "$jwk_pub" -s jwk_pub -UUUUo-)"
 jwe="$(jose fmt -j "$jwe" -g protected -g clevis -g tpm2 -q "$jwk_priv" -s jwk_priv -UUUUo-)"
 
+# The on_exit() trap will not be fired after exec, so let's clean up the temp
+# directory at this point.
+[ -d "${TMP}" ] && rm -rf "${TMP}"
+
 exec jose jwe enc -i- -k- -I- -c < <(echo -n "$jwe$jwk"; /bin/cat)

--- a/src/pins/tpm2/meson.build
+++ b/src/pins/tpm2/meson.build
@@ -13,3 +13,22 @@ if all
 else
   warning('Will not install tpm2 pin due to missing dependencies!')
 endif
+
+# Tests.
+env = environment()
+env.prepend('PATH',
+  join_paths(meson.source_root(), 'src'),
+  join_paths(meson.source_root(), 'src', 'luks'),
+  join_paths(meson.source_root(), 'src', 'luks', 'tests'),
+  join_paths(meson.source_root(), 'src', 'pins', 'sss'),
+  join_paths(meson.source_root(), 'src', 'pins', 'tang'),
+  join_paths(meson.source_root(), 'src', 'pins', 'tpm2'),
+  join_paths(meson.build_root(), 'src'),
+  join_paths(meson.build_root(), 'src', 'luks'),
+  join_paths(meson.build_root(), 'src', 'luks', 'tests'),
+  join_paths(meson.build_root(), 'src', 'pins', 'sss'),
+  join_paths(meson.build_root(), 'src', 'pins', 'tang'),
+  join_paths(meson.build_root(), 'src', 'pins', 'tpm2'),
+  separator: ':'
+)
+test('pin-tpm2', find_program('pin-tpm2'), env: env, timeout: 90)

--- a/src/pins/tpm2/pin-tpm2
+++ b/src/pins/tpm2/pin-tpm2
@@ -1,0 +1,108 @@
+#!/bin/bash -x
+# vim: set tabstop=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+TEST=$(basename "${0}")
+
+# Code to return to mark test as skipped.
+SKIP_RET_CODE=77
+
+tpm2_available() {
+    # Old environment variables for tpm2-tools 3.0
+    export TPM2TOOLS_TCTI_NAME=device
+    export TPM2TOOLS_DEVICE_FILE=
+    for dev in /dev/tpmrm?; do
+        [ -e "${dev}" ] || continue
+        TPM2TOOLS_DEVICE_FILE="${dev}"
+        break
+    done
+
+    # New environment variable for tpm2-tools >= 3.1
+    export TPM2TOOLS_TCTI="${TPM2TOOLS_TCTI_NAME}:${TPM2TOOLS_DEVICE_FILE}"
+
+    if [ -z "${TPM2TOOLS_DEVICE_FILE}" ]; then
+        echo "A TPM2 device with the in-kernel resource manager is needed!" >&2
+        return 1
+    fi
+
+    if ! [[ -r "${TPM2TOOLS_DEVICE_FILE}" \
+            && -w "${TPM2TOOLS_DEVICE_FILE}" ]]; then
+        echo "The ${TPM2TOOLS_DEVICE_FILE} device must be readable and writable!" >&2
+        return 1
+    fi
+}
+
+# Checking if we can run this test.
+if ! tpm2_available; then
+    exit ${SKIP_RET_CODE}
+fi
+
+decode_jwe() {
+    local jwe="${1}"
+
+    local coded
+    if ! coded=$(jose jwe fmt -i- <<< "${jwe}"); then
+        return 1
+    fi
+
+    coded=$(jose fmt -j- -g protected -u- <<< "${coded}" | tr -d '"')
+    jose b64 dec -i- <<< "${coded}"
+}
+
+test_pcr_ids() {
+    local orig="${1}"
+    local cfg="${2}"
+    local expected_pcr_ids="${3}"
+
+    local enc
+    if ! enc=$(echo "${orig}" | clevis encrypt tpm2 "${cfg}"); then
+        echo "${TEST}: encrypt failed for cfg: ${cfg}" >&1
+        return 1
+    fi
+
+    local pcr_ids
+    pcr_ids=$(decode_jwe "${enc}" \
+              | jose fmt -j- -Og clevis -Og tpm2 -Og pcr_ids -u- 2>/dev/null)
+
+    local dec
+    dec=$(echo "${enc}" | clevis decrypt)
+
+    if [ "${orig}" != "${dec}" ]; then
+        echo "${TEST}: decoded text (${dec}) does not match original one (${orig})" >&2
+        return 1
+    fi
+
+    if [ "${pcr_ids}" != "${expected_pcr_ids}" ]; then
+        echo "${TEST}: pcr_ids (${pcr_ids}) do not match the expected (${expected_pcr_ids}) result." >&2
+        return 1
+    fi
+}
+
+test_pcr_ids "${orig}" '{}' "" || exit 1
+test_pcr_ids "${orig}" '{                   }' "" || exit 1
+
+# Issue #103: now let's try a few different configs with both strings and
+# arrays and check if we get the expected pcr_ids.
+test_pcr_ids "${orig}" '{"pcr_ids": "16"}' "16" || exit 1
+test_pcr_ids "${orig}" '{"pcr_ids": ["16"]}' "16"  || exit 1
+test_pcr_ids "${orig}" '{"pcr_ids": "4,16"}' "4,16" || exit 1
+test_pcr_ids "${orig}" '{"pcr_ids": ["4,16"]}' "4,16" || exit 1
+test_pcr_ids "${orig}" '{"pcr_ids": [4,16]}' "4,16" || exit 1
+test_pcr_ids "${orig}" '{"pcr_ids": ["4","16"]}' "4,16" || exit 1
+! test_pcr_ids "${orig}" '{"pcr_ids": ["4","16"]}' "foo bar" || exit 1


### PR DESCRIPTION
As of now, our parsing of pcr_ids fails if we try to use an actual JSON
array, and when it happens, we end up silently using no policy at all,
which is certainly not what the user requested/intended.

This patch improves our parsing to support reading both strings and JSON
arrays for the pcr_ids propery. If we encounter an error, we report it
and exit.

Fixes: #103