### PR TITLE
Avoid grep -z, which isn't supported by busybox-initramfs

### DIFF
--- a/src/initramfs-tools/scripts/local-top/clevis.in
+++ b/src/initramfs-tools/scripts/local-top/clevis.in
@@ -106,7 +106,8 @@ clevisloop()
         done
 
         # Import CRYPTTAB_SOURCE from the askpass process.
-        local "$(grep '^CRYPTTAB_SOURCE=' /proc/"$pid"/environ)"
+        local "$(tr '\0' '\n' < /proc/${pid}/environ | \
+	    grep '^CRYPTTAB_SOURCE=')"
 
         # Make sure that CRYPTTAB_SOURCE is actually a block device
         [ ! -b "$CRYPTTAB_SOURCE" ] && continue


### PR DESCRIPTION
While testing clevis-initramfs on an Ubuntu 20.04 system, I observed
the following (w/ set -x enabled):

    + '[' -p /usr/lib/cryptsetup/passfifo ']'
    ++ grep -z '^CRYPTTAB_SOURCE=' /proc/395/environ
    grep: invalid option -- 'z'
    BusyBox v1.30.1 (Ubuntu 1:1.30.1-4ubuntu5) multi-call binary.

    Usage: grep [-HhnlLoqvsriwFE] [-m N] [-A/B/C N] PATTERN/-e PATTERN.../-f FILE [FILE]...

While the busybox package does support 'grep -z', the busybox-initramfs
package does not. Use tr to do the NULL conversion instead.