### PR TITLE
initramfs-tools: Copy a certificate bundle so curl can do https

### DIFF
--- a/src/initramfs-tools/hooks/clevis.in
+++ b/src/initramfs-tools/hooks/clevis.in
@@ -103,3 +103,5 @@ done
 for so in $(ldconfig -p | sed -nr 's/^\s*libnss_dns\.so\.[0-9]+\s.*=>\s*//p'); do
   copy_exec "${so}"
 done
+
+copy_file data @sysconfdir@/ssl/certs/ca-certificates.crt || die 2 "Unable to copy certificate bundle to initrd image"


### PR DESCRIPTION
The path is the one used on Debian and Ubuntu, which should match
where initramfs-tools is used.