### PR TITLE
luks: add clevis luks regen command

### DIFF
--- a/src/luks/clevis-luks-common-functions
+++ b/src/luks/clevis-luks-common-functions
@@ -18,6 +18,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+CLEVIS_UUID="cb6e8904-81ff-40da-a84a-07ab9ab5715e"
+
 # valid_slot() will check whether a given slot is possibly valid, i.e., if it
 # is a numeric value within the specified range.
 valid_slot() {
@@ -63,7 +65,6 @@ clevis_luks_read_slot() {
             return 1
         fi
 
-        local CLEVIS_UUID="cb6e8904-81ff-40da-a84a-07ab9ab5715e"
         local uuid
         # Pattern from luksmeta: active slot uuid.
         read -r _ _ uuid <<< "$(luksmeta show -d "${DEV}" | grep "^${SLT} *")"
@@ -111,20 +112,25 @@ clevis_luks_read_slot() {
 # clevis_luks_used_slots() will return the list of used slots for a given LUKS
 # device.
 clevis_luks_used_slots() {
-    local DEV="${1}"
+    local DEV="${1:-}"
+    [ -z "${DEV}" ] && return 1
 
-    local slots
+    local used_slots
     if cryptsetup isLuks --type luks1 "${DEV}"; then
-        readarray -t slots < <(cryptsetup luksDump "${DEV}" \
-            | sed -rn 's|^Key Slot ([0-7]): ENABLED$|\1|p')
+        if ! used_slots=$(cryptsetup luksDump "${DEV}" 2>/dev/null \
+                          | sed -rn 's|^Key Slot ([0-7]): ENABLED$|\1|p'); then
+            return 1
+        fi
     elif cryptsetup isLuks --type luks2 "${DEV}"; then
-        readarray -t slots < <(cryptsetup luksDump "${DEV}" \
-            | sed -rn 's|^\s+([0-9]+): luks2$|\1|p')
+        if ! used_slots=$(cryptsetup luksDump "${DEV}" 2>/dev/null \
+                          | sed -rn 's|^\s+([0-9]+): luks2$|\1|p'); then
+            return 1
+        fi
     else
         echo "${DEV} is not a supported LUKS device!" >&2
         return 1
     fi
-    echo "${slots[@]}"
+    echo "${used_slots}"
 }
 
 # clevis_luks_decode_jwe() will decode a given JWE.
@@ -374,4 +380,246 @@ clevis_devices_to_unlock() {
         clevis_devices="${clevis_devices} ${dev}"
     done < /etc/crypttab
     echo "${clevis_devices}" | sed -e 's/^ //'
+}
+
+# clevis_luks1_save_slot() works with LUKS1 devices and it saves a given JWE
+# to a specific device and slot. The last parameter indicates whether we
+# should overwrite existing metadata.
+clevis_luks1_save_slot() {
+    local DEV="${1}"
+    local SLOT="${2}"
+    local JWE="${3}"
+    local SHOULD_OVERWRITE="${4:-}"
+
+    luksmeta test -d "${DEV}" || return 1
+
+    if luksmeta load -d "${DEV}" -s "${SLOT}" -u "${CLEVIS_UUID}" \
+                        >/dev/null 2>/dev/null; then
+        [ -z "${SHOULD_OVERWRITE}" ] && return 1
+        if ! luksmeta wipe -f -d "${DEV}" -s "${SLOT}" \
+                           -u "${CLEVIS_UUID}"; then
+            echo "Error wiping slot ${SLOT} from ${DEV}" >&2
+            return 1
+        fi
+    fi
+
+    if ! echo -n "${JWE}" | luksmeta save -d "${DEV}" -s "${SLOT}" \
+                                          -u "${CLEVIS_UUID}"; then
+        echo "Error saving metadata to LUKSMeta slot ${SLOT} from ${DEV}" >&2
+        return 1
+    fi
+    return 0
+}
+
+# clevis_luks2_save_slot() works with LUKS2 devices and it saves a given JWE
+# to a specific device and slot. The last parameter indicates whether we
+# should overwrite existing metadata.
+clevis_luks2_save_slot() {
+    local DEV="${1}"
+    local SLOT="${2}"
+    local TKN_ID="${3}"
+    local JWE="${4}"
+    local SHOULD_OVERWRITE="${5:-}"
+
+    # Sanitize clevis LUKS2 tokens. Remove "orphan" clevis tokens, i.e.,
+    # tokens that are not linked to any key slots.
+    local token array_len
+    for token in $(cryptsetup luksDump "${DEV}" \
+                   | sed -rn 's|^\s+([0-9]+): clevis|\1|p'); do
+        # Let's check the length of the "keyslots" array. If zero, it means
+        # no key slots are linked, which is a problem.
+        if ! array_len=$(cryptsetup token export --token-id \
+                         "${token}" "${DEV}" \
+                         | jose fmt --json=- --get keyslots --array --length \
+                         --output=-) || [ "${array_len}" -eq 0 ]; then
+            # Remove bad token.
+            cryptsetup token remove --token-id "${token}" "${DEV}"
+        fi
+    done
+
+
+    if ! token="$(cryptsetup luksDump "${DEV}" \
+                  | grep -E -B1 "^\s+Keyslot:\s+${SLOT}$" \
+                  | sed -rn 's|^\s+([0-9]+): clevis|\1|p')"; then
+        echo "Error trying to read token from LUKS2 device ${DEV}, slot ${SLOT}" >&2
+        return 1
+    fi
+
+    if [ -n "${token}" ]; then
+        [ -z "${SHOULD_OVERWRITE}" ] && return 1
+        if ! cryptsetup token remove --token-id "${token}" "${DEV}"; then
+            echo "Error while removing token ${token} from LUKS2 device ${DEV}" >&2
+            return 1
+        fi
+    fi
+
+    if [ -n "${SHOULD_OVERWRITE}" ] && [ -n "${TKN_ID}" ]; then
+        cryptsetup token remove --token-id "${TKN_ID}" "${DEV}" || :
+    fi
+
+    local metadata
+    metadata=$(printf '{"type":"clevis","keyslots":["%s"],"jwe":%s}' \
+               "${SLOT}" "$(jose jwe fmt --input="${JWE}")")
+    if ! printf '%s' "${metadata}" | cryptsetup token import \
+                $([ -n "${TKN_ID}" ] && printf -- '--token-id %s' "${TKN_ID}") \
+                "${DEV}"; then
+        echo "Error saving metadata to LUKS2 header in device ${DEV}" >&2
+        return 1
+    fi
+    return 0
+}
+
+# clevis_luks_save_slot() saves a given JWE to a LUKS device+slot. It can also
+# overwrite existing metadata.
+clevis_luks_save_slot() {
+    local DEV="${1}"
+    local SLOT="${2}"
+    local TKN_ID="${3}"
+    local JWE="${4}"
+    local SHOULD_OVERWRITE="${5:-}"
+
+    if cryptsetup isLuks --type luks1 "${DEV}"; then
+        clevis_luks1_save_slot "${DEV}" "${SLOT}" "${JWE}" \
+                               "${SHOULD_OVERWRITE}" || return 1
+    elif cryptsetup isLuks --type luks2 "${DEV}"; then
+        clevis_luks2_save_slot "${DEV}" "${SLOT}" "${TKN_ID}" "${JWE}" \
+                               "${SHOULD_OVERWRITE}" || return 1
+    else
+        return 1
+    fi
+    return 0
+}
+
+# clevis_luks1_backup_dev() backups the LUKSMeta slots from a LUKS device,
+# which can be restored with clevis_luks1_restore_dev().
+clevis_luks1_backup_dev() {
+    local DEV="${1}"
+    local TMP="${2}"
+
+    [ -z "${DEV}" ] && return 1
+    [ -z "${TMP}" ] && return 1
+
+    luksmeta test -d "${DEV}" || return 0
+    touch "${TMP}/initialized"
+
+    local used_slots slt uuid jwe fname
+    if ! used_slots=$(clevis_luks_used_slots "${DEV}") \
+                      || [ -z "${used_slots}" ]; then
+        return 1
+    fi
+
+    for slt in ${used_slots}; do
+        if ! uuid=$(luksmeta show -d "${DEV}" -s "${slt}") \
+                    || [ -z "${uuid}" ]; then
+            continue
+        fi
+        if ! jwe=$(luksmeta load -d "${DEV}" -s "${slt}") \
+                   || [ -z "${jwe}" ]; then
+            continue
+        fi
+
+        fname=$(printf "slot_%s_%s" "${slt}" "${uuid}")
+        printf "%s" "${jwe}" > "${TMP}/${fname}"
+    done
+    return 0
+}
+
+# clevis_luks1_restore_dev() takes care of restoring the LUKSMeta slots from
+# a LUKS device that was backup'ed by clevis_luks1_backup_dev().
+clevis_luks1_restore_dev() {
+    local DEV="${1}"
+    local TMP="${2}"
+
+    [ -z "${DEV}" ] && return 1
+    [ -z "${TMP}" ] && return 1
+
+    [ -e "${TMP}/initialized" ] || return 0
+    luksmeta test -d "${DEV}" || luksmeta init -f -d "${DEV}"
+
+    local slt uuid jwe fname
+    for fname in "${TMP}"/slot_*; do
+        [ -f "${fname}" ] || break
+        if ! slt=$(echo "${fname}" | cut -d '_' -f 2) \
+                   || [ -z "${slt}" ]; then
+            continue
+        fi
+        if ! uuid=$(echo "${fname}" | cut -d '_' -f 3) \
+                    || [ -z "${uuid}" ]; then
+            continue
+        fi
+        if ! jwe=$(cat "${fname}") || [ -z "${jwe}" ]; then
+            continue
+        fi
+        if ! clevis_luks1_save_slot "${DEV}" "${slt}" \
+                                    "${jwe}" "overwrite"; then
+            echo "Error restoring LUKSmeta slot ${slt} from ${DEV}" >&2
+            return 1
+        fi
+    done
+    return 0
+}
+
+# clevis_luks_backup_dev() backups a particular LUKS device, which can then
+# be restored with clevis_luks_restore_dev().
+clevis_luks_backup_dev() {
+    local DEV="${1}"
+    local TMP="${2}"
+
+    [ -z "${DEV}" ] && return 1
+    [ -z "${TMP}" ] && return 1
+
+    printf '%s' "${DEV}" > "${TMP}/device"
+
+    local HDR
+    HDR="${TMP}/$(basename "${DEV}").header"
+    if ! cryptsetup luksHeaderBackup "${DEV}" --batch-mode \
+            --header-backup-file "${HDR}"; then
+        echo "Error backing up LUKS header from ${DEV}" >&2
+        return 1
+    fi
+
+    # If LUKS1, we need to manually back up (and later restore) the
+    # LUKSmeta slots. For LUKS2, simply saving the header also saves
+    # the associated tokens.
+    if cryptsetup isLuks --type luks1 "${DEV}"; then
+        if ! clevis_luks1_backup_dev "${DEV}" "${TMP}"; then
+            return 1
+        fi
+    fi
+    return 0
+}
+
+# clevis_luks_restore_dev() restores a given device that was backup'ed by
+# clevis_luks_backup_dev().
+clevis_luks_restore_dev() {
+    local TMP="${1}"
+
+    [ -z "${TMP}" ] && return 1
+    [ -r "${TMP}"/device ] || return 1
+
+    local DEV
+    DEV="$(cat "${TMP}"/device)"
+
+    local HDR
+    HDR="${TMP}/$(basename "${DEV}").header"
+    if [ ! -e "${HDR}" ]; then
+        echo "LUKS header backup does not exist" >&2
+        return 1
+    fi
+
+    if ! cryptsetup luksHeaderRestore "${DEV}" --batch-mode \
+            --header-backup-file "${HDR}"; then
+        echo "Error restoring LUKS header from ${DEV}" >&2
+        return 1
+    fi
+
+    # If LUKS1, we need to manually back up (and later restore) the
+    # LUKSmeta slots. For LUKS2, simply saving the header also saves
+    # the associated tokens.
+    if cryptsetup isLuks --type luks1 "${DEV}"; then
+        if ! clevis_luks1_restore_dev "${DEV}" "${TMP}"; then
+            return 1
+        fi
+    fi
+    return 0
 }

--- a/src/luks/clevis-luks-common-functions
+++ b/src/luks/clevis-luks-common-functions
@@ -284,6 +284,54 @@ clevis_luks_read_pins_from_slot() {
     printf "%s: %s\n" "${SLOT}" "${cfg}"
 }
 
+# clevis_luks_check_valid_key_or_keyfile() receives a devices and either a
+# passphrase or keyfile and then checks whether it is able to unlock the
+# device wih the received passphrase/keyfile.
+clevis_luks_check_valid_key_or_keyfile() {
+    local DEV="${1}"
+    local KEY="${2:-}"
+    local KEYFILE="${3:-}"
+    local SLT="${4:-}"
+
+    [ -z "${DEV}" ] && return 1
+    [ -z "${KEYFILE}" ] && [ -z "${KEY}" ] && return 1
+
+    local extra_args
+    extra_args="$([ -n "${SLT}" ] && printf -- '--key-slot %s' "${SLT}")"
+    if [ -n "${KEYFILE}" ]; then
+        cryptsetup open --test-passphrase "${DEV}" --key-file "${KEYFILE}" \
+                   ${extra_args}
+        return
+    fi
+
+    printf '%s' "${KEY}" | cryptsetup open --test-passphrase "${DEV}" \
+                                      ${extra_args}
+}
+
+# clevis_luks_unlock_device_by_slot() does the unlock of the device and slot
+# passed as parameters and returns the decoded passphrase.
+clevis_luks_unlock_device_by_slot() {
+    local DEV="${1}"
+    local SLT="${2}"
+
+    [ -z "${DEV}" ] && return 1
+    [ -z "${SLT}" ] && return 1
+
+    local jwe passphrase
+    if ! jwe="$(clevis_luks_read_slot "${DEV}" "${SLT}" 2>/dev/null)" \
+                || [ -z "${jwe}" ]; then
+        return 1
+    fi
+
+    if ! passphrase="$(printf '%s' "${jwe}" | clevis decrypt 2>/dev/null)" \
+                       || [ -z "${passphrase}" ]; then
+        return 1
+    fi
+
+    clevis_luks_check_valid_key_or_keyfile "${DEV}" "${passphrase}" || return 1
+    printf '%s' "${passphrase}"
+}
+
 # clevis_luks_unlock_device() does the unlock of the device passed as
 # parameter and returns the decoded passphrase.
 clevis_luks_unlock_device() {
@@ -296,26 +344,15 @@ clevis_luks_unlock_device() {
         return 1
     fi
 
-    local slt jwe passphrase
+    local slt pt
     for slt in ${used_slots}; do
-        if ! jwe="$(clevis_luks_read_slot "${DEV}" "${slt}" 2>/dev/null)" \
-                   || [ -z "${jwe}" ]; then
-            continue
+        if ! pt=$(clevis_luks_unlock_device_by_slot "${DEV}" "${slt}") \
+                  || [ -z "${pt}" ]; then
+             continue
         fi
-
-        if ! passphrase="$(clevis decrypt < <(echo -n "${jwe}"))" \
-                           || [ -z "${passphrase}" ]; then
-            continue
-        fi
-
-        if ! cryptsetup luksOpen --test-passphrase "${DEV}" \
-             --key-file <(echo -n "${passphrase}"); then
-            continue
-        fi
-        echo -n "${passphrase}"
+        printf '%s' "${pt}"
         return 0
     done
-
     return 1
 }
 
@@ -454,7 +491,7 @@ clevis_luks2_save_slot() {
     fi
 
     if [ -n "${SHOULD_OVERWRITE}" ] && [ -n "${TKN_ID}" ]; then
-        cryptsetup token remove --token-id "${TKN_ID}" "${DEV}" || :
+        cryptsetup token remove --token-id "${TKN_ID}" "${DEV}" 2>/dev/null || :
     fi
 
     local metadata
@@ -570,6 +607,8 @@ clevis_luks_backup_dev() {
 
     printf '%s' "${DEV}" > "${TMP}/device"
 
+    printf '%s' "${DEV}" > "${TMP}/device"
+
     local HDR
     HDR="${TMP}/$(basename "${DEV}").header"
     if ! cryptsetup luksHeaderBackup "${DEV}" --batch-mode \
@@ -621,5 +660,328 @@ clevis_luks_restore_dev() {
             return 1
         fi
     fi
+    return 0
+}
+
+# clevis_luks_get_existing_key() may try to recover a valid password from
+# existing bindings and additionally prompt the user for the passphrase.
+clevis_luks_get_existing_key() {
+    local DEV="${1}"
+    local PROMPT="${2}"
+    local RECOVER="${3:-}"
+
+    [ -z "${DEV}" ] && return 1
+
+    local pt
+    if [ -n "${RECOVER}" ] && pt="$(clevis_luks_unlock_device "${DEV}")" \
+                           && [ -n "${pt}" ]; then
+        printf '%s' "${pt}"
+        return 0
+    fi
+
+    # Let's prompt the user for the password.
+    read -r -s -p "${PROMPT}" pt; echo >&2
+
+    # Check if key is valid.
+    clevis_luks_check_valid_key_or_keyfile "${DEV}" "${pt}" || return 1
+    printf '%s' "${pt}"
+}
+
+# clevis_luks_luksmeta_sync_fix() makes sure LUKSmeta slots are sync'ed with
+# cryptsetup, in order to prevent issues when saving clevis metadata.
+clevis_luks_luksmeta_sync_fix() {
+    local DEV="${DEV}"
+    [ -z "${DEV}" ] && return 1
+
+    # This applies only to LUKS1 devices.
+    cryptsetup isLuks --type luks1 "${DEV}" || return 0
+
+    # No issues if the LUKSmeta metadata is not initialized.
+    luksmeta test -d "${DEV}" || return 0
+
+    local first_free_slot
+    if ! first_free_slot=$(clevis_luks_first_free_slot "${DEV}") \
+                           || [ -z "${first_free_slot}" ]; then
+        echo "There are possibly no free slots in ${DEV}" >&2
+        return 1
+    fi
+
+    # In certain circumstances, we may have LUKSMeta slots "not in sync" with
+    # cryptsetup, which means we will try to save LUKSMeta metadata over an
+    # already used or partially used slot -- github issue #70.
+    # If that is the case, let's wipe the LUKSMeta slot here prior to using
+    # the LUKSMeta slot.
+    local lmeta_slot lmeta_status lmeta_uuid
+    lmeta_slot="$(luksmeta show -d "${DEV}" | grep "^${first_free_slot}")"
+    # 1   active cb6e8904-81ff-40da-a84a-07ab9ab5715e
+    # 2 inactive cb6e8904-81ff-40da-a84a-07ab9ab5715e
+    lmeta_status="$(echo "${lmeta_slot}" | awk '{print $2}')"
+    [ "${lmeta_status}" != 'inactive' ] && return 0
+
+    lmeta_uuid="$(echo "${lmeta_slot}" | awk '{print $3}')"
+    [ "${lmeta_uuid}" != "${CLEVIS_UUID}" ] && return 0
+
+    luksmeta wipe -f -d "${DEV}" -s "${first_free_slot}"
+}
+
+# clevis_luks_add_key() adds a new key to a key slot.
+clevis_luks_add_key() {
+    local DEV="${1}"
+    local SLT="${2}"
+    local NEWKEY="${3}"
+    local KEY="${4}"
+    local KEYFILE="${5:-}"
+
+    [ -z "${DEV}" ] && return 1
+    [ -z "${NEWKEY}" ] && return 1
+    [ -z "${KEY}" ] && [ -z "${KEYFILE}" ] && return 1
+
+    local extra_args='' input
+    input="$(printf '%s\n%s' "${KEY}" "${NEWKEY}")"
+    if [ -n "${KEYFILE}" ]; then
+        extra_args="$(printf -- '--key-file %s' "${KEYFILE}")"
+        input="$(printf '%s' "${NEWKEY}")"
+    fi
+
+    printf '%s' "${input}" | cryptsetup luksAddKey --batch-mode \
+                                         --key-slot "${SLT}" \
+                                         "${DEV}" \
+                                         ${extra_args}
+}
+
+# clevis_luks_update_key() will update a key slot with a new key.
+clevis_luks_update_key() {
+    local DEV="${1}"
+    local SLT="${2}"
+    local NEWKEY="${3}"
+    local KEY="${4}"
+    local KEYFILE="${5:-}"
+
+    [ -z "${DEV}" ] && return 1
+    [ -z "${NEWKEY}" ] && return 1
+
+    # Update the key slot with the new key. If we have the key for this slot,
+    # the change happens in-place. Otherwise, we kill the slot and re-add it.
+    local in_place
+    clevis_luks_check_valid_key_or_keyfile "${DEV}" \
+                                           "${KEY}" "${KEYFILE}" \
+                                           "${SLT}" 2>/dev/null \
+                                           && in_place=true
+
+    local input extra_args=
+    input="$(printf '%s\n%s' "${KEY}" "${NEWKEY}")"
+    if [ -n "${KEYFILE}" ]; then
+        extra_args="$(printf -- '--key-file %s' "${KEYFILE}")"
+        input="$(printf '%s' "${NEWKEY}")"
+    fi
+
+    if [ -n "${in_place}" ]; then
+        printf '%s' "${input}" | cryptsetup luksChangeKey "${DEV}" \
+                                            --key-slot "${SLT}" \
+                                            --batch-mode ${extra_args}
+        return
+    fi
+
+    if ! printf '%s' "${input}" | cryptsetup luksKillSlot "${DEV}" \
+                                                          "${SLT}" \
+                                                          ${extra_args}; then
+        echo "Error wiping slot ${SLT} from ${DEV}" >&2
+        return 1
+    fi
+    clevis_luks_add_key "${DEV}" "${SLT}" "${NEWKEY}" "${KEY}" "${KEYFILE}"
+}
+
+# clevis_luks_save_key_to_slot() will save a new key to a slot. It can either
+# add a new key to a slot or updating an already used slot.
+clevis_luks_save_key_to_slot() {
+    local DEV="${1}"
+    local SLT="${2}"
+    local NEWKEY="${3}"
+    local KEY="${4}"
+    local KEYFILE="${5:-}"
+    local OVERWRITE="${6:-}"
+
+    [ -z "${DEV}" ] && return 1
+    [ -z "${SLT}" ] && return 1
+    [ -z "${NEWKEY}" ] && return 1
+
+    # Make sure LUKSmeta slots are in sync with cryptsetup, to avoid the
+    # problem reported in github issue #70. Applies to LUKS1 only.
+    clevis_luks_luksmeta_sync_fix "${DEV}"
+
+    # Let's check if we are adding a new key or updating an existing one.
+    local update
+    update="$(clevis_luks_used_slots "${DEV}" | grep "^${SLT}$")"
+    if [ -n "${update}" ]; then
+        # Replace an existing key.
+        [ -n "${OVERWRITE}" ] || return 1
+
+        clevis_luks_update_key "${DEV}" "${SLT}" \
+                               "${NEWKEY}" "${KEY}" "${KEYFILE}"
+        return
+    fi
+
+    # Add a new key.
+    clevis_luks_add_key "${DEV}" "${SLT}" \
+                        "${NEWKEY}" "${KEY}" "${KEYFILE}"
+}
+
+# clevis_luks_generate_key() generates a new key for use with clevis.
+clevis_luks_generate_key() {
+    local DEV="${1}"
+    [ -z "${DEV}" ] && return 1
+
+    local dump filter bits
+    dump=$(cryptsetup luksDump "${DEV}")
+    if cryptsetup isLuks --type luks1 "${DEV}"; then
+        filter="$(echo "${dump}" | sed -rn 's|MK bits:[ \t]*([0-9]+)|\1|p')"
+    elif cryptsetup isLuks --type luks2 "${DEV}"; then
+        filter="$(echo -n "${dump}" | \
+                  sed -rn 's|^\s+Key:\s+([0-9]+) bits\s*$|\1|p')"
+    else
+        return 1
+    fi
+
+    bits="$(echo -n "${filter}" | sort -n | tail -n 1)"
+    pwmake "${bits}"
+}
+
+# clevis_luks_token_id_by_slot() returns the token ID linked to a
+# particular LUKS2 key slot.
+clevis_luks_token_id_by_slot() {
+    local DEV="${1}"
+    local SLT="${2}"
+
+    [ -z "${DEV}" ] && return 1
+    [ -z "${SLT}" ] && return 1
+
+    cryptsetup isLuks --type luks1 "${DEV}" && echo && return
+    local tkn_id
+    tkn_id="$(cryptsetup luksDump "${DEV}" \
+              | grep -E -B1 "^\s+Keyslot:\s+${SLT}$" \
+              | sed -rn 's|^\s+([0-9]+): clevis|\1|p')"
+
+    printf '%s' "${tkn_id}"
+}
+
+# clevis_luks_cleanup() removes the temporary directory used to store the data
+# relevant to device backup and restore.
+clevis_luks_cleanup() {
+    [ -z "${CLEVIS_TMP_DIR}" ] && return 0
+    [ -d "${CLEVIS_TMP_DIR}" ] || return 0
+
+    if ! rm -rf "${CLEVIS_TMP_DIR}"; then
+        echo "Deleting temporary files failed!" >&2
+        echo "You may need to clean up '${CLEVIS_TMP_DIR}'" >&2
+        exit 1
+    fi
+    unset CLEVIS_TMP_DIR
+}
+
+# clevis_luks_first_free_slot() returns the first key slot that is available
+# in a LUKS device.
+clevis_luks_first_free_slot() {
+    local DEV="${1}"
+    [ -z "${DEV}" ] && return 1
+    local first_free_slot
+    if cryptsetup isLuks --type luks1 "${DEV}"; then
+        first_free_slot=$(cryptsetup luksDump "${DEV}" \
+                          | sed -rn 's|^Key Slot ([0-7]): DISABLED$|\1|p' \
+                          | head -n 1)
+    elif cryptsetup isLuks --type luks2 "${DEV}"; then
+        local used_slots slt
+        used_slots="$(clevis_luks_used_slots "${DEV}")"
+        for slt in $(seq 0 31); do
+            if ! echo "${used_slots}" | grep -q "^${slt}$"; then
+                first_free_slot="${slt}"
+                break
+            fi
+        done
+    else
+        echo "Unsupported device ${DEV}" >&2
+        return 1
+    fi
+    echo "${first_free_slot}"
+}
+
+# clevis_luks_do_bind() creates or updates a particular binding.
+clevis_luks_do_bind() {
+    local DEV="${1}"
+    local SLT="${2}"
+    local TKN_ID="${3}"
+    local PIN="${4}"
+    local CFG="${5}"
+    local YES="${6:-}"
+    local OVERWRITE="${7:-}"
+    local KEY="${8:-}"
+    local KEYFILE="${9:-}"
+
+    [ -z "${DEV}" ] && return 1
+    [ -z "${PIN}" ] && return 1
+    [ -z "${CFG}" ] && return 1
+
+
+    if ! clevis_luks_check_valid_key_or_keyfile "${DEV}" \
+                                                "${KEY}" \
+                                                "${KEYFILE}" \
+                    && ! KEY="$(clevis_luks_get_existing_key "${DEV}" \
+                                "Enter existing LUKS password: " \
+                                "recover")" || [ -z "${KEY}" ]; then
+        return 1
+    fi
+
+    local newkey jwe
+    if ! newkey="$(clevis_luks_generate_key "${DEV}")" \
+                   || [ -z "${newkey}" ]; then
+        echo "Unable to generate a new key" >&2
+        return 1
+    fi
+
+    # Encrypt the new key.
+    jwe="$(printf '%s' "${newkey}" | clevis encrypt "${PIN}" "${CFG}" ${YES})"
+
+    # We can proceed to binding, after backing up the LUKS header and
+    # metadata.
+    local CLEVIS_TMP_DIR
+
+    if ! CLEVIS_TMP_DIR="$(mktemp -d)" || [ -z "${CLEVIS_TMP_DIR}" ]; then
+        echo "Unable to create a a temporary dir for device backup/restore" >&2
+        return 1
+    fi
+    export CLEVIS_TMP_DIR
+    trap 'clevis_luks_cleanup' EXIT
+
+    # Backup LUKS header.
+    if ! clevis_luks_backup_dev "${DEV}" "${CLEVIS_TMP_DIR}"; then
+        echo "Unable to back up LUKS header from ${DEV}" >&2
+        return 1
+    fi
+
+    if [ -z "${SLT}" ] && ! SLT=$(clevis_luks_first_free_slot "${DEV}") \
+                                  || [ -z "${SLT}" ]; then
+        echo "Unable to find a free slot in ${DEV}" >&2
+        return 1
+    fi
+
+    [ -z "${TKN_ID}" ] && ! TKN_ID="$(clevis_luks_token_id_by_slot "${DEV}" \
+                                      "${SLT}")" && return 1
+
+    if ! clevis_luks_save_key_to_slot "${DEV}" "${SLT}" \
+                                      "${newkey}" "${KEY}" "${KEYFILE}" \
+                                      "${OVERWRITE}"; then
+        echo "Unable to save/update key slot; operation cancelled" >&2
+        clevis_luks_restore_dev "${CLEVIS_TMP_DIR}" || :
+        return 1
+    fi
+
+    if ! clevis_luks_save_slot "${DEV}" "${SLT}" "${tkn_id}" \
+                               "${jwe}" "${OVERWRITE}"; then
+        echo "Unable to update metadata; operation cancelled" >&2
+        clevis_luks_restore_dev "${CLEVIS_TMP_DIR}" || :
+        return 1
+    fi
+
+    clevis_luks_cleanup
+    trap - EXIT
     return 0
 }

--- a/src/luks/clevis-luks-regen
+++ b/src/luks/clevis-luks-regen
@@ -1,0 +1,93 @@
+#!/bin/bash -e
+# vim: set ts=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# Author: Radovan Sroka <rsroka@redhat.com>
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+. clevis-luks-common-functions
+
+SUMMARY="Regenerate clevis binding"
+
+if [ "${1}" = "--summary" ]; then
+    echo "${SUMMARY}"
+    exit 0
+fi
+
+usage_and_exit () {
+    exec >&2
+    echo "Usage: clevis luks regen [-q] -d DEV -s SLOT"
+    echo
+    echo "${SUMMARY}"
+    echo
+    echo "  -d DEV  The LUKS device on which to perform rebinding"
+    echo
+    echo "  -s SLT  The LUKS slot to use"
+    echo
+    echo "  -q      Do not prompt for confirmation"
+    echo
+    exit "${1}"
+}
+
+QOPT=
+while getopts ":hqd:s:" o; do
+    case "${o}" in
+    d) DEV="${OPTARG}";;
+    h) usage_and_exit 0;;
+    s) SLT="${OPTARG}";;
+    q) QOPT="-q";;
+    *) usage_and_exit 1;;
+    esac
+done
+
+if [ -z "${DEV}" ]; then
+    echo "Did not specify a device!" >&2
+    exit 1
+fi
+
+if [ -z "${SLT}" ]; then
+    echo "Did not specify a slot!" >&2
+    exit 1
+fi
+
+# Get pin and configuration.
+if ! pin_cfg="$(clevis luks list -d "${DEV}" -s "${SLT}")" \
+                || [ -z "${pin_cfg}" ]; then
+    return 1
+fi
+
+pin="$(echo "${pin_cfg}" | cut -d' ' -f2)"
+cfg="$(echo "${pin_cfg}" | cut -d' ' -f3 | sed -e "s/'//g")"
+if [ -z "${pin}" ] || [ -z "${cfg}" ]; then
+    echo "Invalid pin or configuration" >&2
+    exit 1
+fi
+
+echo "Regenerating binding (device ${DEV}, slot ${SLT}):"
+echo "Pin: ${pin}, Config: '${cfg}'"
+
+if [ -z "${QOPT}" ]; then
+    read -r -p "Do you want to proceed? [ynYN] " ans
+    [ "${ans}" != "y" ] && [ "${ans}" != "Y" ] && exit 0
+fi
+
+if ! clevis_luks_do_bind "${DEV}" "${SLT}" "" "${pin}" "${cfg}" \
+                         "-y" "overwrite"; then
+    echo "Unable to regenerate binding in ${DEV}:${SLT}" >&2
+    exit 1
+fi
+echo "Binding regenerated successfully" >&2

--- a/src/luks/clevis-luks-regen.1.adoc
+++ b/src/luks/clevis-luks-regen.1.adoc
@@ -1,0 +1,51 @@
+CLEVIS-LUKS-REGEN(1)
+=====================
+:doctype: manpage
+
+
+== NAME
+
+clevis-luks-regen - Regenerates a clevis binding
+
+== SYNOPSIS
+
+*clevis luks regen* [-q] -d DEV -s SLT
+
+== OVERVIEW
+
+The *clevis luks regen* command regenerates the clevis binding for a given slot in a LUKS device, using the same configuration of the
+existing binding. Its operation can be compared to performing *clevis luks unbind* and *clevis luks bind* for rebinding said slot and device.
+This is useful when rotating tang keys.
+
+== OPTIONS
+
+* *-d* _DEV_ :
+  The bound LUKS device
+
+* *-s* _SLT_ :
+  The slot or key slot number for rebinding. Note that it requires that such slot is currently bound by clevis.
+
+* *-q*:
+  Do not prompt for confirmation.
+
+== EXAMPLE
+
+    Let's start by using clevis luks list to see the current binding configuration in /dev/sda1:
+
+    # clevis luks list -d /dev/sda1
+    1: tang '{"url":"http://tang.server"}'
+    2: tpm2 '{"hash":"sha256","key":"ecc"}'
+
+    We see that slot 1 in /dev/sda1 has a tang binding with the following configuration:
+    '{"url":"http://tang.server"}'
+
+    Now let's do the rebinding of slot 1:
+    # clevis luks regen -d /dev/sda1 -s 1
+
+    After a successful operation, we will have the new binding using the same configuration that was already in place.
+
+== SEE ALSO
+
+link:clevis-luks-list.1.adoc[*clevis-luks-list*(1)]
+link:clevis-luks-bind.1.adoc[*clevis-luks-bind*(1)]
+link:clevis-luks-unbind.1.adoc[*clevis-luks-unbind*(1)]

--- a/src/luks/meson.build
+++ b/src/luks/meson.build
@@ -41,6 +41,8 @@ if libcryptsetup.found() and luksmeta.found() and pwmake.found()
 
   bins += join_paths(meson.current_source_dir(), 'clevis-luks-unlock')
   mans += join_paths(meson.current_source_dir(), 'clevis-luks-unlock.1')
+
+  bins += join_paths(meson.current_source_dir(), 'clevis-luks-regen')
 else
   warning('Will not install LUKS support due to missing dependencies!')
 endif

--- a/src/luks/meson.build
+++ b/src/luks/meson.build
@@ -43,6 +43,7 @@ if libcryptsetup.found() and luksmeta.found() and pwmake.found()
   mans += join_paths(meson.current_source_dir(), 'clevis-luks-unlock.1')
 
   bins += join_paths(meson.current_source_dir(), 'clevis-luks-regen')
+  mans += join_paths(meson.current_source_dir(), 'clevis-luks-regen.1')
 else
   warning('Will not install LUKS support due to missing dependencies!')
 endif

--- a/src/luks/tests/backup-restore-luks1
+++ b/src/luks/tests/backup-restore-luks1
@@ -1,0 +1,84 @@
+#!/bin/bash -ex
+# vim: set ts=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+TEST=$(basename "${0}")
+. tests-common-functions
+. clevis-luks-common-functions
+
+on_exit() {
+    [ -d "${TMP}" ] && rm -rf "${TMP}"
+}
+
+trap 'on_exit' EXIT
+
+TMP="$(mktemp -d)"
+
+ADV="${TMP}/adv.jws"
+create_tang_adv "${ADV}"
+CFG="$(printf '{"url":"foobar","adv":"%s"}' "$ADV")"
+
+# LUKS1.
+DEV="${TMP}/luks1-device"
+new_device "luks1" "${DEV}"
+
+for slt in 6 2 3; do
+    if ! clevis luks bind -f -d "${DEV}" -s "${slt}" tang "${CFG}" <<< "${DEFAULT_PASS}"; then
+        error "${TEST}: [slot: $slt] Binding is expected to succeed when given a correct (${DEFAULT_PASS}) password." >&2
+    fi
+done
+
+
+# Backup device.
+if ! clevis_luks_backup_dev "${DEV}" "${TMP}"; then
+    error "${TEST}: problem performing device backup"
+fi
+
+# Save the original device for conference later.
+BKPDEV="${TMP}"/device-for-conference
+cp "${DEV}" "${BKPDEV}"
+
+# Recreate device
+new_device "luks1" "${DEV}"
+
+used_slots=$(clevis_luks_used_slots "${DEV}")
+if [ "${used_slots}" -ne 0 ]; then
+    error "${TEST}: only used slot shold be 0 ($used_slots)"
+fi
+
+if compare_luks_header "${DEV}" "${BKPDEV}" "${TMP}"; then
+    error "${TEST}: LUKS headers should not match"
+fi
+
+if compare_luks1_metadata "${DEV}" "${BKPDEV}"; then
+    error "${TEST}: LUKS metadata should not match"
+fi
+
+# Restore from backup.
+if ! clevis_luks_restore_dev "${TMP}"; then
+    error "${TEST}: problem performing device restore"
+fi
+
+if ! compare_luks_header "${DEV}" "${BKPDEV}" "${TMP}"; then
+    error "${TEST}: LUKS headers should match"
+fi
+
+if ! compare_luks1_metadata "${DEV}" "${BKPDEV}"; then
+    error "${TEST}: metadata should match"
+fi

--- a/src/luks/tests/backup-restore-luks2
+++ b/src/luks/tests/backup-restore-luks2
@@ -1,0 +1,84 @@
+#!/bin/bash -ex
+# vim: set ts=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+TEST=$(basename "${0}")
+. tests-common-functions
+. clevis-luks-common-functions
+
+on_exit() {
+    [ -d "${TMP}" ] && rm -rf "${TMP}"
+}
+
+trap 'on_exit' EXIT
+
+TMP="$(mktemp -d)"
+
+ADV="${TMP}/adv.jws"
+create_tang_adv "${ADV}"
+CFG="$(printf '{"url":"foobar","adv":"%s"}' "$ADV")"
+
+# LUKS1.
+DEV="${TMP}/luks2-device"
+new_device "luks2" "${DEV}"
+
+for slt in 6 2 3; do
+    if ! clevis luks bind -f -d "${DEV}" -s "${slt}" tang "${CFG}" <<< "${DEFAULT_PASS}"; then
+        error "${TEST}: [slot: $slt] Binding is expected to succeed when given a correct (${DEFAULT_PASS}) password." >&2
+    fi
+done
+
+
+# Backup device.
+if ! clevis_luks_backup_dev "${DEV}" "${TMP}"; then
+    error "${TEST}: problem performing device backup"
+fi
+
+# Save the original device for conference later.
+BKPDEV="${TMP}"/device-for-conference
+cp "${DEV}" "${BKPDEV}"
+
+# Recreate device
+new_device "luks2" "${DEV}"
+
+used_slots=$(clevis_luks_used_slots "${DEV}")
+if [ "${used_slots}" -ne 0 ]; then
+    error "${TEST}: only used slot shold be 0 ($used_slots)"
+fi
+
+if compare_luks_header "${DEV}" "${BKPDEV}" "${TMP}"; then
+    error "${TEST}: LUKS headers should not match"
+fi
+
+if compare_luks2_metadata "${DEV}" "${BKPDEV}"; then
+    error "${TEST}: LUKS metadata should not match"
+fi
+
+# Restore from backup.
+if ! clevis_luks_restore_dev "${TMP}"; then
+    error "${TEST}: problem performing device restore"
+fi
+
+if ! compare_luks_header "${DEV}" "${BKPDEV}" "${TMP}"; then
+    error "${TEST}: LUKS headers should match"
+fi
+
+if ! compare_luks2_metadata "${DEV}" "${BKPDEV}"; then
+    error "${TEST}: metadata should match"
+fi

--- a/src/luks/tests/meson.build
+++ b/src/luks/tests/meson.build
@@ -90,6 +90,8 @@ if has_tang
   test('assume-yes', find_program('assume-yes'), env: env, timeout: 60)
 endif
 
+test('backup-restore-luks1', find_program('backup-restore-luks1'), env: env)
+
 # LUKS2 tests go here, and they get included if we get support for it, based
 # on the cryptsetup version.
 # Binding LUKS2 takes longer, so timeout is increased for a few tests.
@@ -110,4 +112,5 @@ if luksmeta_data.get('OLD_CRYPTSETUP') == '0'
     test('assume-yes-luks2', find_program('assume-yes-luks2'), env: env, timeout: 60)
   endif
 
+test('backup-restore-luks2', find_program('backup-restore-luks2'), env: env, timeout: 120)
 endif

--- a/src/luks/tests/meson.build
+++ b/src/luks/tests/meson.build
@@ -88,6 +88,8 @@ endif
 if has_tang
   test('unlock-tang-luks1', find_program('unlock-tang-luks1'), env: env, timeout: 90)
   test('assume-yes', find_program('assume-yes'), env: env, timeout: 60)
+  test('regen-inplace-luks1', find_program('regen-inplace-luks1'), env: env, timeout: 90)
+  test('regen-not-inplace-luks1', find_program('regen-not-inplace-luks1'), env: env, timeout: 90)
 endif
 
 test('backup-restore-luks1', find_program('backup-restore-luks1'), env: env)
@@ -110,6 +112,8 @@ if luksmeta_data.get('OLD_CRYPTSETUP') == '0'
   if has_tang
     test('unlock-tang-luks2', find_program('unlock-tang-luks2'), env: env, timeout: 120)
     test('assume-yes-luks2', find_program('assume-yes-luks2'), env: env, timeout: 60)
+    test('regen-inplace-luks2', find_program('regen-inplace-luks2'), env: env, timeout: 120)
+    test('regen-not-inplace-luks2', find_program('regen-not-inplace-luks2'), env: env, timeout: 120)
   endif
 
 test('backup-restore-luks2', find_program('backup-restore-luks2'), env: env, timeout: 120)

--- a/src/luks/tests/regen-inplace-luks1
+++ b/src/luks/tests/regen-inplace-luks1
@@ -1,0 +1,76 @@
+#!/bin/bash -x
+# vim: set ts=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+TEST="${0}"
+. tests-common-functions
+. clevis-luks-common-functions
+
+function on_exit() {
+    [ -d "${TMP}" ] || return 0
+    tang_stop "${TMP}"
+    rm -rf "${TMP}"
+}
+
+trap 'on_exit' EXIT
+
+TMP=$(mktemp -d)
+
+port=$(get_random_port)
+tang_run "${TMP}" "${port}" &
+tang_wait_until_ready "${port}"
+
+url="http://${TANG_HOST}:${port}"
+adv="${TMP}/adv"
+tang_get_adv "${port}" "${adv}"
+
+cfg=$(printf '{"url":"%s","adv":"%s"}' "$url" "$adv")
+
+# LUKS1.
+DEV="${TMP}/luks1-device"
+new_device "luks1" "${DEV}"
+
+if ! clevis luks bind -f -d "${DEV}" tang "${cfg}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: Bind should have succeeded."
+fi
+
+# Now let's remove the initial passphrase.
+if ! cryptsetup luksRemoveKey --batch-mode "${DEV}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: error removing the default password from ${DEV}."
+fi
+
+# Making sure we have a single slot enabled.
+enabled=$(clevis_luks_used_slots "${DEV}" | wc -l)
+if [ "${enabled}" -ne 1 ]; then
+    error "${TEST}: we should have only one slot enabled (${enabled})."
+fi
+
+old_key=$(clevis_luks_unlock_device_by_slot "${DEV}" "${SLT}")
+
+# Now let's try regen.
+SLT=1
+if ! clevis luks regen -q -d "${DEV}" -s "${SLT}"; then
+    error "${TEST}: clevis luks regen failed"
+fi
+
+new_key=$(clevis_luks_unlock_device_by_slot "${DEV}" "${SLT}")
+
+if [ "${old_key}" = "${new_key}" ]; then
+    error "${TEST}: the passphrases should be different"
+fi

--- a/src/luks/tests/regen-inplace-luks2
+++ b/src/luks/tests/regen-inplace-luks2
@@ -1,0 +1,76 @@
+#!/bin/bash -x
+# vim: set ts=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+TEST="${0}"
+. tests-common-functions
+. clevis-luks-common-functions
+
+function on_exit() {
+    [ -d "${TMP}" ] || return 0
+    tang_stop "${TMP}"
+    rm -rf "${TMP}"
+}
+
+trap 'on_exit' EXIT
+
+TMP=$(mktemp -d)
+
+port=$(get_random_port)
+tang_run "${TMP}" "${port}" &
+tang_wait_until_ready "${port}"
+
+url="http://${TANG_HOST}:${port}"
+adv="${TMP}/adv"
+tang_get_adv "${port}" "${adv}"
+
+cfg=$(printf '{"url":"%s","adv":"%s"}' "$url" "$adv")
+
+# LUKS2.
+DEV="${TMP}/luks2-device"
+new_device "luks2" "${DEV}"
+
+if ! clevis luks bind -f -d "${DEV}" tang "${cfg}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: Bind should have succeeded."
+fi
+
+# Now let's remove the initial passphrase.
+if ! cryptsetup luksRemoveKey --batch-mode "${DEV}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: error removing the default password from ${DEV}."
+fi
+
+# Making sure we have a single slot enabled.
+enabled=$(clevis_luks_used_slots "${DEV}" | wc -l)
+if [ "${enabled}" -ne 1 ]; then
+    error "${TEST}: we should have only one slot enabled (${enabled})."
+fi
+
+old_key=$(clevis_luks_unlock_device_by_slot "${DEV}" "${SLT}")
+
+# Now let's try regen.
+SLT=1
+if ! clevis luks regen -q -d "${DEV}" -s "${SLT}"; then
+    error "${TEST}: clevis luks regen failed"
+fi
+
+new_key=$(clevis_luks_unlock_device_by_slot "${DEV}" "${SLT}")
+
+if [ "${old_key}" = "${new_key}" ]; then
+    error "${TEST}: the passphrases should be different"
+fi

--- a/src/luks/tests/regen-not-inplace-luks1
+++ b/src/luks/tests/regen-not-inplace-luks1
@@ -1,0 +1,79 @@
+#!/bin/bash -x
+# vim: set ts=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+TEST="${0}"
+. tests-common-functions
+. clevis-luks-common-functions
+
+function on_exit() {
+    [ -d "${TMP}" ] || return 0
+    tang_stop "${TMP}"
+    rm -rf "${TMP}"
+}
+
+trap 'on_exit' EXIT
+
+export TMP=$(mktemp -d)
+
+port=$(get_random_port)
+tang_run "${TMP}" "${port}" &
+tang_wait_until_ready "${port}"
+
+url="http://${TANG_HOST}:${port}"
+adv="${TMP}/adv"
+tang_get_adv "${port}" "${adv}"
+
+cfg=$(printf '{"url":"%s","adv":"%s"}' "$url" "$adv")
+
+# LUKS1.
+DEV="${TMP}/luks1-device"
+new_device "luks1" "${DEV}"
+
+SLT=1
+if ! clevis luks bind -f -s "${SLT}" -d "${DEV}" tang "${cfg}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: Bind should have succeeded."
+fi
+
+# Now let's rotate the keys in the server and remove the old ones, so that we
+# will be unable to unlock the volume using clevis and will have to provide
+# manually a password for clevis luks regen.
+tang_new_keys "${TMP}" "rotate-keys"
+tang_remove_rotated_keys "${TMP}"
+
+# Making sure we have two slots enabled.
+enabled=$(clevis_luks_used_slots "${DEV}" | wc -l)
+if [ "${enabled}" -ne 2 ]; then
+    error "${TEST}: we should have two slots enabled (${enabled})."
+fi
+
+# Make sure we cannot unlock the device.
+if clevis_luks_unlock_device_by_slot "${DEV}"; then
+    error "${TEST}: we should NOT be able to unlock ${DEV}"
+fi
+
+# Now let's try regen.
+if ! clevis luks regen -q -d "${DEV}" -s "${SLT}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: clevis luks regen failed"
+fi
+
+# Make sure we can unlock the device.
+if ! clevis_luks_unlock_device_by_slot "${DEV}" "${SLT}"; then
+    error "${TEST}: we should be able to unlock ${DEV}"
+fi

--- a/src/luks/tests/regen-not-inplace-luks2
+++ b/src/luks/tests/regen-not-inplace-luks2
@@ -1,0 +1,79 @@
+#!/bin/bash -x
+# vim: set ts=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+TEST="${0}"
+. tests-common-functions
+. clevis-luks-common-functions
+
+function on_exit() {
+    [ -d "${TMP}" ] || return 0
+    tang_stop "${TMP}"
+    rm -rf "${TMP}"
+}
+
+trap 'on_exit' EXIT
+
+export TMP=$(mktemp -d)
+
+port=$(get_random_port)
+tang_run "${TMP}" "${port}" &
+tang_wait_until_ready "${port}"
+
+url="http://${TANG_HOST}:${port}"
+adv="${TMP}/adv"
+tang_get_adv "${port}" "${adv}"
+
+cfg=$(printf '{"url":"%s","adv":"%s"}' "$url" "$adv")
+
+# LUKS2.
+DEV="${TMP}/luks2-device"
+new_device "luks2" "${DEV}"
+
+SLT=1
+if ! clevis luks bind -f -s "${SLT}" -d "${DEV}" tang "${cfg}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: Bind should have succeeded."
+fi
+
+# Now let's rotate the keys in the server and remove the old ones, so that we
+# will be unable to unlock the volume using clevis and will have to provide
+# manually a password for clevis luks regen.
+tang_new_keys "${TMP}" "rotate-keys"
+tang_remove_rotated_keys "${TMP}"
+
+# Making sure we have two slots enabled.
+enabled=$(clevis_luks_used_slots "${DEV}" | wc -l)
+if [ "${enabled}" -ne 2 ]; then
+    error "${TEST}: we should have two slots enabled (${enabled})."
+fi
+
+# Make sure we cannot unlock the device.
+if clevis_luks_unlock_device_by_slot "${DEV}"; then
+    error "${TEST}: we should NOT be able to unlock ${DEV}"
+fi
+
+# Now let's try regen.
+if ! clevis luks regen -q -d "${DEV}" -s "${SLT}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: clevis luks regen failed"
+fi
+
+# Make sure we can unlock the device.
+if ! clevis_luks_unlock_device_by_slot "${DEV}" "${SLT}"; then
+    error "${TEST}: we should be able to unlock ${DEV}"
+fi

--- a/src/luks/tests/tests-common-functions.in
+++ b/src/luks/tests/tests-common-functions.in
@@ -121,6 +121,122 @@ pin_cfg_equal() {
     return 1
 }
 
+compare_luks_header() {
+    DEV1="${1}"
+    DEV2="${2}"
+    TMP="${3}"
+
+    cryptsetup luksHeaderBackup "${DEV1}" \
+               --header-backup-file "${TMP}"/check-header1
+    cryptsetup luksHeaderBackup "${DEV2}" \
+               --header-backup-file "${TMP}"/check-header2
+
+    local cs1 cs2
+    cs1=$(cksum "${TMP}"/check-header1 | cut -d' ' -f 1)
+    cs2=$(cksum "${TMP}"/check-header2 | cut -d' ' -f 1)
+    rm -f "${TMP}"/check-header{1,2}
+
+    if [ "${cs1}" == "${cs2}" ]; then
+        return 0
+    fi
+    return 1
+}
+
+used_luks1_metadata_slots() {
+    DEV="${1}"
+    if ! luksmeta test -d "${DEV}"; then
+        echo ""
+        return 0
+    fi
+
+    local clevis_uuid="cb6e8904-81ff-40da-a84a-07ab9ab5715e"
+    luksmeta show -d "${DEV}" \
+        | sed -rn "s|^([0-9]+)\s+active\s+${clevis_uuid}$|\1|p" \
+        | tr '\n' ' ' | sed 's/ $//'
+}
+
+used_luks2_metadata_slots() {
+    DEV="${1}"
+    cryptsetup luksDump "${DEV}" \
+        | grep -E -A1 "^\s+[0-9]+:\s+clevis$" \
+        | sed -rn 's|^\s+Keyslot:\s+([0-9]+)$|\1|p' | sort -n \
+        | tr '\n' ' ' | sed 's/ $//'
+}
+
+used_luks2_metadata_tokens() {
+    DEV="${1}"
+    cryptsetup luksDump "${DEV}" \
+        | grep -E -B1 "^\s+Keyslot:\s+[0-9]+$" \
+        | sed -rn 's|^\s+([0-9]+): clevis|\1|p' \
+        | tr '\n' ' ' | sed 's/ $//'
+}
+
+compare_luks1_metadata() {
+    DEV1="${1}"
+    DEV2="${2}"
+
+    # If both are non-initialized, metadata is the same.
+    ! luksmeta test -d "${DEV1}" && ! luksmeta test -d "${DEV2}" && return 0
+    # Otherwise, metadata differ.
+    ! luksmeta test -d "${DEV1}" && return 1
+    ! luksmeta test -d "${DEV2}" && return 1
+
+    local slt1 slt2
+    slt1=$(used_luks1_metadata_slots "${DEV1}")
+    slt2=$(used_luks1_metadata_slots "${DEV2}")
+
+    if [ "${slt1}" != "${slt2}" ]; then
+        echo "used slots did not match ($slt1) ($slt2)" >&2
+        return 1
+    fi
+
+    local slt md1 md2
+    for slt in ${slt1}; do
+        md1="$(luksmeta load -d "${DEV}" -s "${slt}")"
+        md2="$(luksmeta load -d "${DEV2}" -s "${slt}")"
+        if [ "${md1}" != "${md2}" ]; then
+            echo "metadata in slot ${slt} did not match" >&2
+            return 1
+        fi
+    done
+    return 0
+}
+
+compare_luks2_metadata() {
+    DEV1="${1}"
+    DEV2="${2}"
+
+    local slt1 slt2
+    slt1=$(used_luks2_metadata_slots "${DEV1}")
+    slt2=$(used_luks2_metadata_slots "${DEV2}")
+
+    if [ "${slt1}" != "${slt2}" ]; then
+        echo "used slots did not match ($slt1) ($slt2)" >&2
+        return 1
+    fi
+
+    local tkn1 tkn2
+    tkn1=$(used_luks2_metadata_tokens "${DEV1}")
+    tkn2=$(used_luks2_metadata_tokens "${DEV2}")
+
+    if [ "${tkn1}" != "${tkn2}" ]; then
+        echo "used tokens did not match ($tkn1) ($tkn2)" >&2
+        return 1
+    fi
+
+    local tkn md1 md2
+    for tkn in ${tkn1}; do
+        md1="$(cryptsetup token export --token-id "${tkn}" "${DEV1}")"
+        md2="$(cryptsetup token export --token-id "${tkn}" "${DEV2}")"
+        if [ "${md1}" != "${md2}" ]; then
+            echo "metadata in token ${tkn} did not match" >&2
+            return 1
+        fi
+    done
+    return 0
+}
+
+
 # Get a random port to be used with a test tang server.
 get_random_port() {
     shuf -i 1024-65535 -n 1


### PR DESCRIPTION
`clevis luks regen` can be used to rotate bindings, for example rotating
tang keys.

General usage is the following: clevis luks regen [-q] -d DEV -s SLT

The above command will regenerate the binding in DEV:SLT.

Tests and man pages added as well.