### PR TITLE
Use clevis-luks-askpass systemd units in dracut

### DIFF
--- a/src/luks/systemd/clevis-luks-askpass.path
+++ b/src/luks/systemd/clevis-luks-askpass.path
@@ -1,7 +1,8 @@
 [Unit]
 Description=Clevis systemd-ask-password Watcher
-Before=remote-fs-pre.target
-Wants=remote-fs-pre.target
+DefaultDependencies=no
+Conflicts=shutdown.target
+Before=basic.target shutdown.target remote-fs-pre.target
 
 [Path]
 PathChanged=/run/systemd/ask-password

--- a/src/luks/systemd/clevis-luks-askpass.service.in
+++ b/src/luks/systemd/clevis-luks-askpass.service.in
@@ -1,6 +1,8 @@
 [Unit]
 Description=Clevis LUKS systemd-ask-password Responder
-Requires=network-online.target
+DefaultDependencies=no
+Conflicts=shutdown.target
+Before=systemd-ask-password-console.service systemd-ask-password-plymouth.service shutdown.target
 After=network-online.target
 
 [Service]

--- a/src/luks/systemd/dracut/clevis/clevis-hook.sh.in
+++ b/src/luks/systemd/dracut/clevis/clevis-hook.sh.in
@@ -1,2 +1,0 @@
-#!/bin/bash
-@libexecdir@/clevis-luks-askpass

--- a/src/luks/systemd/dracut/clevis/meson.build
+++ b/src/luks/systemd/dracut/clevis/meson.build
@@ -9,13 +9,6 @@ if dracut.found()
     install_dir: dracutdir,
     configuration: data,
   )
-
-  configure_file(
-    input: 'clevis-hook.sh.in',
-    output: 'clevis-hook.sh',
-    install_dir: dracutdir,
-    configuration: data,
-  )
 else
   warning('Will not install dracut module due to missing dependencies!')
 endif

--- a/src/luks/systemd/dracut/clevis/module-setup.sh.in
+++ b/src/luks/systemd/dracut/clevis/module-setup.sh.in
@@ -24,11 +24,10 @@ depends() {
 }
 
 install() {
-    inst_hook initqueue/online 60 "$moddir/clevis-hook.sh"
-    inst_hook initqueue/settled 60 "$moddir/clevis-hook.sh"
-
     inst_multiple \
-	/etc/services \
+        "$systemdsystemunitdir/clevis-luks-askpass.path" \
+        "$systemdsystemunitdir/clevis-luks-askpass.service" \
+        /etc/services \
         @libexecdir@/clevis-luks-askpass \
         clevis-decrypt \
         cryptsetup \
@@ -38,5 +37,5 @@ install() {
         jose \
         ncat
 
-    dracut_need_initqueue
+    systemctl -q --root "$initdir" add-wants sysinit.target clevis-luks-askpass.path
 }


### PR DESCRIPTION
With `Before=systemd-ask-password-console.service systemd-ask-password-plymouth.service` it also fixes #150, so that the user only gets prompted for a password if the clevis unlocker fails.

I am using this with the tpm2 pin and it works correctly both in case of success or failure. If there is interest in merging this I can also test if it works with the tang pin and others.
