### PR TITLE
luks: add clevis luks report

### DIFF
--- a/src/luks/clevis-luks-report
+++ b/src/luks/clevis-luks-report
@@ -1,0 +1,213 @@
+#!/bin/bash -e
+# vim: set ts=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2018, 2020 Red Hat, Inc.
+# Author: Radovan Sroka <rsroka@redhat.com>
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+. clevis-luks-common-functions
+
+SUMMARY="Report tang keys' rotations"
+
+if [ "${1}" = "--summary" ]; then
+    echo "${SUMMARY}"
+    exit 0
+fi
+
+report_compare() {
+    local adv_keys="${1}"
+    local mdata_keys="${2}"
+    [ -z "${adv_keys}" ] && return 1
+    [ -z "${mdata_keys}" ] && return 1
+
+    local thp keys
+    for thp in $(printf '%s' "${mdata_keys}" | jose jwk thp --input=-); do
+        if ! printf '%s' "${adv_keys}" | jose jwk thp --input=- \
+                                              --find "${thp}" >/dev/null; then
+            keys="$(printf '%s %s' "${keys}" "${thp}")"
+        fi
+    done
+    printf '%s' "${keys}"
+}
+
+report_tang() {
+    local content="${1}"
+    [ -z "${content}" ] && return 1
+
+    local url
+    if ! url="$(jose fmt --json="${content}" --get url --unquote=-)" \
+                || [ -z "${url}" ]; then
+        echo "Invalid tang metadata; URL not found" >&2
+        return 1
+    fi
+
+    local jws
+    if ! jws="$(curl -sfg "${url}/adv")"; then
+        echo "Unable to fetch advertisement (${url}/adv)" >&2
+        return 1
+    fi
+
+    local adv_keys
+    if ! adv_keys="$(jose fmt --json="${jws}" --object --get payload \
+                     --string --b64load --object --get keys \
+                     --array --unwind --output=-)"; then
+        echo "Advertisement is malformed" >&2
+        return 1
+    fi
+
+    # Check advertisement validity.
+    local ver
+    if ! ver="$(printf '%s' "${adv_keys}" | jose jwk use --input=- \
+                                                 --required \
+                                                 --use=verify \
+                                                 --output=-)"; then
+        echo "Unable to validate advertisement" >&2
+        return 1
+    fi
+    if ! printf '%s' "${ver}" | jose jws ver --input="${jws}" --key=- \
+                                     --all; then
+        echo "Advertisement is missing signatures" >&2
+        return 1
+    fi
+    local mdata_keys
+    if ! mdata_keys="$(jose fmt --json="${content}" --get adv --output=-)" \
+                       || [ -z "${mdata_keys}" ]; then
+        echo "Keys from clevis metadata not found" >&2
+        return 1
+    fi
+    report_compare "${adv_keys}" "${mdata_keys}"
+}
+
+report_sss() {
+    local content="${1}"
+    [ -z "${content}" ] && return 1
+
+    local jwe
+    for jwe in $(jose fmt --json="${content}" --get jwe --foreach=-); do
+        jwe="$(printf '%s' "${jwe}" | sed -e 's/"//g')"
+        report_decode "${jwe}"
+    done
+}
+
+report_decode() {
+    local data64="${1}"
+    [ -z "${data64}" ] && return 1
+
+    local data
+    if ! data="$(clevis_luks_decode_jwe "${data64}")" || [ -z "${data}" ]; then
+        echo "Unable to decode metadata" >&2
+        exit 1
+    fi
+
+    local pin
+    if ! pin="$(jose fmt --json="${data}" --get clevis --get pin --unquote=-)" \
+                || [ -z "${pin}" ]; then
+        echo "Pin not found in clevis metadata" >&2
+        exit 1
+    fi
+
+    local content
+    if ! content="$(jose fmt --json="${data}" --get clevis --get "${pin}" \
+                    --output=-)" || [ -z "${content}" ]; then
+        echo "Invalid pin metadata; no content found" >&2
+        return 1
+    fi
+
+    case "${pin}" in
+    tang)
+        report_tang "${content}"
+        ;;
+    sss)
+        report_sss "${content}"
+        ;;
+    esac
+}
+
+usage_and_exit () {
+    exec >&2
+    echo "Usage: clevis luks report [-q] [-r] -d DEV -s SLOT"
+    echo
+    echo "${SUMMARY}"
+    echo
+    echo "  -d DEV  The LUKS device to check for key rotations"
+    echo
+    echo "  -s SLT  The LUKS slot to use"
+    echo
+    echo "  -q      Quiet mode; do not prompt for using 'clevis luks regen'"
+    echo
+    echo "  -r      Regenerate binding with 'clevis luks regen -q -d DEV -s SLOT'"
+    echo
+    exit "${1}"
+}
+
+while getopts "hd:s:rq" o; do
+    case "${o}" in
+    d) DEV="${OPTARG}";;
+    h) usage_and_exit 0;;
+    r) ROPT="regen";;
+    s) SLT="${OPTARG}";;
+    q) QOPT="quiet";;
+    *) usage_and_exit 1;;
+    esac
+done
+
+if [ -z "${DEV}" ]; then
+    echo "Did not specify a device!" >&2
+    exit 1
+fi
+
+if [ -z "${SLT}" ]; then
+    echo "Did not specify a slot!" >&2
+    exit 1
+fi
+
+if ! data64="$(clevis_luks_read_slot "${DEV}" "${SLT}")" \
+               || [ -z "${data64}" ]; then
+    # Error message was already displayed by clevis_luks_read_slot(),
+    # at this point.
+    exit 1
+fi
+
+if ! keys="$(report_decode "${data64}")"; then
+    echo "Unable to verify whether there are rotated keys" >&2
+    exit 1
+fi
+
+# No rotated keys.
+[ -z "${keys}" ] && exit 0
+
+echo "The following keys are not in the current advertisement and were probably rotated:"
+for k in ${keys}; do
+    printf '  %s\n' "${k}"
+done
+
+
+if [ -z "${QOPT}" ] && [ -z "${ROPT}" ]; then
+    read -r -p "Do you want to regenerate the binding with \"clevis luks regen -q -d ${DEV} -s ${SLT}\"? [ynYN] " ans
+    if [ "${ans}" = "y" ] || [ "${ans}" = "Y" ]; then
+        ROPT="regen"
+    fi
+fi
+
+if [ "${ROPT}" = "regen" ]; then
+    if ! EXE="$(command -v clevis-luks-regen)" || [ -z "${EXE}" ]; then
+        echo "Unable to find clevis luks regen" >&2
+        exit 1
+    fi
+    exec "${EXE}" -q -d "${DEV}" -s "${SLT}"
+fi
+exit 1

--- a/src/luks/clevis-luks-report.1.adoc
+++ b/src/luks/clevis-luks-report.1.adoc
@@ -1,0 +1,41 @@
+CLEVIS-LUKS-REPORT(1)
+=====================
+:doctype: manpage
+
+
+== NAME
+
+clevis-luks-report - Reports whether a pin bound to a LUKS1 or LUKS2 volume has been rotated
+
+== SYNOPSIS
+
+*clevis luks report* -d DEV -s SLT
+
+== OVERVIEW
+
+The *clevis luks report* command checks a given slot of a LUKS device and reports whether the pin bound to it
+-- if any -- has been rotated.
+
+== OPTIONS
+
+* *-d* _DEV_ :
+  The bound LUKS device
+
+* *-s* _SLT_ :
+  The slot or key slot number for the pin to be verified
+
+* *-q* :
+  Quiet mode. If used, we will not prompt whether to regenerate the binding with *clevis luks regen*
+
+* *-r* :
+  Regenerates LUKS metadata with *clevis luks regen -q -d DEV -s SLT*
+
+== EXAMPLE
+
+    Check whether the pin bound to slot 1 in /dev/sda1 has been rotated:
+
+    # clevis luks report -d /dev/sda1 -s 1
+
+== SEE ALSO
+
+link:clevis-luks-regen.1.adoc[*clevis-luks-regen*(1)]

--- a/src/luks/meson.build
+++ b/src/luks/meson.build
@@ -44,6 +44,8 @@ if libcryptsetup.found() and luksmeta.found() and pwmake.found()
 
   bins += join_paths(meson.current_source_dir(), 'clevis-luks-regen')
   mans += join_paths(meson.current_source_dir(), 'clevis-luks-regen.1')
+
+  bins += join_paths(meson.current_source_dir(), 'clevis-luks-report')
 else
   warning('Will not install LUKS support due to missing dependencies!')
 endif

--- a/src/luks/meson.build
+++ b/src/luks/meson.build
@@ -46,6 +46,7 @@ if libcryptsetup.found() and luksmeta.found() and pwmake.found()
   mans += join_paths(meson.current_source_dir(), 'clevis-luks-regen.1')
 
   bins += join_paths(meson.current_source_dir(), 'clevis-luks-report')
+  mans += join_paths(meson.current_source_dir(), 'clevis-luks-report.1')
 else
   warning('Will not install LUKS support due to missing dependencies!')
 endif

--- a/src/luks/tests/meson.build
+++ b/src/luks/tests/meson.build
@@ -90,6 +90,8 @@ if has_tang
   test('assume-yes', find_program('assume-yes'), env: env, timeout: 60)
   test('regen-inplace-luks1', find_program('regen-inplace-luks1'), env: env, timeout: 90)
   test('regen-not-inplace-luks1', find_program('regen-not-inplace-luks1'), env: env, timeout: 90)
+  test('report-tang-luks1', find_program('report-tang-luks1'), env: env, timeout: 90)
+  test('report-sss-luks1', find_program('report-sss-luks1'), env: env, timeout: 90)
 endif
 
 test('backup-restore-luks1', find_program('backup-restore-luks1'), env: env)
@@ -114,6 +116,8 @@ if luksmeta_data.get('OLD_CRYPTSETUP') == '0'
     test('assume-yes-luks2', find_program('assume-yes-luks2'), env: env, timeout: 60)
     test('regen-inplace-luks2', find_program('regen-inplace-luks2'), env: env, timeout: 120)
     test('regen-not-inplace-luks2', find_program('regen-not-inplace-luks2'), env: env, timeout: 120)
+    test('report-tang-luks2', find_program('report-tang-luks2'), env: env, timeout: 120)
+    test('report-sss-luks2', find_program('report-sss-luks2'), env: env, timeout: 120)
   endif
 
 test('backup-restore-luks2', find_program('backup-restore-luks2'), env: env, timeout: 120)

--- a/src/luks/tests/report-sss-luks1
+++ b/src/luks/tests/report-sss-luks1
@@ -1,0 +1,75 @@
+#!/bin/bash -x
+# vim: set ts=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+TEST="${0}"
+. tests-common-functions
+. clevis-luks-common-functions
+
+function on_exit() {
+    [ -d "${TMP}" ] || return 0
+    tang_stop "${TMP}"
+    rm -rf "${TMP}"
+}
+
+trap 'on_exit' EXIT
+
+TMP=$(mktemp -d)
+
+port=$(get_random_port)
+tang_run "${TMP}" "${port}" &
+tang_wait_until_ready "${port}"
+
+url="http://${TANG_HOST}:${port}"
+adv="${TMP}/adv"
+tang_get_adv "${port}" "${adv}"
+
+cfg=$(printf '{"t": 1, "pins":{"tang":[{"url":"%s"}], "sss":{"t":1,"pins":{"tang":[{"url":"%s"}]}}}}' "${url}" "${url}")
+
+# LUKS1.
+DEV="${TMP}/luks1-device"
+new_device "luks1" "${DEV}"
+
+SLT=3
+if ! clevis luks bind -y -d "${DEV}" -s "${SLT}" sss "${cfg}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: Bind should have succeeded."
+fi
+
+# Report should return 0, as no keys are rotated.
+if ! clevis luks report -q -d "${DEV}" -s "${SLT}"; then
+    error "${TEST}: report should have succeeded, since no keys were rotated"
+fi
+
+# Now let's rotate the keys.
+tang_new_keys "${TMP}" "rotate-keys"
+
+# Report should now return 1.
+if clevis luks report -q -d "${DEV}" -s "${SLT}"; then
+    error "${TEST}: report should have indicated keys were rotated"
+fi
+
+# Now let's regen the keys.
+if ! clevis luks report -q -r -d "${DEV}" -s "${SLT}"; then
+    error "${TEST}: report with regen should have succeeded"
+fi
+
+# Report should return 0 again.
+if ! clevis luks report -q -d "${DEV}" -s "${SLT}"; then
+    error "${TEST}: report should have succeeded after regen"
+fi

--- a/src/luks/tests/report-sss-luks2
+++ b/src/luks/tests/report-sss-luks2
@@ -1,0 +1,75 @@
+#!/bin/bash -x
+# vim: set ts=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+TEST="${0}"
+. tests-common-functions
+. clevis-luks-common-functions
+
+function on_exit() {
+    [ -d "${TMP}" ] || return 0
+    tang_stop "${TMP}"
+    rm -rf "${TMP}"
+}
+
+trap 'on_exit' EXIT
+
+TMP=$(mktemp -d)
+
+port=$(get_random_port)
+tang_run "${TMP}" "${port}" &
+tang_wait_until_ready "${port}"
+
+url="http://${TANG_HOST}:${port}"
+adv="${TMP}/adv"
+tang_get_adv "${port}" "${adv}"
+
+cfg=$(printf '{"t": 1, "pins":{"tang":[{"url":"%s"}], "sss":{"t":1,"pins":{"tang":[{"url":"%s"}]}}}}' "${url}" "${url}")
+
+# LUKS2.
+DEV="${TMP}/luks2-device"
+new_device "luks2" "${DEV}"
+
+SLT=3
+if ! clevis luks bind -y -d "${DEV}" -s "${SLT}" sss "${cfg}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: Bind should have succeeded."
+fi
+
+# Report should return 0, as no keys are rotated.
+if ! clevis luks report -q -d "${DEV}" -s "${SLT}"; then
+    error "${TEST}: report should have succeeded, since no keys were rotated"
+fi
+
+# Now let's rotate the keys.
+tang_new_keys "${TMP}" "rotate-keys"
+
+# Report should now return 1.
+if clevis luks report -q -d "${DEV}" -s "${SLT}"; then
+    error "${TEST}: report should have indicated keys were rotated"
+fi
+
+# Now let's regen the keys.
+if ! clevis luks report -q -r -d "${DEV}" -s "${SLT}"; then
+    error "${TEST}: report with regen should have succeeded"
+fi
+
+# Report should return 0 again.
+if ! clevis luks report -q -d "${DEV}" -s "${SLT}"; then
+    error "${TEST}: report should have succeeded after regen"
+fi

--- a/src/luks/tests/report-tang-luks1
+++ b/src/luks/tests/report-tang-luks1
@@ -1,0 +1,75 @@
+#!/bin/bash -x
+# vim: set ts=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+TEST="${0}"
+. tests-common-functions
+. clevis-luks-common-functions
+
+function on_exit() {
+    [ -d "${TMP}" ] || return 0
+    tang_stop "${TMP}"
+    rm -rf "${TMP}"
+}
+
+trap 'on_exit' EXIT
+
+TMP=$(mktemp -d)
+
+port=$(get_random_port)
+tang_run "${TMP}" "${port}" &
+tang_wait_until_ready "${port}"
+
+url="http://${TANG_HOST}:${port}"
+adv="${TMP}/adv"
+tang_get_adv "${port}" "${adv}"
+
+cfg=$(printf '{"url":"%s","adv":"%s"}' "$url" "$adv")
+
+# LUKS1.
+DEV="${TMP}/luks1-device"
+new_device "luks1" "${DEV}"
+
+SLT=3
+if ! clevis luks bind -f -d "${DEV}" -s "${SLT}" tang "${cfg}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: Bind should have succeeded."
+fi
+
+# Report should return 0, as no keys are rotated.
+if ! clevis luks report -q -d "${DEV}" -s "${SLT}"; then
+    error "${TEST}: report should have succeeded, since no keys were rotated"
+fi
+
+# Now let's rotate the keys.
+tang_new_keys "${TMP}" "rotate-keys"
+
+# Report should now return 1.
+if clevis luks report -q -d "${DEV}" -s "${SLT}"; then
+    error "${TEST}: report should have indicated keys were rotated"
+fi
+
+# Now let's regen the keys.
+if ! clevis luks report -q -r -d "${DEV}" -s "${SLT}"; then
+    error "${TEST}: report with regen should have succeeded"
+fi
+
+# Report should return 0 again.
+if ! clevis luks report -q -d "${DEV}" -s "${SLT}"; then
+    error "${TEST}: report should have succeeded after regen"
+fi

--- a/src/luks/tests/report-tang-luks2
+++ b/src/luks/tests/report-tang-luks2
@@ -1,0 +1,75 @@
+#!/bin/bash -x
+# vim: set ts=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+TEST="${0}"
+. tests-common-functions
+. clevis-luks-common-functions
+
+function on_exit() {
+    [ -d "${TMP}" ] || return 0
+    tang_stop "${TMP}"
+    rm -rf "${TMP}"
+}
+
+trap 'on_exit' EXIT
+
+TMP=$(mktemp -d)
+
+port=$(get_random_port)
+tang_run "${TMP}" "${port}" &
+tang_wait_until_ready "${port}"
+
+url="http://${TANG_HOST}:${port}"
+adv="${TMP}/adv"
+tang_get_adv "${port}" "${adv}"
+
+cfg=$(printf '{"url":"%s","adv":"%s"}' "$url" "$adv")
+
+# LUKS2.
+DEV="${TMP}/luks2-device"
+new_device "luks2" "${DEV}"
+
+SLT=3
+if ! clevis luks bind -f -d "${DEV}" -s "${SLT}" tang "${cfg}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: Bind should have succeeded."
+fi
+
+# Report should return 0, as no keys are rotated.
+if ! clevis luks report -q -d "${DEV}" -s "${SLT}"; then
+    error "${TEST}: report should have succeeded, since no keys were rotated"
+fi
+
+# Now let's rotate the keys.
+tang_new_keys "${TMP}" "rotate-keys"
+
+# Report should now return 1.
+if clevis luks report -q -d "${DEV}" -s "${SLT}"; then
+    error "${TEST}: report should have indicated keys were rotated"
+fi
+
+# Now let's regen the keys.
+if ! clevis luks report -q -r -d "${DEV}" -s "${SLT}"; then
+    error "${TEST}: report with regen should have succeeded"
+fi
+
+# Report should return 0 again.
+if ! clevis luks report -q -d "${DEV}" -s "${SLT}"; then
+    error "${TEST}: report should have succeeded after regen"
+fi


### PR DESCRIPTION
`clevis luks report` is able to identify whether the keys have been
rotated in the server, making it easier to also rotate them in the
clients with the help of `clevis luks regen`.

Usage: `clevis luks report [-r] [-q] -d DEV -s SLT`

The above command will check whether the binding in DEV:SLT had its
keys rotated. If -r is given, it will also run the following, to
rotate the binding, in case it needs rotating:

`clevis luks regen -q -d DEV -s SLT`