### PR TITLE
tpm2: fix pcr_ids validation

### DIFF
--- a/src/pins/tpm2/clevis-encrypt-tpm2
+++ b/src/pins/tpm2/clevis-encrypt-tpm2
@@ -106,7 +106,7 @@ pcr_bank="$(jose fmt -j- -Og pcr_bank -u- <<< "$cfg")" || pcr_bank="sha1"
 # Issue #103: We support passing pcr_ids using both a single string, as in
 # "1,3", as well as an actual JSON array, such as ["1,"3"]. Let's handle both
 # cases here.
-if [[ ${cfg// /} != '{}' ]] \
+if jose fmt -j- -Og pcr_ids 2>/dev/null <<< "$cfg" \
     && ! pcr_ids="$(jose fmt -j- -Og pcr_ids -u- 2>/dev/null <<< "$cfg")"; then
 
     # We failed to parse a string, so let's try to parse a JSON array instead.

--- a/src/pins/tpm2/pin-tpm2
+++ b/src/pins/tpm2/pin-tpm2
@@ -96,6 +96,7 @@ test_pcr_ids() {
 
 test_pcr_ids "${orig}" '{}' "" || exit 1
 test_pcr_ids "${orig}" '{                   }' "" || exit 1
+test_pcr_ids "${orig}" '{"key": "ecc"}' "" || exit 1
 
 # Issue #103: now let's try a few different configs with both strings and
 # arrays and check if we get the expected pcr_ids.


### PR DESCRIPTION
In PR#140 we improved the validation for pcr_ids, however we introduced
an error in this validation, which broke cases in which we specify
something in the configuration, but not the pcr_ids attribute.

E.g.: '{"key": "ecc"}' now fails with "Parsing the requested policy
failed!".

In this commit we fix this issue and add a new test case to cover it.