### PR TITLE
Readability Fix: "do" statement indentation offset from "done"

### DIFF
--- a/src/initramfs-tools/scripts/local-top/clevis.in
+++ b/src/initramfs-tools/scripts/local-top/clevis.in
@@ -42,8 +42,7 @@ in_fds() {
 # /lib/cryptsetup/passfifo if there is one.
 get_askpass_pid() {
     psinfo=$(ps) # Doing this so I don't end up matching myself
-    echo "$psinfo" | awk "/$cryptkeyscript/ { print \$1 }" | \
-        while read -r pid; do
+    echo "$psinfo" | awk "/$cryptkeyscript/ { print \$1 }" | while read -r pid; do
         if in_fds "$pid" "$PASSFIFO"; then
             echo "$pid"
             break
@@ -122,8 +121,7 @@ clevisloop()
             # If the device is not initialized, sliently skip it.
             luksmeta test -d "$CRYPTTAB_SOURCE" || continue
 
-            luksmeta show -d "$CRYPTTAB_SOURCE" |
-                while read -r slot state uuid; do
+            luksmeta show -d "$CRYPTTAB_SOURCE" | while read -r slot state uuid; do
                 [ "$state" == "active" ] || continue
                 [ "$uuid" == "$UUID" ] || continue
 
@@ -133,8 +131,7 @@ clevisloop()
                 fi
             done
         elif cryptsetup isLuks --type luks2 "$CRYPTTAB_SOURCE"; then
-            cryptsetup luksDump "$CRYPTTAB_SOURCE" | sed -rn 's|^\s+([0-9]+): clevis|\1|p' |
-                while read -r id; do
+            cryptsetup luksDump "$CRYPTTAB_SOURCE" | sed -rn 's|^\s+([0-9]+): clevis|\1|p' | while read -r id; do
                 jwe="$(luks2_jwe --token-id "$id" "$CRYPTTAB_SOURCE")" \
                     || continue
 


### PR DESCRIPTION
Some "do" statements with data piped to them were on new lines and further indented. While the formatting was consistent, this brought the actual "do" statement an indentation further in than its corresponding "done" statement making the termination of the code segment ambiguous. Removed these line breaks to improve readability.