### PR TITLE
pins: improve error reporting for sss pin

### DIFF
--- a/src/luks/tests/bad-sss
+++ b/src/luks/tests/bad-sss
@@ -1,0 +1,40 @@
+#!/bin/bash -ex
+# vim: set ts=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+TEST=$(basename "${0}")
+. tests-common-functions
+
+on_exit() {
+    [ -d "${TMP}" ] && rm -rf "${TMP}"
+}
+
+trap 'on_exit' EXIT
+
+TMP="$(mktemp -d)"
+
+CFG='{"t":1, "pins":{"tang":[{"url":"foo bar"}]}}'
+
+# LUKS1.
+DEV="${TMP}/luks1-device"
+new_device "luks1" "${DEV}"
+
+if clevis luks bind -f -d "${DEV}" sss "${CFG}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: Binding is not expected to succeed when given a bad sss config." >&2
+fi

--- a/src/luks/tests/meson.build
+++ b/src/luks/tests/meson.build
@@ -75,6 +75,7 @@ test('bind-pass-with-newline', find_program('bind-pass-with-newline-luks1'), env
 test('bind-pass-with-newline-keyfile', find_program('bind-pass-with-newline-keyfile-luks1'), env: env)
 # Bug #70.
 test('bind-already-used-luksmeta-slot', find_program('bind-already-used-luksmeta-slot'), env: env, timeout: 60)
+test('bad-sss', find_program('bad-sss'), env: env)
 
 if jq.found()
   test('list-recursive-luks1', find_program('list-recursive-luks1'), env: env)

--- a/src/pins/sss/clevis-encrypt-sss.c
+++ b/src/pins/sss/clevis-encrypt-sss.c
@@ -95,6 +95,7 @@ encrypt_frag(json_t *sss, const char *pin, const json_t *cfg)
     FILE *pipe = NULL;
     size_t pntl = 0;
     pid_t pid = 0;
+    int status = 0;
 
     str = args[3] = json_dumps(cfg, JSON_SORT_KEYS | JSON_COMPACT);
     if (!str)
@@ -132,7 +133,10 @@ encrypt_frag(json_t *sss, const char *pin, const json_t *cfg)
     }
 
     fclose(pipe);
-    waitpid(pid, NULL, 0);
+    waitpid(pid, &status, 0);
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        return NULL;
+    }
     return json_incref(jwe);
 }
 

--- a/src/pins/sss/meson.build
+++ b/src/pins/sss/meson.build
@@ -18,8 +18,9 @@ if jansson.found() and libcrypto.found()
   mans += join_paths(src, 'clevis-encrypt-sss.1')
 
   env = environment()
-  env.append('PATH',
+  env.prepend('PATH',
     join_paths(meson.source_root(), 'src'),
+    join_paths(meson.source_root(), 'src', 'pins', 'tang'),
     meson.current_build_dir(),
     '/usr/libexec',
     libexecdir,

--- a/src/pins/sss/pin-sss
+++ b/src/pins/sss/pin-sss
@@ -20,3 +20,5 @@ e="$(echo hi | clevis encrypt sss '{"t":2,"pins":{"test":[{},{"fail":true}]}}')"
 
 e="$(echo hi | clevis encrypt sss '{"t":2,"pins":{"test":[{"fail":true},{"fail":true}]}}')"
 ! echo "$e" | clevis decrypt
+
+! e="$(echo hi | clevis encrypt sss '{"t":1,"pins":{"tang":[{"url":"foo bar"}]}}')"

--- a/src/pins/tang/meson.build
+++ b/src/pins/tang/meson.build
@@ -31,7 +31,7 @@ if curl.found()
   if actv.found() and kgen.found() and updt.found() and tang.found()
     env = environment()
     env.set('SD_ACTIVATE', actv.path())
-    env.append('PATH',
+    env.prepend('PATH',
       join_paths(meson.source_root(), 'src'),
       meson.current_source_dir(),
       '/usr/libexec',


### PR DESCRIPTION
clevis-encrypt-sss would return 0 (and a JWE, without the pins that failed)
even if the encryption operation failed, when using the sss pin, such as:

echo test | clevis encrypt sss '{"t":1, "pins":{"tang":[{"url":"foo bar"}]}}'
Unable to fetch advertisement: 'foo bar/adv/'!
eyJhbGciOiJkaXIiLCJjbGV2aXMiOnsicGluIjoic3NzIiwic3NzIjp7Imp3ZSI6WyIiXSwicCI6Inlqald0bkM2ZkwtNDhIbTd5Yy1fVmlwWWxTTHZ1ZlliZnRaejFjLW5ucU0iLCJ0IjoxfX0sImVuYyI6IkEyNTZHQ00ifQ..rM6IMXjNIN3uybW1.J5jAtiU.61x_fjXJC1uCjljTnkkdCw

echo $?
0

This is particularly problematic when using clevis luks bind, as it would
appear the operation succeeded, while in practice it did not, which
means we would be unable to unlock this device. E.g.:

clevis luks bind -d device sss '{"t":1, "pins":{"tang":[{"url":"foo bar"}]}}' <<< password
Unable to fetch advertisement: 'foo bar/adv/'!

echo $?
0

clevis luks list -d device
1: sss '{"t":1,"pins":{}}'

clevis luks unlock -d device
Nothing to read on input.

We now check the exit code of the pins encryption, when doing an sss
encrypt, and indicate errors correctly, so that we avoid this situation.

After the fix:

echo test | clevis encrypt sss '{"t":1, "pins":{"tang":[{"url":"foo bar"}]}}'
Unable to fetch advertisement: 'foo bar/adv/'!

echo $?
1

Also:
clevis luks bind -d device sss '{"t":1, "pins":{"tang":[{"url":"foo bar"}]}}' <<< password
Unable to fetch advertisement: 'foo bar/adv/'!

echo $?
1

clevis luks list -d device
[no output]