### PR TITLE
askpass: change systemd directory watch condition to DirectoryNotEmpty

### DIFF
--- a/src/luks/systemd/clevis-luks-askpass.path
+++ b/src/luks/systemd/clevis-luks-askpass.path
@@ -6,7 +6,8 @@ Before=cryptsetup-pre.target
 Wants=cryptsetup-pre.target
 
 [Path]
-PathChanged=/run/systemd/ask-password
+DirectoryNotEmpty=/run/systemd/ask-password
+MakeDirectory=yes
 
 [Install]
 WantedBy=cryptsetup.target


### PR DESCRIPTION
The current condition was have for watching systemd's ask-password
directory is `PathChanged', which means clevis-luks-askpass would
activate whenever the watched directory changed [1].

However, it is possible that the watched directory is already populated
with ask.xxxx files when clevis-luks-askpass tries to start, in which
case it won't do so, because the condition on the watched directory
won't match. With clevis-luks-askpass not starting, it means that
devices that are bound by clevis won't be unlocked either, as was
reported in [2].

This commit changes the condition on the watched [Path] to the same one
used by both:
- systemd-ask-password-console.path and
- systemd-ask-password-plymouth.path

which are units that handle ask.XXXX ask-password files, similar to
clevis-luks-askpass.

The condition in question is the following:

[Path]
DirectoryNotEmpty=/run/systemd/ask-password
MakeDirectory=yes

[1] https://www.freedesktop.org/software/systemd/man/systemd.path.html
[2] https://bugzilla.redhat.com/show_bug.cgi?id=1878892