### PR TITLE
clevis-luks-askpass.service: use Type=simple

### DIFF
--- a/src/luks/systemd/clevis-luks-askpass.service.in
+++ b/src/luks/systemd/clevis-luks-askpass.service.in
@@ -4,5 +4,5 @@ Documentation=man:clevis-luks-unlockers(7)
 DefaultDependencies=no
 
 [Service]
-Type=oneshot
+Type=simple
 ExecStart=@libexecdir@/clevis-luks-askpass -l


### PR DESCRIPTION
Let's use `Type=simple` since `clevis-luks-askpass -l` is long-running
and not "one-shot".

Noticed this while debugging something else. It doesn't make any
practical difference but could in the future. With `oneshot`, the
service will be stuck in `activating` which means that systemd won't be
able to start any follow-up services which explicitly do
`After=clevis-luks-askpass.service`.