### PR TITLE
Rework the logic for reading the existing key

### DIFF
--- a/src/luks/clevis-luks-bind.in
+++ b/src/luks/clevis-luks-bind.in
@@ -128,20 +128,22 @@ if [ "$luks_type" == "luks1" ] && ! luksmeta test -d "$DEV"; then
     luksmeta init -d "$DEV" "${FRC[@]}"
 fi
 
-# Get the old key
+# Get the existing key.
 case "$KEY" in
-"") read -r -s -p "Enter existing LUKS password: " old; echo;;
- -) old="$(/bin/cat)";;
- *) old="$(/bin/cat "$KEY")";;
+"") read -r -s -p "Enter existing LUKS password: " existing_key; echo;;
+ -) existing_key="$(/bin/cat)";;
+ *) ! IFS= read -rd '' existing_key < "$KEY";;
 esac
 
 # Add the new key
 if [ -n "$SLT" ]; then
-    cryptsetup luksAddKey --key-slot "$SLT" "$DEV"
+    cryptsetup luksAddKey --key-slot "$SLT" --key-file \
+        <(echo -n "$existing_key") "$DEV"
 else
-    SLT="$(cryptsetup luksAddKey -v "$DEV" \
+    SLT="$(cryptsetup luksAddKey \
+        --key-file <(echo -n "${existing_key}") -v "$DEV" \
         | sed -rn 's|^Key slot ([0-9]+) created\.$|\1|p')"
-fi < <(echo "$old"; echo -n "$key")
+fi < <(echo -n "${key}")
 if [ $? -ne 0 ]; then
     echo "Error while adding new key to LUKS header!" >&2
     exit 1

--- a/src/luks/tests/bind-key-file-non-interactive-luks1
+++ b/src/luks/tests/bind-key-file-non-interactive-luks1
@@ -1,0 +1,59 @@
+#!/bin/bash -ex
+# vim: set tabstop=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+TEST="${0}"
+. tests-common-functions
+
+on_exit() {
+    [ -d "${TMP}" ] && rm -rf "${TMP}"
+}
+
+trap 'on_exit' EXIT
+trap 'exit' ERR
+
+TMP="$(mktemp -d)"
+
+ADV="${TMP}/adv.jws"
+create_tang_adv "${ADV}"
+CFG="$(printf '{"url":"foobar","adv":"%s"}' "$ADV")"
+UUID="cb6e8904-81ff-40da-a84a-07ab9ab5715e"
+KEYFILE="${TMP}/key"
+PASS=$(openssl rand -hex 8)
+echo -n "${PASS}" > "${KEYFILE}"
+
+# LUKS1.
+DEV="${TMP}/luks1-device"
+new_device_keyfile "luks1" "${DEV}" "${KEYFILE}"
+if ! clevis luks bind -f -k "${KEYFILE}" -d "${DEV}" tang "${CFG}"; then
+    error "${TEST}: Binding is expected to succeed when given a correct (${KEYFILE})." >&2
+fi
+
+SLT=1
+if ! read -r _ state uuid < <(luksmeta show -d "${DEV}" | grep "^${SLT} *"); then
+    error "${TEST}: Error reading LUKSmeta info for slot ${SLT} of ${DEV}." >&2
+fi
+
+if [ "${state}" != "active" ]; then
+    error "${TEST}: state (${state}) is expected to be 'active'." >&2
+fi
+
+if [ "${uuid}" != "${UUID}" ]; then
+    error "${TEST}: UUID ($uuid) is expected to be '${UUID}'." >&2
+fi

--- a/src/luks/tests/bind-pass-with-newline-keyfile-luks1
+++ b/src/luks/tests/bind-pass-with-newline-keyfile-luks1
@@ -1,0 +1,70 @@
+#!/bin/bash -ex
+# vim: set tabstop=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+TEST="${0}"
+. tests-common-functions
+
+on_exit() {
+    [ -d "${TMP}" ] && rm -rf "${TMP}"
+}
+
+trap 'on_exit' EXIT
+trap 'exit' ERR
+
+TMP="$(mktemp -d)"
+
+ADV="${TMP}/adv.jws"
+create_tang_adv "${ADV}"
+CFG="$(printf '{"url":"foobar","adv":"%s"}' "$ADV")"
+
+# LUKS1.
+DEV="${TMP}/luks1-device"
+UUID="cb6e8904-81ff-40da-a84a-07ab9ab5715e"
+
+# Using newlines and special chars in the passphrase.
+PASS="foo
+
+bar
+
+\\\&#@@&@*!)(
+
+$$$
+"
+
+KEYFILE="${TMP}/key"
+echo -n "${PASS}" > "${KEYFILE}"
+
+new_device_keyfile "luks1" "${DEV}" "${KEYFILE}"
+if ! clevis luks bind -f -k "${KEYFILE}" -d "${DEV}" tang "${CFG}"; then
+    error "${TEST}: Binding is expected to succeed when given a correct (${KEYFILE}) password." >&2
+fi
+
+SLT=1
+if ! read -r _ state uuid < <(luksmeta show -d "${DEV}" | grep "^${SLT} *"); then
+    error "${TEST}: Error reading LUKSmeta info for slot ${SLT} of ${DEV}." >&2
+fi
+
+if [ "${state}" != "active" ]; then
+    error "${TEST}: state (${state}) is expected to be 'active'." >&2
+fi
+
+if [ "${uuid}" != "${UUID}" ]; then
+    error "${TEST}: UUID ($uuid) is expected to be '${UUID}'." >&2
+fi

--- a/src/luks/tests/bind-pass-with-newline-luks1
+++ b/src/luks/tests/bind-pass-with-newline-luks1
@@ -1,0 +1,67 @@
+#!/bin/bash -ex
+# vim: set tabstop=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+TEST="${0}"
+. tests-common-functions
+
+on_exit() {
+    [ -d "${TMP}" ] && rm -rf "${TMP}"
+}
+
+trap 'on_exit' EXIT
+trap 'exit' ERR
+
+TMP="$(mktemp -d)"
+
+ADV="${TMP}/adv.jws"
+create_tang_adv "${ADV}"
+CFG="$(printf '{"url":"foobar","adv":"%s"}' "$ADV")"
+
+# LUKS1.
+DEV="${TMP}/luks1-device"
+UUID="cb6e8904-81ff-40da-a84a-07ab9ab5715e"
+
+# Using newlines and special chars in the passphrase.
+PASS="foo
+
+bar
+
+\\\&#@@&@*!)(
+
+$$$
+"
+new_device "luks1" "${DEV}" "${PASS}"
+
+if ! clevis luks bind -f -d "${DEV}" tang "${CFG}" <<< "${PASS}"; then
+    error "${TEST}: Binding is expected to succeed when given a correct (${PASS}) password." >&2
+fi
+
+SLT=1
+if ! read -r _ state uuid < <(luksmeta show -d "${DEV}" | grep "^${SLT} *"); then
+    error "${TEST}: Error reading LUKSmeta info for slot ${SLT} of ${DEV}." >&2
+fi
+
+if [ "${state}" != "active" ]; then
+    error "${TEST}: state (${state}) is expected to be 'active'." >&2
+fi
+
+if [ "${uuid}" != "${UUID}" ]; then
+    error "${TEST}: UUID ($uuid) is expected to be '${UUID}'." >&2
+fi

--- a/src/luks/tests/meson.build
+++ b/src/luks/tests/meson.build
@@ -21,6 +21,9 @@ test('bind-wrong-pass-luks1', find_program('bind-wrong-pass-luks1'), env: env)
 test('bind-luks1', find_program('bind-luks1'), env: env)
 test('unbind-unbound-slot-luks1', find_program('unbind-unbound-slot-luks1'), env: env)
 test('unbind-luks1', find_program('unbind-luks1'), env: env)
+test('bind-key-file-non-interactive', find_program('bind-key-file-non-interactive-luks1'), env: env)
+test('bind-pass-with-newline', find_program('bind-pass-with-newline-luks1'), env: env)
+test('bind-pass-with-newline-keyfile', find_program('bind-pass-with-newline-keyfile-luks1'), env: env)
 
 # LUKS2 tests go here, and they get included if we get support for it, based
 # on the cryptsetup version.

--- a/src/luks/tests/tests-common-functions.in
+++ b/src/luks/tests/tests-common-functions.in
@@ -18,6 +18,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+error() {
+    echo "${1}" >&2
+    exit 1
+}
+
 # We require cryptsetup >= 2.0.4 to fully support LUKSv2.
 # Support is determined at build time.
 luks2_supported() {
@@ -43,6 +48,12 @@ create_tang_adv() {
 new_device() {
     local LUKS="${1}"
     local DEV="${2}"
+    local PASS="${3}"
+
+    # Using a default password, if none has been provided.
+    if [ -z "${PASS}" ]; then
+        PASS="${DEFAULT_PASS}"
+    fi
 
     local DEV_CACHED="${TMP}/${LUKS}.cached"
 
@@ -54,14 +65,23 @@ new_device() {
     fi
 
     fallocate -l16M "${DEV}"
-    cryptsetup luksFormat --type "${LUKS}" --batch-mode --force-password "${DEV}" <<< "${DEFAULT_PASS}"
+    cryptsetup luksFormat --type "${LUKS}" --batch-mode --force-password "${DEV}" <<< "${PASS}"
     # Caching the just-formatted device for possible reuse.
     cp -f "${DEV}" "${DEV_CACHED}"
 }
 
-error() {
-    echo "${1}" >&2
-    exit 1
+# Creates a new LUKS1 or LUKS2 device to be used, using a keyfile.
+new_device_keyfile() {
+    local LUKS="${1}"
+    local DEV="${2}"
+    local KEYFILE="${3}"
+
+    if [[ -z "${KEYFILE}" ]] || [[ ! -f "${KEYFILE}" ]]; then
+        error "Invalid keyfile (${KEYFILE})."
+    fi
+
+    fallocate -l16M "${DEV}"
+    cryptsetup luksFormat --type "${LUKS}" --batch-mode "${DEV}" "${KEYFILE}"
 }
 
 export DEFAULT_PASS='just-some-test-password-here'


### PR DESCRIPTION
We now use cryptsetup and key file, and that way we handle
passphrases with newlines on them as well.

Add also tests to confirm non-interactive mode is working.

Fixes: #105