### PR TITLE
Document ncat dependency in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,6 +22,7 @@ following sections describe them for the supported platforms.
 * [tang](https://github.com/latchset/tang)
 * [curl](https://github.com/curl/curl)
 * [tpm2-tools](https://github.com/tpm2-software/tpm2-tools)
+* [ncat](https://nmap.org/ncat/) (for clevis-luks-askpass)
 
 ### Fedora
 


### PR DESCRIPTION
As mentioned in #116, without ncat installed, clevis-luks-askpass cannot write to the socket defined in the _/run/systemd/ask-password/ask.*_ files.
