### PR TITLE
 Introduce -y (assume yes) argument to clevis luks bind

### DIFF
--- a/src/luks/clevis-luks-bind.1.adoc
+++ b/src/luks/clevis-luks-bind.1.adoc
@@ -9,7 +9,7 @@ clevis-luks-bind - Bind a LUKS device using the specified policy
 
 == SYNOPSIS
 
-*clevis luks bind* [-f] -d DEV [-t TKN_ID] [-s SLT] [-k KEY] PIN CFG
+*clevis luks bind* [-f] [-y] -d DEV [-t TKN_ID] [-s SLT] [-k KEY] PIN CFG
 
 == OVERVIEW
 
@@ -33,6 +33,11 @@ Clevis LUKS unlockers. See link:clevis-luks-unlockers.7.adoc[*clevis-luks-unlock
 
 * *-f* :
   Do not prompt for LUKSMeta initialization
+
+* *-y* :
+  Automatically answer yes for all questions. When using _tang_, it
+  causes the advertisement trust check to be skipped, which can be
+  useful in automated deployments
 
 * *-d* _DEV_ :
   The LUKS device on which to perform binding

--- a/src/luks/clevis-luks-bind.in
+++ b/src/luks/clevis-luks-bind.in
@@ -31,13 +31,15 @@ function luks2_supported() {
 function usage() {
     exec >&2
     echo
-    echo "Usage: clevis luks bind [-f] [-s SLT] [-k KEY] [-t TOKEN_ID] -d DEV PIN CFG"
+    echo "Usage: clevis luks bind [-y] [-f] [-s SLT] [-k KEY] [-t TOKEN_ID] -d DEV PIN CFG"
     echo
     echo "$SUMMARY":
     echo
     echo "  -f           Do not prompt for LUKSMeta initialization"
     echo
     echo "  -d DEV       The LUKS device on which to perform binding"
+    echo
+    echo "  -y           Automatically answer yes for all questions"
     echo
     echo "  -s SLT       The LUKS slot to use"
     echo
@@ -55,13 +57,16 @@ if [ $# -eq 1 ] && [ "$1" == "--summary" ]; then
 fi
 
 FRC=()
-while getopts ":hfd:s:k:t:" o; do
+YES=()
+while getopts ":hfyd:s:k:t:" o; do
     case "$o" in
     f) FRC+=(-f);;
     d) DEV="$OPTARG";;
     s) SLT="$OPTARG";;
     k) KEY="$OPTARG";;
     t) TOKEN_ID="$OPTARG";;
+    y) FRC+=(-f)
+       YES+=(-y);;
     *) usage;;
     esac
 done
@@ -144,7 +149,7 @@ cryptsetup luksDump "$DEV" \
 )")"
 
 # Encrypt the new key
-jwe="$(echo -n "$key" | clevis encrypt "$PIN" "$CFG")"
+jwe="$(echo -n "$key" | clevis encrypt "$PIN" "$CFG" "${YES}")"
 
 # If necessary, initialize the LUKS volume
 if [ "$luks_type" == "luks1" ] && ! luksmeta test -d "$DEV"; then

--- a/src/luks/tests/assume-yes
+++ b/src/luks/tests/assume-yes
@@ -1,0 +1,113 @@
+#!/bin/bash -ex
+# vim: set ts=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+TEST=$(basename "${0}")
+. tests-common-functions
+
+. clevis-luks-common-functions
+
+on_exit() {
+    [ ! -d "${TMP}" ] && return 0
+    tang_stop "${TMP}"
+    rm -rf "${TMP}"
+}
+
+trap 'on_exit' EXIT
+trap 'on_exit' ERR
+
+TMP="$(mktemp -d)"
+
+port=$(get_random_port)
+tang_run "${TMP}" "${port}" &
+tang_wait_until_ready "${port}"
+
+url="http://${TANG_HOST}:${port}"
+cfg=$(printf '{"url":"%s"}' "$url")
+
+test_tang() {
+    local url="${1}"
+    local cfg data pt
+    cfg=$(printf '{"url":"%s"}' "$url")
+
+    for data in "foo" "bar" "foo bar" "some-password-here"; do
+        if ! pt="$(echo "${data}" | clevis encrypt tang "${cfg}" -y \
+                   | clevis decrypt)"; then
+            error "${TEST}: tang - encrypt should succeed."
+        fi
+        if ["${pt}" != "${data}" ]; then
+            error "${TEST}: tang - pt(${pt}) != data("${data}")."
+        fi
+    done
+}
+
+test_sss() {
+    local url="${1}"
+    local sss1 sss2 data pt
+    sss1=$(printf '{"t":1, "pins": {"tang": [{"url": "%s"}]}}' "${url}")
+    sss2=$(printf '{"t":2, "pins": {"tang": [{"url": "%s"}, {"url": "%s"}]}}' \
+           "${url}" "${url}")
+
+    for data in "foo" "bar" "foo bar" "some-password-here"; do
+        if ! pt="$(echo "${data}" | clevis encrypt sss "${sss1}" -y \
+                   | clevis decrypt)"; then
+            error "${TEST}: sss1 - encrypt should succeed."
+        fi
+        if ["${pt}" != "${data}" ]; then
+            error "${TEST}: sss1 - pt(${pt}) != data("${data}")."
+        fi
+
+        if ! pt="$(echo "${data}" | clevis encrypt sss "${sss2}" -y \
+                   | clevis decrypt)"; then
+            error "${TEST}: sss2 - encrypt should succeed."
+        fi
+        if ["${pt}" != "${data}" ]; then
+            error "${TEST}: sss2 - pt(${pt}) != data("${data}")."
+        fi
+    done
+}
+
+test_tang "${url}"
+test_sss "${url}"
+
+# LUKS1.
+DEV="${TMP}/luks1-device"
+new_device "luks1" "${DEV}"
+
+# tang.
+if ! clevis luks bind -y -d "${DEV}" tang "${cfg}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: Bind should have succeeded (tang - $DEV)."
+fi
+
+if ! clevis_luks_unlock_device "${DEV}"; then
+    error "${TEST}: we were unable to unlock ${DEV} (tang)."
+fi
+
+# sss.
+new_device "luks1" "${DEV}"
+
+sss=$(printf '{"t":2, "pins": {"tang": [{"url": "%s"}, {"url": "%s"}]}}' \
+             "${url}" "${url}")
+
+if ! clevis luks bind -y -d "${DEV}" sss "${sss}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: Bind should have succeeded (sss - $DEV)."
+fi
+
+if ! clevis_luks_unlock_device "${DEV}"; then
+    error "${TEST}: we were unable to unlock ${DEV} (sss)."
+fi

--- a/src/luks/tests/assume-yes-luks2
+++ b/src/luks/tests/assume-yes-luks2
@@ -1,0 +1,69 @@
+#!/bin/bash -ex
+# vim: set ts=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+TEST=$(basename "${0}")
+. tests-common-functions
+
+. clevis-luks-common-functions
+
+on_exit() {
+    [ ! -d "${TMP}" ] && return 0
+    tang_stop "${TMP}"
+    rm -rf "${TMP}"
+}
+
+trap 'on_exit' EXIT
+trap 'on_exit' ERR
+
+TMP="$(mktemp -d)"
+
+port=$(get_random_port)
+tang_run "${TMP}" "${port}" &
+tang_wait_until_ready "${port}"
+
+url="http://${TANG_HOST}:${port}"
+cfg=$(printf '{"url":"%s"}' "$url")
+
+# LUKS2.
+DEV="${TMP}/luks2-device"
+new_device "luks2" "${DEV}"
+
+# tang.
+if ! clevis luks bind -y -d "${DEV}" tang "${cfg}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: Bind should have succeeded (tang - $DEV)."
+fi
+
+if ! clevis_luks_unlock_device "${DEV}"; then
+    error "${TEST}: we were unable to unlock ${DEV} (tang)."
+fi
+
+# sss.
+new_device "luks2" "${DEV}"
+
+sss=$(printf '{"t":2, "pins": {"tang": [{"url": "%s"}, {"url": "%s"}]}}' \
+             "${url}" "${url}")
+
+if ! clevis luks bind -y -d "${DEV}" sss "${sss}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: Bind should have succeeded (sss - $DEV)."
+fi
+
+if ! clevis_luks_unlock_device "${DEV}"; then
+    error "${TEST}: we were unable to unlock ${DEV} (sss)."
+fi
+

--- a/src/luks/tests/meson.build
+++ b/src/luks/tests/meson.build
@@ -87,6 +87,7 @@ endif
 
 if has_tang
   test('unlock-tang-luks1', find_program('unlock-tang-luks1'), env: env, timeout: 90)
+  test('assume-yes', find_program('assume-yes'), env: env, timeout: 60)
 endif
 
 # LUKS2 tests go here, and they get included if we get support for it, based
@@ -106,5 +107,7 @@ if luksmeta_data.get('OLD_CRYPTSETUP') == '0'
 
   if has_tang
     test('unlock-tang-luks2', find_program('unlock-tang-luks2'), env: env, timeout: 120)
+    test('assume-yes-luks2', find_program('assume-yes-luks2'), env: env, timeout: 60)
   endif
+
 endif

--- a/src/pins/sss/clevis-encrypt-sss.1.adoc
+++ b/src/pins/sss/clevis-encrypt-sss.1.adoc
@@ -5,11 +5,11 @@ CLEVIS-ENCRYPT-SSS(1)
 
 == NAME
 
-clevis-encrypt-sss - Encrypts using a Shamir's Secret Sharing policy 
+clevis-encrypt-sss - Encrypts using a Shamir's Secret Sharing policy
 
 == SYNOPSIS
 
-*clevis encrypt sss* CONFIG < PT > JWE
+*clevis encrypt sss* CONFIG [-y] < PT > JWE
 
 == OVERVIEW
 
@@ -51,6 +51,16 @@ The format of the *pins* property is as follows:
 
 When the list version of the format is used, multiple pins of that type will
 receive key fragments.
+
+== OPTIONS
+
+* *-y* :
+  Automatically answer yes for all questions. For the _tang_ pin, it will
+  skip the advertisement trust check, which can be useful in automated
+  deployments:
+
+    $ cfg='{"t":1,"pins":{"tang":[{"url":...},{"url":...}]}}'
+    $ clevis encrypt sss "$cfg" -y < PT > JWE
 
 == SEE ALSO
 

--- a/src/pins/tang/clevis-encrypt-tang
+++ b/src/pins/tang/clevis-encrypt-tang
@@ -28,9 +28,13 @@ fi
 if [ -t 0 ]; then
     exec >&2
     echo
-    echo "Usage: clevis encrypt tang CONFIG < PLAINTEXT > JWE"
+    echo "Usage: clevis encrypt tang CONFIG [-y] < PLAINTEXT > JWE"
     echo
     echo "$SUMMARY"
+    echo
+    echo "  -y              Use this option for skipping the advertisement"
+    echo "                  trust check. This can be useful in automated"
+    echo "                  deployments"
     echo
     echo "This command uses the following configuration properties:"
     echo
@@ -59,6 +63,9 @@ if ! cfg="$(jose fmt -j- -Oo- <<< "$1" 2>/dev/null)"; then
     echo "Configuration is malformed!" >&2
     exit 1
 fi
+
+trust=
+[ -n "${2}" ] && [ "${2}" == "-y" ] && trust=yes
 
 if ! url="$(jose fmt -j- -Og url -u- <<< "$cfg")"; then
     echo "Missing the required 'url' property!" >&2
@@ -100,18 +107,20 @@ if ! jose jws ver -i "$jws" -k- -a <<< "$ver"; then
 fi
 
 ### Check advertisement trust
-if [ -z "$thp" ]; then
-    echo "The advertisement contains the following signing keys:" >&2
-    echo >&2
-    jose jwk thp -i- <<< "$ver" >&2
-    echo >&2
-    read -r -p "Do you wish to trust these keys? [ynYN] " ans < /dev/tty
-    [[ "$ans" =~ ^[yY]$ ]] || exit 1
+if [ -z "${trust}" ]; then
+    if [ -z "$thp" ]; then
+        echo "The advertisement contains the following signing keys:" >&2
+        echo >&2
+        jose jwk thp -i- <<< "$ver" >&2
+        echo >&2
+        read -r -p "Do you wish to trust these keys? [ynYN] " ans < /dev/tty
+        [[ "$ans" =~ ^[yY]$ ]] || exit 1
 
-elif [ "$thp" != "any" ] && \
-    ! jose jwk thp -i- -f "$thp" -o /dev/null <<< "$ver"; then
-    echo "Trusted JWK '$thp' did not sign the advertisement!" >&2
-    exit 1
+    elif [ "$thp" != "any" ] && \
+        ! jose jwk thp -i- -f "$thp" -o /dev/null <<< "$ver"; then
+        echo "Trusted JWK '$thp' did not sign the advertisement!" >&2
+        exit 1
+    fi
 fi
 
 ### Perform encryption

--- a/src/pins/tang/clevis-encrypt-tang.1.adoc
+++ b/src/pins/tang/clevis-encrypt-tang.1.adoc
@@ -9,7 +9,7 @@ clevis-encrypt-tang - Encrypts using a Tang binding server policy
 
 == SYNOPSIS
 
-*clevis encrypt tang* CONFIG < PT > JWE
+*clevis encrypt tang* CONFIG [-y] < PT > JWE
 
 == OVERVIEW
 
@@ -75,6 +75,15 @@ This command uses the following configuration properties:
 
 * *adv* (object) :
   A trusted advertisement (raw JSON)
+
+== OPTIONS
+
+* *-y* :
+  Automatically answer yes for all questions. Use this option for skipping
+  the advertisement trust check. This can be useful in automated deployments:
+
+    $ clevis encrypt tang '{"url":...}' -y < PT > JWE
+
 
 == SEE ALSO
 


### PR DESCRIPTION
In order to simplify automated operations with e.g. ansible,
it would be helpful to have a way to automate the creation of
bindings with clevis.

In simple scenarios, it's possible to download the advertisement
from a tang server and pass it in the binding configuration, to
do the binding offline, in the following way:

curl -sfg http://tang.server/adv -o adv.jws

clevis luks bind -d /dev/sda2 tang '{"url":"http://tang.server", "adv":"adv.jws}'

However, for more complex scenarios using multiple servers with
the sss pin, it becomes a lot more complicated to do the same
thing and do the binding in an automated fashion. An alternative
would be to use expect (tcl), but it can also be complicated.

In this commit we introduce -y as a parameter meaning _assume yes_.
Essentially, this would make it so that the user would not have to
manually trust tang key(s) by typing y/yes.

Security-wise, it would be similar to downloading the advertisement
manually and passing it to tang as the "adv" configuration option,
something already supported, and the same caveat of making sure the
network isn't compromised applies here as well.