### PR TITLE
Drop hard requirement on networking

### DIFF
--- a/src/luks/systemd/clevis-luks-askpass.path
+++ b/src/luks/systemd/clevis-luks-askpass.path
@@ -1,10 +1,11 @@
 [Unit]
 Description=Clevis systemd-ask-password Watcher
-Before=remote-fs-pre.target
-Wants=remote-fs-pre.target
+DefaultDependencies=no
+Before=cryptsetup-pre.target
+Wants=cryptsetup-pre.target
 
 [Path]
 PathChanged=/run/systemd/ask-password
 
 [Install]
-WantedBy=remote-fs.target
+WantedBy=cryptsetup.target

--- a/src/luks/systemd/clevis-luks-askpass.path
+++ b/src/luks/systemd/clevis-luks-askpass.path
@@ -1,5 +1,5 @@
 [Unit]
-Description=Clevis systemd-ask-password Watcher
+Description=Forward Password Requests to Clevis Directory Watch
 Documentation=man:clevis-luks-unlockers(7)
 DefaultDependencies=no
 Before=cryptsetup-pre.target

--- a/src/luks/systemd/clevis-luks-askpass.path
+++ b/src/luks/systemd/clevis-luks-askpass.path
@@ -1,5 +1,6 @@
 [Unit]
 Description=Clevis systemd-ask-password Watcher
+Documentation=man:clevis-luks-unlockers(7)
 DefaultDependencies=no
 Before=cryptsetup-pre.target
 Wants=cryptsetup-pre.target

--- a/src/luks/systemd/clevis-luks-askpass.service.in
+++ b/src/luks/systemd/clevis-luks-askpass.service.in
@@ -1,7 +1,6 @@
 [Unit]
 Description=Clevis LUKS systemd-ask-password Responder
-Requires=network-online.target
-After=network-online.target
+DefaultDependencies=no
 
 [Service]
 Type=oneshot

--- a/src/luks/systemd/clevis-luks-askpass.service.in
+++ b/src/luks/systemd/clevis-luks-askpass.service.in
@@ -1,5 +1,5 @@
 [Unit]
-Description=Clevis LUKS systemd-ask-password Responder
+Description=Forward Password Requests to Clevis
 Documentation=man:clevis-luks-unlockers(7)
 DefaultDependencies=no
 

--- a/src/luks/systemd/clevis-luks-askpass.service.in
+++ b/src/luks/systemd/clevis-luks-askpass.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=Clevis LUKS systemd-ask-password Responder
+Documentation=man:clevis-luks-unlockers(7)
 DefaultDependencies=no
 
 [Service]

--- a/src/luks/systemd/dracut/clevis-pin-tang/module-setup.sh.in
+++ b/src/luks/systemd/dracut/clevis-pin-tang/module-setup.sh.in
@@ -23,13 +23,7 @@ depends() {
     return 0
 }
 
-cmdline() {
-    echo "rd.neednet=1"
-}
-
 install() {
-    cmdline > "${initdir}/etc/cmdline.d/99clevis-pin-tang.conf"
-
     inst_multiple \
 	clevis-decrypt-tang \
 	curl


### PR DESCRIPTION
Hi,

While integrating Clevis into Fedora CoreOS and RHCOS, we've encountered problems with the way the dracut modules and Clevis units pull in networking targets. These problems are not unique to FCOS/RHCOS (see e.g. #54 and #206). This patch series fixes these dependencies to better conform to the systemd and dracut models. The most important commits in this patch series are the first two:

```
commit 088be96472a234b9368a437078582e8446fffc73
Date:   Thu Jul 2 11:08:55 2020 -0400

    systemd: drop hard requirement on networking

    Whether we need networking or not for unlocking an encrypted block
    device is a property of the block device in question. This is expressed
    in `/etc/crypttab` via the `_netdev` option. For example, the systemd
    cryptsetup generator[1] picks up on this and correctly orders unlocking
    of devices that need networking after `remote-fs-pre.target`.

    Thus, we shouldn't need to unconditionally require and order ourselves
    after networking comes up. Let whatever interprets `/etc/crypttab` take
    care of this.

    Add `DefaultDependencies=no` because we need to be able to run well
    before `sysinit.target`.

    [1] https://www.freedesktop.org/software/systemd/man/systemd-cryptsetup-generator.html

commit 48e426f4631eeac7dc516ef4bbe25768b71cc58c
Date:   Thu Jul 2 11:08:56 2020 -0400

    dracut: drop rd.neednet=1 injection

    By default, dracut builds generic initrds which by design shouldn't have
    any configuration specific to a host baked in (as opposed to so-called
    "hostonly" initrds). This property is leveraged with great success in
    immutable hosts like Fedora CoreOS and its downstream RHCOS where the
    initrd is created server-side.

    By unconditionally injecting `rd.neednet=1`, the clevis-pin-tang dracut
    module makes it impossible to be included into a truly generic initrd,
    where one cannot make assumptions about the network (or lack thereof,
    see #54) of the target hosts.

    So with a generic initrd, how can we make sure that networking is up at
    initrd time on a host which has been configured with root-on-LUKS with a
    Tang pin? By also configuring it with `rd.neednet=1` specified on the
    kernel command-line, and possibly `ip=...` to configure the network
    interfaces.

    This is no different from root-on-{NFS,iSCSI,NBD,...}, where one must
    use explicit kernel arguments like `root=nfs:<server>:...` or
    `root=iscsi:<server>:...` or `root=nbd:<server>:...`, all of which imply
    `rd.neednet=1` (one could imagine then a `root=tang:<luks2_uuid>` type
    karg in the future which would be roughly equivalent to
    `root=UUID=<luks2_uuid> rd.neednet=1`).

    Dracut also allows one to build host-specific initrds using the
    `-H`/`--hostonly` option, and further the ability to bake the
    command-line arguments when `--hostonly-cmdline` is provided.

    So a supplementary approach here would be for `install()` to only inject
    `rd.neednet=1` if using `--hostonly-cmdline` *and* somewhere along the
    root block device hierarchy, there is a Tang-pinned LUKS device. This is
    also analogous to what other dracut modules like 95nfs and 95iscsi do.

    However, optimizations for host-only initrds should not come before
    getting correct support for generic initrds.

    Closes: #54
    Closes: #206
```