### PR TITLE
initramfs: Wait for interface to appear before attempting configuration

### DIFF
--- a/src/initramfs-tools/scripts/local-top/clevis.in
+++ b/src/initramfs-tools/scripts/local-top/clevis.in
@@ -206,29 +206,49 @@ clevis_all_netbootable_devices() {
     echo "$DEVICE"
 }
 
-# Check if network is up before trying to configure it.
-eth_check() {
-    for device in $(clevis_all_netbootable_devices); do
-        ip link set dev "$device" up
-        sleep 1
-        ETH_HAS_CARRIER=$(cat /sys/class/net/"$device"/carrier)
-        if [ "$ETH_HAS_CARRIER" = '1' ]; then
-            return 0
-        fi
-    done
-    return 1
+get_specified_device() {
+    local dev="$(echo $IP | cut -d: -f6)"
+    [ -z "$dev" ] || echo $dev
 }
-if eth_check; then
-    # Make sure networking is set up: if booting via nfs, it already is
-    # Doesn't seem to work when added to clevisloop for some reason
-    if [ "$boot" != nfs ]; then
-        clevis_net_cnt=$(clevis_all_netbootable_devices | tr ' ' '\n' | wc -l)
-        if [ -z "$IP" ] && [ "$clevis_net_cnt" -gt 1 ]; then
-            echo ""
-            echo "clevis: Warning: multiple network interfaces available but no ip= parameter provided."
+
+# Workaround configure_networking() not waiting long enough for an interface
+# to appear. This code can be removed once that has been fixed in all the
+# distro releases we care about.
+wait_for_device() {
+    local device="$(get_specified_device)"
+    local ret=0
+
+    if [ -n "$device" ]; then
+        log_begin_msg "clevis: Waiting for interface ${device} to become available"
+        local netdev_wait=0
+        while [ $netdev_wait -lt 10 ]; do
+            if [ -e "/sys/class/net/${device}" ]; then
+                break
+            fi
+            netdev_wait=$((netdev_wait + 1))
+            sleep 1
+        done
+        if [ ! -e "/sys/class/net/${device}" ]; then
+            log_failure_msg "clevis: Interface ${device} did not appear in time"
+            ret=1
         fi
-        configure_networking
+        log_end_msg
     fi
+
+    wait_for_udev 10
+
+    return $ret
+}
+
+# Make sure networking is set up: if booting via nfs, it already is
+# Doesn't seem to work when added to clevisloop for some reason
+if [ "$boot" != nfs ] && wait_for_device; then
+    clevis_net_cnt=$(clevis_all_netbootable_devices | tr ' ' '\n' | wc -l)
+    if [ -z "$IP" ] && [ "$clevis_net_cnt" -gt 1 ]; then
+        echo ""
+        echo "clevis: Warning: multiple network interfaces available but no ip= parameter provided."
+    fi
+    configure_networking
 fi
 
 clevisloop &


### PR DESCRIPTION
eth_check() currently tries to "link up" each NIC it finds until one is
successful. However, just because it has a link doesn't mean it is the
correct one to use. In fact, the correct interface may not even have been
enumerated yet.

Call a new wait_for_device() function that checks if a user has specified
the correct interface via the ip= command line argument. If so, busy wait
for up to 10s until that device appears. If the user did not specify
an interface, then make a best effort attempt to wait for all devices
to be discovered by calling wait_for_udev(). This will wait for the
udev event queue to empty, which usually means all NICs have been
enumerated. Though it is possible for the event queue to clear temporarily
before the desired NIC is enumerated - we've seen this with some USB-attached
NICs. So for robustness, we should recommend users always specify an
appropriate ip= parameter.

In theory this code should really go into initramfs-tools'
configure_networking() function, where clevis would automatically benefit
from it. I've a merge proposal open for that[*]. However, that will only
help once it gets merged, and then only for future Debian/Debian derivative
releases, unless it were to be backported everywhere. On the other hand,
there's no real harm in doing it in both places.

Also, optimize the existing carrier check code for the case where the user
specified an interface. Though we should consider whether or not the link
check is still valuable or can be removed. configure_networking()
already gives each interface plenty of time to obtain link (10 ipconfig
attempts w/ increasing timeouts). Seems like at this point we may just be
delaying boot for 1 second for every NIC in the system.

Fixes #145

[*] https://salsa.debian.org/kernel-team/initramfs-tools/-/merge_requests/32