### PR TITLE
systemd: clevis-luks-askpass: exit cleanly with SIGTERM

### DIFF
--- a/src/luks/systemd/clevis-luks-askpass
+++ b/src/luks/systemd/clevis-luks-askpass
@@ -22,6 +22,9 @@ set -eu
 
 . clevis-luks-common-functions
 
+# Make sure to exit cleanly if SIGTERM is received.
+trap 'echo "Exiting due to SIGTERM" && exit 0' TERM
+
 loop=
 path=/run/systemd/ask-password
 while getopts ":lp:" o; do


### PR DESCRIPTION
Especially when running in early boot, clevis-luks-askpass may be
looping because e.g. we still have devices remaining to unlock, as
per crypttab, or we were unable to determine if there are any devices
left to be unlocked.

Eventually we may receive a SIGTERM, from e.g. systemd and we should
exit cleanly in this situation.