### PR TITLE
Misc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ user intervention.
 
 #### Unlocker: Clevis command
 
-A LUKSv1 device bound to a Clevis policy can also be unlocked by using the clevis
+A LUKS device bound to a Clevis policy can also be unlocked by using the clevis
 luks unlock command.
 
 ```bash

--- a/src/clevis.1.adoc
+++ b/src/clevis.1.adoc
@@ -103,7 +103,7 @@ This command performs four steps:
 
 1. Creates a new key with the same entropy as the LUKS master key.
 2. Encrypts the new key with Clevis.
-3. Stores the Clevis JWE in the LUKS header with LUKSMeta.
+3. Stores the Clevis JWE in the LUKS header.
 4. Enables the new key for use with LUKS.
 
 This disk can now be unlocked with your existing password as well as with

--- a/src/luks/clevis-luks-bind.1.adoc
+++ b/src/luks/clevis-luks-bind.1.adoc
@@ -5,7 +5,7 @@ CLEVIS-LUKS-BIND(1)
 
 == NAME
 
-clevis-luks-bind - Bind a LUKSv1 device using the specified policy
+clevis-luks-bind - Bind a LUKS device using the specified policy
 
 == SYNOPSIS
 
@@ -13,7 +13,7 @@ clevis-luks-bind - Bind a LUKSv1 device using the specified policy
 
 == OVERVIEW
 
-The *clevis luks bind* command binds a LUKSv1 device using the specified
+The *clevis luks bind* command binds a LUKS device using the specified
 policy. This is accomplished with a simple command:
 
     $ clevis luks bind -d /dev/sda tang '{"url":...}'
@@ -22,7 +22,7 @@ This command performs four steps:
 
 1. Creates a new key with the same entropy as the LUKS master key.
 2. Encrypts the new key with Clevis.
-3. Stores the Clevis JWE in the LUKS header with LUKSMeta.
+3. Stores the Clevis JWE in the LUKS header.
 4. Enables the new key for use with LUKS.
 
 This disk can now be unlocked with your existing password as well as with

--- a/src/luks/clevis-luks-list.1.adoc
+++ b/src/luks/clevis-luks-list.1.adoc
@@ -34,6 +34,7 @@ For example:
     3: tpm2 '{"hash":"sha256","key":"ecc","pcr_bank":"sha1","pcr_ids":"7"}'
 
 As we can see in the example above, */dev/sda1* has three slots bound each with a different pin.
+
 - Slot #1 is bound with the _sss_ pin, and uses also tang and tpm2 pins in its policy.
 - Slot #2 is bound using the _tang_ pin
 - Slot #3 is bound with the _tpm2_ pin

--- a/src/luks/clevis-luks-unbind.1.adoc
+++ b/src/luks/clevis-luks-unbind.1.adoc
@@ -5,7 +5,7 @@ CLEVIS-LUKS-UNBIND(1)
 
 == NAME
 
-clevis-luks-unbind - Unbinds a pin bound to a LUKSv1 volume
+clevis-luks-unbind - Unbinds a pin bound to a LUKS volume
 
 == SYNOPSIS
 
@@ -13,7 +13,7 @@ clevis-luks-unbind - Unbinds a pin bound to a LUKSv1 volume
 
 == OVERVIEW
 
-The *clevis luks unbind* command unbinds a pin bound to a LUKSv1 volume.
+The *clevis luks unbind* command unbinds a pin bound to a LUKS volume.
 For example:
 
     $ clevis luks unbind -d /dev/sda -s 1
@@ -24,7 +24,8 @@ For example:
   The bound LUKS device
 
 * *-s* _SLT_ :
-  The LUKSMeta slot number for the pin to unbind
+  The slot number for the pin to unbind. When using LUKSv1, this is the
+  the LUKSmeta slot
 
 * *-f* :
   Do not ask for confirmation and wipe slot in batch-mode

--- a/src/luks/clevis-luks-unlock.1.adoc
+++ b/src/luks/clevis-luks-unlock.1.adoc
@@ -5,7 +5,7 @@ CLEVIS-LUKS-UNLOCK(1)
 
 == NAME
 
-clevis-luks-unlock - Unlocks a LUKSv1 device bound with a Clevis policy
+clevis-luks-unlock - Unlocks a LUKS device bound with a Clevis policy
 
 == SYNOPSIS
 
@@ -13,7 +13,7 @@ clevis-luks-unlock - Unlocks a LUKSv1 device bound with a Clevis policy
 
 == OVERVIEW
 
-The *clevis luks unlock* command unlocks a LUKSv1 device using its already
+The *clevis luks unlock* command unlocks a LUKS device using its already
 provisioned Clevis policy. For example:
 
     $ clevis luks unlock -d /dev/sda

--- a/src/pins/sss/clevis-encrypt-sss.c
+++ b/src/pins/sss/clevis-encrypt-sss.c
@@ -297,12 +297,11 @@ usage:
     fprintf(stderr, "\n");
     fprintf(stderr, "  pins: <object>   Pins used for encrypting fragments (REQUIRED)\n");
     fprintf(stderr, "\n");
-    fprintf(stderr, "Here is an example configuration for two of three servers:\n");
+    fprintf(stderr, "Here is an example configuration for one of two servers:\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "{\n");
-    fprintf(stderr, "  \"t\": 2,\n");
+    fprintf(stderr, "  \"t\": 1,\n");
     fprintf(stderr, "  \"pins\": {\n");
-    fprintf(stderr, "    \"http\": { \"url\": \"https://example.com/escrow/foo\" },\n");
     fprintf(stderr, "    \"tang\": [\n");
     fprintf(stderr, "      { \"url\": \"http://example.com/tang1\" },\n");
     fprintf(stderr, "      { \"url\": \"http://example.com/tang2\" }\n");


### PR DESCRIPTION
- Remove reference to `http` pin in `clevis-encrypt-sss`
- Updates to README and man pages, which were referring to LUKSv1 as the only supported