### PR TITLE
initramfs: Avoid noise due to /proc race

### DIFF
--- a/src/initramfs-tools/scripts/local-top/clevis.in
+++ b/src/initramfs-tools/scripts/local-top/clevis.in
@@ -131,8 +131,9 @@ clevisloop() {
         done
 
         # Import CRYPTTAB_SOURCE from the askpass process.
-        local "$(tr '\0' '\n' < /proc/${pid}/environ | \
-	    grep '^CRYPTTAB_SOURCE=')"
+        local CRYPTTAB_SOURCE="$(cat /proc/${pid}/environ 2> /dev/null | \
+            tr '\0' '\n' | grep '^CRYPTTAB_SOURCE=' | cut -d= -f2)"
+        [ -n "$CRYPTTAB_SOURCE" ] || continue
 
         # Make sure that CRYPTTAB_SOURCE is actually a block device
         [ ! -b "$CRYPTTAB_SOURCE" ] && continue


### PR DESCRIPTION
The askpass pid we've found may exit before we try to read its environ
file. When that happens, we'll see some ugly messages on the console:

  /scripts/local-top/clevis: line 135: local: `': not a valid identifier
  /scripts/local-top/clevis: line 135: /proc/361/environ: No such file or directory
  /scripts/local-top/clevis: line 135: local: `': not a valid identifier
  /scripts/local-top/clevis: line 135: /proc/361/environ: No such file or directory
  /scripts/local-top/clevis: line 135: local: `': not a valid identifier
  /scripts/local-top/clevis: line 135: /proc/361/environ: No such file or directory
  /scripts/local-top/clevis: line 135: local: `': not a valid identifier

Avoid this by using cat to read the file and prevent it from emitting an error
to the console if the /proc file has vanished by redirecting its stderr to
/dev/null. Also use an explicit assignment so $CRYPTTAB_SOURCE gets set
to "" if the race is hit, and restart in the loop in that case. The latter
check is functionally redundant with the [ -b ] that follows, but I felt it
safer to be explicit.