### PR TITLE
udisks2: call initgroups() before setgid/setuid

### DIFF
--- a/src/luks/udisks2/clevis-luks-udisks2.c
+++ b/src/luks/udisks2/clevis-luks-udisks2.c
@@ -330,6 +330,11 @@ recover_key(const pkt_t *jwe, char *out, size_t max, uid_t uid, gid_t gid)
             }
         }
 
+        if (initgroups(CLEVIS_USER, gid) != 0) {
+            perror("initgroups");
+            exit(EXIT_FAILURE);
+        }
+
         if (setgid(gid) != 0) {
             perror("setgid");
             exit(EXIT_FAILURE);


### PR DESCRIPTION
So that the process will have correct group access when recovering the
key.