### PR TITLE
Updates to travis CI

### DIFF
--- a/.travis/install
+++ b/.travis/install
@@ -21,8 +21,8 @@ debian:*|ubuntu:*)
         sleep 5
     done
 
-    DEBIAN_FRONTEND=noninteractive apt-get install -y keyboard-configuration \
-        console-setup
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get install -y keyboard-configuration console-setup
 
     while ! apt-get -y install ${COMMON} \
         build-essential pkg-config libssl-dev libjansson-dev libjose-dev \

--- a/.travis/install
+++ b/.travis/install
@@ -36,9 +36,8 @@ debian:*|ubuntu:*)
 fedora:*)
     dnf -y clean all
     dnf -y --setopt=deltarpm=0 update
-    dnf -y install ${COMMON} pkgconfig openssl-devel jansson-devel \
-        findutils libjose-devel luksmeta libluksmeta-devel audit-libs-devel \
-        libudisks2-devel tpm2-tools desktop-file-utils
+    dnf -y install dnf-utils
+    dnf -y builddep clevis
     ;;
 
 centos:*)

--- a/.travis/script
+++ b/.travis/script
@@ -30,7 +30,7 @@ fi
 ninja=$(findexe ninja ninja-build)
 "${ninja}" test
 
-bash <(curl -s https://codecov.io/bash) 2>&1 \
+bash <(curl --retry 10 -s https://codecov.io/bash) 2>&1 \
        | grep -E -v "has arcs (to entry|from exit) block"
 
 # vim: set ts=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:


### PR DESCRIPTION
- Use dnf builddep for installing Fedora dependencies
- export DEBIAN_FRONTEND variable for Debian/Ubuntu
- retry when uploading coverage info