### PR TITLE
 dracut: favour systemd units over dracut hooks 

### DIFF
--- a/src/luks/systemd/dracut/clevis/module-setup.sh.in
+++ b/src/luks/systemd/dracut/clevis/module-setup.sh.in
@@ -28,7 +28,7 @@ install() {
     inst_hook initqueue/settled 60 "$moddir/clevis-hook.sh"
 
     inst_multiple \
-	/etc/services \
+        /etc/services \
         @libexecdir@/clevis-luks-askpass \
         clevis-luks-common-functions \
         head grep sed \

--- a/src/luks/systemd/dracut/clevis/module-setup.sh.in
+++ b/src/luks/systemd/dracut/clevis/module-setup.sh.in
@@ -24,8 +24,15 @@ depends() {
 }
 
 install() {
-    inst_hook initqueue/online 60 "$moddir/clevis-hook.sh"
-    inst_hook initqueue/settled 60 "$moddir/clevis-hook.sh"
+    if dracut_module_included "systemd"; then
+        inst_multiple \
+            $systemdsystemunitdir/clevis-luks-askpass.service \
+            $systemdsystemunitdir/clevis-luks-askpass.path
+        systemctl -q --root "$initdir" add-wants cryptsetup.target clevis-luks-askpass.path
+    else
+        inst_hook initqueue/online 60 "$moddir/clevis-hook.sh"
+        inst_hook initqueue/settled 60 "$moddir/clevis-hook.sh"
+    fi
 
     inst_multiple \
         /etc/services \


### PR DESCRIPTION
In general, when possible it's better to use systemd units instead of
dracut hooks because it's (not surprisingly) easier to integrate with
other systemd units in the initramfs.

Let's do our part towards eventually phasing out the "init system within
an init system" situation we're in right now and prefer systemd units on
systemd-based initrds.

It also mirrors how unlocking works in the real root.

You can see this similar "don't ship hooks on systemd" pattern in other
dracut modules (for example `04watchdog`, `50plymouth`, and `90crypt`).