### PR TITLE
Allow user to specify token ID when binding

### DIFF
--- a/src/luks/clevis-luks-bind.1.adoc
+++ b/src/luks/clevis-luks-bind.1.adoc
@@ -9,7 +9,7 @@ clevis-luks-bind - Bind a LUKS device using the specified policy
 
 == SYNOPSIS
 
-*clevis luks bind* [-f] -d DEV [-s SLT] [-k KEY] PIN CFG
+*clevis luks bind* [-f] -d DEV [-t TKN_ID] [-s SLT] [-k KEY] PIN CFG
 
 == OVERVIEW
 
@@ -36,6 +36,9 @@ Clevis LUKS unlockers. See link:clevis-luks-unlockers.7.adoc[*clevis-luks-unlock
 
 * *-d* _DEV_ :
   The LUKS device on which to perform binding
+
+* *-t* _TKN_ID_ :
+  The LUKS token ID to use; only available for LUKS2
 
 * *-s* _SLT_ :
   The LUKSMeta slot to use for metadata storage

--- a/src/luks/clevis-luks-bind.1.adoc
+++ b/src/luks/clevis-luks-bind.1.adoc
@@ -37,11 +37,11 @@ Clevis LUKS unlockers. See link:clevis-luks-unlockers.7.adoc[*clevis-luks-unlock
 * *-d* _DEV_ :
   The LUKS device on which to perform binding
 
-* *-t* _TKN_ID_ :
-  The LUKS token ID to use; only available for LUKS2
-
 * *-s* _SLT_ :
   The LUKSMeta slot to use for metadata storage
+
+* *-t* _TKN_ID_ :
+  The LUKS token ID to use; only available for LUKS2
 
 * *-k* _KEY_ :
   Non-interactively read LUKS password from KEY file

--- a/src/luks/clevis-luks-bind.in
+++ b/src/luks/clevis-luks-bind.in
@@ -102,6 +102,11 @@ else
     luks_type="luks1"
 fi
 
+if [ "$luks_type" = "luks1" -a -n "$TOKEN_ID" ]; then
+    echo "$DEV is a LUKS1 device; -t is only supported in LUKS2"
+    exit 1
+fi
+
 if [ "${luks_type}" = "luks1" ]; then
     # The first free slot, as per cryptsetup. In connection to bug #70, we may
     # have to wipe out the LUKSMeta slot priot to adding the new key.

--- a/src/luks/clevis-luks-bind.in
+++ b/src/luks/clevis-luks-bind.in
@@ -39,7 +39,7 @@ function usage() {
     echo
     echo "  -d DEV       The LUKS device on which to perform binding"
     echo
-    echo "  -s SLT       The LUKS slot to use"
+    echo "  -s SLT       The LUKS slot to use; only available for LUKS2"
     echo
     echo "  -t TOKEN_ID  The LUKS token ID to use"
     echo

--- a/src/luks/clevis-luks-bind.in
+++ b/src/luks/clevis-luks-bind.in
@@ -39,9 +39,9 @@ function usage() {
     echo
     echo "  -d DEV       The LUKS device on which to perform binding"
     echo
-    echo "  -s SLT       The LUKS slot to use; only available for LUKS2"
+    echo "  -s SLT       The LUKS slot to use"
     echo
-    echo "  -t TOKEN_ID  The LUKS token ID to use"
+    echo "  -t TKN_ID    The LUKS token ID to use; only available for LUKS2"
     echo
     echo "  -k KEY       Non-interactively read LUKS password from KEY file"
     echo "  -k -         Non-interactively read LUKS password from standard input"

--- a/src/luks/clevis-luks-bind.in
+++ b/src/luks/clevis-luks-bind.in
@@ -31,18 +31,20 @@ function luks2_supported() {
 function usage() {
     exec >&2
     echo
-    echo "Usage: clevis luks bind [-f] [-s SLT] [-k KEY] -d DEV PIN CFG"
+    echo "Usage: clevis luks bind [-f] [-s SLT] [-k KEY] [-t TOKEN_ID] -d DEV PIN CFG"
     echo
     echo "$SUMMARY":
     echo
-    echo "  -f      Do not prompt for LUKSMeta initialization"
+    echo "  -f           Do not prompt for LUKSMeta initialization"
     echo
-    echo "  -d DEV  The LUKS device on which to perform binding"
+    echo "  -d DEV       The LUKS device on which to perform binding"
     echo
-    echo "  -s SLT  The LUKS slot to use"
+    echo "  -s SLT       The LUKS slot to use"
     echo
-    echo "  -k KEY  Non-interactively read LUKS password from KEY file"
-    echo "  -k -    Non-interactively read LUKS password from standard input"
+    echo "  -t TOKEN_ID  The LUKS token ID to use"
+    echo
+    echo "  -k KEY       Non-interactively read LUKS password from KEY file"
+    echo "  -k -         Non-interactively read LUKS password from standard input"
     echo
     exit 2
 }
@@ -53,12 +55,13 @@ if [ $# -eq 1 ] && [ "$1" == "--summary" ]; then
 fi
 
 FRC=()
-while getopts ":hfd:s:k:" o; do
+while getopts ":hfd:s:k:t:" o; do
     case "$o" in
     f) FRC+=(-f);;
     d) DEV="$OPTARG";;
     s) SLT="$OPTARG";;
     k) KEY="$OPTARG";;
+    t) TOKEN_ID="$OPTARG";;
     *) usage;;
     esac
 done
@@ -214,7 +217,7 @@ if [ "$luks_type" == "luks1" ]; then
     echo -n "$jwe" | luksmeta save -d "$DEV" -u "$UUID" -s "$SLT" 2>/dev/null
 else
     printf '{"type":"clevis","keyslots":["%s"],"jwe":%s}' "$SLT" "$(jose jwe fmt -i- <<< "$jwe")" \
-        | cryptsetup token import "$DEV"
+        | cryptsetup token import $([ -n "$TOKEN_ID" ] && echo '--token-id '$TOKEN_ID) "$DEV"
 fi
 if [ $? -ne 0 ]; then
     echo "Error while saving Clevis metadata in LUKSMeta!" >&2

--- a/src/luks/tests/bind-luks2
+++ b/src/luks/tests/bind-luks2
@@ -41,8 +41,9 @@ CFG="$(printf '{"url":"foobar","adv":"%s"}' "$ADV")"
 # LUKS2.
 
 DEV="${TMP}/luks2-device"
+TOKEN_ID=5
 new_device "luks2" "${DEV}"
 
-if ! clevis luks bind -d "${DEV}" tang "${CFG}" <<< "${DEFAULT_PASS}"; then
+if ! clevis luks bind -d "${DEV}" -t "$TOKEN_ID" tang "${CFG}" <<< "${DEFAULT_PASS}"; then
     error "${TEST}: Binding is expected to succeed when given a correct (${DEFAULT_PASS}) password." >&2
 fi


### PR DESCRIPTION
Currently, when interacting with LUKS2 volumes, my workflow involves using a static token ID and using this static ID to determine the keyslot by reading the `keyslots` key from the token. Given that knowing the keyslot number is required for unbinding, adding this parameter would allow me to determine the keyslot deterministically from the token slot that I've assigned it to. This PR allows users to specify a token ID when binding to a LUKS2 volume so that the token ends up under that ID. Does this sound like something you'd be willing to accept?