### PR TITLE
Rewrote to work on 18.04 AND 20.04, as well as support retries

### DIFF
--- a/src/initramfs-tools/scripts/local-top/clevis.in
+++ b/src/initramfs-tools/scripts/local-top/clevis.in
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 #
 # Copyright (c) 2017 Red Hat, Inc.
 # Copyright (c) 2017 Shawn Rose
@@ -24,62 +24,105 @@
 #
 
 case $1 in
-prereqs) exit 0;;
+prereqs) exit 0 ;;
 esac
 
-# Return 0 if $pid has a file descriptor pointing to $name, 1 otherwise
-in_fds() {
-    local  pid="$1" name="$2" fd
+# Return fifo path or nothing if not found
+get_fifo_path() {
+    local pid="$1"
     for fd in /proc/$pid/fd/*; do
         if [ -e "$fd" ]; then
-            [ "$(readlink -f "$fd")" != "$name" ] || return 0
+            if [[ $(readlink -f "${fd}") == *"/cryptsetup/passfifo" ]]; then
+                echo $(readlink -f "${fd}")
+            fi
         fi
     done
-    return 1
 }
 
-# Print the PID of the askpass process with a file descriptor opened to
-# /lib/cryptsetup/passfifo if there is one.
+# Print the PID of the askpass process and fifo path with a file descriptor opened to
 get_askpass_pid() {
     psinfo=$(ps) # Doing this so I don't end up matching myself
     echo "$psinfo" | awk "/$cryptkeyscript/ { print \$1 }" | while read -r pid; do
-        if in_fds "$pid" "$PASSFIFO"; then
-            echo "$pid"
+        pf=$(get_fifo_path "${pid}")
+        if [[ $pf != "" ]]; then
+            echo "${pid} ${pf}"
             break
         fi
     done
 }
 
 luks1_decrypt() {
-    luksmeta load "$@" \
-        | clevis decrypt
+    local CRYPTTAB_SOURCE=$1
+    local PASSFIFO=$2
+    UUID=cb6e8904-81ff-40da-a84a-07ab9ab5715e
+    luksmeta show -d "$CRYPTTAB_SOURCE" | while read -r slot state uuid; do
+        [ "$state" == "active" ] || continue
+        [ "$uuid" == "$UUID" ] || continue
 
-    local rc
-    for rc in "${PIPESTATUS[@]}"; do
-        [ $rc -eq 0 ] || return $rc
+        lml=$(luksmeta load -d "${CRYPTTAB_SOURCE}" -s "${slot}" -u "${UUID}")
+        if [ $? -ne 0 ]; then
+            return 1
+        fi
+
+        decrypted=$(echo -n "${lml}" | clevis decrypt 2>/dev/null)
+        if [ $? -ne 0 ]; then
+            return 1
+        fi
+
+        # Fail safe
+        if [ "$decrypted" == "" ]; then
+            return 1
+        fi
+
+        echo -n "${decrypted}" >"$PASSFIFO"
+        return 0
     done
-    return 0
+
+    return 1
 }
 
-luks2_jwe() {
-    # jose jwe fmt -c outputs extra \n, so clean it up
-    cryptsetup token export "$@" \
-        | jose fmt -j- -Og jwe -o- \
-        | jose jwe fmt -i- -c \
-        | tr -d '\n'
+luks2_decrypt() {
+    local CRYPTTAB_SOURCE=$1
+    local PASSFIFO=$2
+    cryptsetup luksDump "$CRYPTTAB_SOURCE" | sed -rn 's|^\s+([0-9]+): clevis|\1|p' | while read -r id; do
 
-    local rc
-    for rc in "${PIPESTATUS[@]}"; do
-        [ $rc -eq 0 ] || return $rc
+        # jose jwe fmt -c outputs extra \n, so clean it up
+        cte=$(cryptsetup token export --token-id "$id" "$CRYPTTAB_SOURCE")
+        if [ $? -ne 0 ]; then
+            return 1
+        fi
+
+        josefmt=$(echo ${cte} | jose fmt -j- -Og jwe -o-)
+        if [ $? -ne 0 ]; then
+            return 1
+        fi
+
+        josejwe=$(echo ${josefmt} | jose jwe fmt -i- -c)
+        if [ $? -ne 0 ]; then
+            return 1
+        fi
+
+        jwe=$(echo ${josejwe} | tr -d '\n')
+        if [ $? -ne 0 ]; then
+            return 1
+        fi
+
+        decrypted=$(echo -n "${jwe}" | clevis decrypt 2>/dev/null)
+        if [ $? -ne 0 ]; then
+            return 1
+        fi
+
+        echo -n "${decrypted}" >"$PASSFIFO"
+        return 0
     done
-    return 0
+
+    return 1
 }
 
 # Wait for askpass, and then try and decrypt immediately. Just in case
 # there are multiple devices that need decrypting, this will loop
 # infinitely (The local-bottom script will kill this after decryption)
-clevisloop()
-{
+clevisloop() {
     set -e
 
     # Set the path how we want it (Probably not all needed)
@@ -92,17 +135,15 @@ clevisloop()
         cryptkeyscript='\/lib\/cryptsetup\/askpass'
     fi
 
-    PASSFIFO='/usr/lib/cryptsetup/passfifo'
-
     OLD_CRYPTTAB_SOURCE=""
 
     while true; do
 
-        pid=$(get_askpass_pid)
-
         until [ "$pid" ] && [ -p "$PASSFIFO" ]; do
             sleep .1
-            pid=$(get_askpass_pid)
+            pid_fifo=$(get_askpass_pid)
+            pid=$(echo ${pid_fifo} | cut -d' ' -f1)
+            PASSFIFO=$(echo ${pid_fifo} | cut -d' ' -f2-)
         done
 
         # Import CRYPTTAB_SOURCE from the askpass process.
@@ -111,35 +152,28 @@ clevisloop()
         # Make sure that CRYPTTAB_SOURCE is actually a block device
         [ ! -b "$CRYPTTAB_SOURCE" ] && continue
 
+        sleep .1
         # Make the source has changed if needed
         [ "$CRYPTTAB_SOURCE" = "$OLD_CRYPTTAB_SOURCE" ] && continue
-
         OLD_CRYPTTAB_SOURCE="$CRYPTTAB_SOURCE"
 
-        UUID=cb6e8904-81ff-40da-a84a-07ab9ab5715e
         if cryptsetup isLuks --type luks1 "$CRYPTTAB_SOURCE"; then
             # If the device is not initialized, sliently skip it.
             luksmeta test -d "$CRYPTTAB_SOURCE" || continue
 
-            luksmeta show -d "$CRYPTTAB_SOURCE" | while read -r slot state uuid; do
-                [ "$state" == "active" ] || continue
-                [ "$uuid" == "$UUID" ] || continue
-
-                if pt="$(luks1_decrypt -d "$CRYPTTAB_SOURCE" -s "$slot" -u "$UUID")"; then
-                    echo -n "$pt" > "$PASSFIFO"
-                    break
-                fi
-            done
+            if $(luks1_decrypt "${CRYPTTAB_SOURCE}" "${PASSFIFO}"); then
+                echo "Unlocked ${CRYPTTAB_SOURCE} with clevis"
+            else
+                OLD_CRYPTTAB_SOURCE=""
+                sleep 5
+            fi
         elif cryptsetup isLuks --type luks2 "$CRYPTTAB_SOURCE"; then
-            cryptsetup luksDump "$CRYPTTAB_SOURCE" | sed -rn 's|^\s+([0-9]+): clevis|\1|p' | while read -r id; do
-                jwe="$(luks2_jwe --token-id "$id" "$CRYPTTAB_SOURCE")" \
-                    || continue
-
-                if pt="$(echo -n "$jwe" | clevis decrypt)"; then
-                    echo -n "$pt" > "$PASSFIFO"
-                    break
-                fi
-            done
+            if $(luks2_decrypt "${CRYPTTAB_SOURCE}" "${PASSFIFO}"); then
+                echo "Unlocked ${CRYPTTAB_SOURCE} with clevis"
+            else
+                OLD_CRYPTTAB_SOURCE=""
+                sleep 5
+            fi
         fi
         # Now that the current device has its password, let's sleep a
         # bit. This gives cryptsetup time to actually decrypt the
@@ -150,35 +184,34 @@ clevisloop()
 
 . /scripts/functions
 
-
 # This is a copy  of 'all_netbootable_devices/all_non_enslaved_devices' for
 # platforms that might not provide it.
 clevis_all_netbootable_devices() {
-    for device in /sys/class/net/* ; do
-            if [ ! -e "$device/flags" ]; then
-                    continue
-            fi
+    for device in /sys/class/net/*; do
+        if [ ! -e "$device/flags" ]; then
+            continue
+        fi
 
-            loop=$(($(cat "$device/flags") & 0x8 && 1 || 0))
-            bc=$(($(cat "$device/flags") & 0x2 && 1 || 0))
-            ptp=$(($(cat "$device/flags") & 0x10 && 1 || 0))
+        loop=$(($(cat "$device/flags") & 0x8 && 1 || 0))
+        bc=$(($(cat "$device/flags") & 0x2 && 1 || 0))
+        ptp=$(($(cat "$device/flags") & 0x10 && 1 || 0))
 
-            # Skip any device that is a loopback
-            if [ $loop = 1 ]; then
-                    continue
-            fi
+        # Skip any device that is a loopback
+        if [ $loop = 1 ]; then
+            continue
+        fi
 
-            # Skip any device that isn't a broadcast
-            # or point-to-point.
-            if [ $bc = 0 ] && [ $ptp = 0 ]; then
-                    continue
-            fi
+        # Skip any device that isn't a broadcast
+        # or point-to-point.
+        if [ $bc = 0 ] && [ $ptp = 0 ]; then
+            continue
+        fi
 
-            # Skip any enslaved device (has "master" link
-            # attribute on it)
-            device=$(basename "$device")
-            ip -o link show "$device" | grep -q -w master && continue
-            DEVICE="$DEVICE $device"
+        # Skip any enslaved device (has "master" link
+        # attribute on it)
+        device=$(basename "$device")
+        ip -o link show "$device" | grep -q -w master && continue
+        DEVICE="$DEVICE $device"
     done
     echo "$DEVICE"
 }
@@ -202,4 +235,5 @@ if eth_check; then
 fi
 
 clevisloop &
-echo $! > /run/clevis.pid
+echo $! >/run/clevis.pid
+


### PR DESCRIPTION
I refactored a bunch of this to support failures so that we could retry. The problem in my environment is we are using tang and if the tang service was unavailable, this would just exit out. Now with these modifications, it will sit and attempt to retry every 5 seconds. Besides that, I made the PATHFIFO support dynamic so it works on 18.04 and 20.04 (tested both), and hopefully, all others going forward since it isn't so rigid.

Most of the moving to functions were so that we could properly handle error code returns and loop. My testing here is 100% limited to typing in passwords and tang + tang failure+resurrection. I have not used other methods but given the scope of how the code was originally written it shouldn't be impacted but I would love to have somebody validate that.


