### PR TITLE
luks: add clevis luks edit command

### DIFF
--- a/src/luks/clevis-luks-edit
+++ b/src/luks/clevis-luks-edit
@@ -1,0 +1,180 @@
+#!/bin/bash -e
+# vim: set ts=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+. clevis-luks-common-functions
+
+SUMMARY="Edit a binding from a clevis-bound slot in a LUKS device"
+
+usage() {
+    exec >&2
+    echo "Usage: clevis luks edit [-f] -d DEV -s SLT [-c CONFIG]"
+    echo
+    echo "${SUMMARY}"
+    echo
+    echo "'clevis luks edit' uses the text editor defined in the EDITOR environment variable."
+    echo "                   If EDITOR is not defined, it will attempt to use 'vi' as default editor."
+    echo
+    echo "  -d DEV     The LUKS device to edit clevis-bound pins"
+    echo
+    echo "  -s SLOT    The slot to use when editing the clevis binding"
+    echo
+    echo "  -f         Proceed with the edit operation even if the configuration is unchanged"
+    echo
+    echo "  -c CONFIG  The updated config to use"
+    echo
+    exit 1
+}
+
+on_exit() {
+    [ -d "${CLEVIS_EDIT_TMP}" ] && rm -rf "${CLEVIS_EDIT_TMP}"
+}
+
+validate_cfg() {
+    local json="${1}"
+    [ -z "${json}" ] && return 1
+    jose fmt --json="${json}" --object 2>/dev/null
+}
+
+edit_cfg() {
+    local cfg_file="${1}"
+    local editor="${EDITOR:-vi}"
+
+    if ! command -v "${editor}" >/dev/null; then
+        echo "Editor '${editor}' not found. " >&2
+        echo "Please define a valid text editor with the EDITOR environment variable." >&2
+        exit 1
+    fi
+
+    "${editor}" "${cfg_file}" || true
+    if ! validate_cfg "${cfg_file}"; then
+        local ans=
+        while true; do
+            read -r -p \
+              "Malformed configuration. Would you like to edit again? [ynYN] " \
+            ans
+            [ "${ans}" != "y" ] && [ "${ans}" != "Y" ] && return 1
+            break
+        done
+        edit_cfg "${cfg_file}"
+    fi
+    return 0
+}
+
+if [ "${#}" -eq 1 ] && [ "${1}" = "--summary" ]; then
+    echo "${SUMMARY}"
+    exit 0
+fi
+
+CFG=
+FRC=
+while getopts ":fd:s:c:" o; do
+    case "$o" in
+    d) DEV=${OPTARG};;
+    s) SLT=${OPTARG};;
+    c) CFG=${OPTARG};;
+    f) FRC=-f;;
+    *) usage;;
+    esac
+done
+
+if [ -z "${DEV}" ]; then
+    echo "Did not specify a device!" >&2
+    usage
+fi
+
+if [ -z "${SLT}" ]; then
+    echo "Did not specify a slot!" >&2
+    usage
+fi
+
+if ! binding="$(clevis luks list -d "${DEV}" -s "${SLT}" 2>/dev/null)" \
+                || [ -z "${binding}" ]; then
+    echo "Error retrieving current configuration from ${DEV}:${SLT}" >&2
+    exit 1
+fi
+
+pin="$(echo "${binding}" | cut -d' ' -f2)"
+cfg="$(echo "${binding}" | cut -d' ' -f3 | sed -e "s/'//g")"
+
+if ! pretty_cfg="$(printf '%s' "${cfg}" | jq --monochrome-output .)" \
+                   || [ -z "${pretty_cfg}" ]; then
+    echo "Error reading the configuration from ${DEV}:${SLT}" >&2
+    exit 1
+fi
+
+if ! CLEVIS_EDIT_TMP="$(mktemp -d)" || [ -z "${CLEVIS_EDIT_TMP}" ]; then
+    echo "Creating a temporary dir for editing binding failed" >&2
+    exit 1
+fi
+
+trap 'on_exit' EXIT
+
+if [ -z "${CFG}" ]; then
+    CFG_FILE="${CLEVIS_EDIT_TMP}/cfg"
+    echo "${pretty_cfg}" > "${CFG_FILE}"
+
+    edit_cfg "${CFG_FILE}" || exit 1
+
+    if ! new_cfg="$(jq . -S < "${CFG_FILE}")" || [ -z "${new_cfg}" ]; then
+        echo "Error reading the updated config for ${DEV}:${SLT}" >&2
+        exit 1
+    fi
+else
+    if ! validate_cfg "${CFG}"; then
+        echo "Invalid configuration given as parameter with -c" >&2
+        exit 1
+    fi
+    new_cfg="$(printf '%s' "${CFG}" | jq --sort-keys --monochrome-output .)"
+fi
+
+if [ "${new_cfg}" = "$(printf '%s' "${pretty_cfg}" \
+                       | jq --sort-keys --monochrome-output .)" ] \
+        && [ -z "${FRC}" ]; then
+    echo "No changes detected; exiting" >&2
+    exit 1
+fi
+
+if ! jcfg="$(jose fmt --json="${new_cfg}" --object --output=- 2>/dev/null)" \
+             || [ -z "${jcfg}" ]; then
+    echo "Error preparing the configuration for the binding update" >&2
+    exit 1
+fi
+
+if [ -z "${CFG}" ]; then
+    printf "Pin: %s\nNew config:\n%s\n" "${pin}" "${new_cfg}"
+    while true; do
+        read -r -p \
+          "Would you like to proceed with the updated configuration? [ynYN] " \
+        ans
+        [ "${ans}" != "y" ] && [ "${ans}" != "Y" ] && exit 0
+        break
+    done
+fi
+
+# Remove temporary directory.
+rm -rf "${CLEVIS_EDIT_TMP}"
+
+echo "Updating binding..."
+if ! clevis_luks_do_bind "${DEV}" "${SLT}" "" "${pin}" "${new_cfg}" \
+                         "-y" "overwrite" 2>/dev/null; then
+    echo "Unable to update binding in ${DEV}:${SLT}. Operation cancelled." >&2
+    exit 1
+fi
+echo "Binding edited successfully" >&2

--- a/src/luks/clevis-luks-edit.1.adoc
+++ b/src/luks/clevis-luks-edit.1.adoc
@@ -1,0 +1,69 @@
+CLEVIS-LUKS-EDIT(1)
+===================
+:doctype: manpage
+
+
+== NAME
+
+clevis-luks-edit - Edit a binding from a clevis-bound slot in a LUKS device
+
+== SYNOPSIS
+
+*clevis luks edit* [-f] -d DEV -s SLT [-c CONFIG]
+
+== OVERVIEW
+
+The *clevis luks edit* command edits clevis bindings from a LUKS device.
+For example:
+
+    clevis luks edit -d /dev/sda1 -s 1
+
+== OPTIONS
+
+* *-d* _DEV_ :
+  The LUKS device to edit clevis-bound pins
+
+* *-s* _SLT_ :
+  The slot to use when editing the clevis binding
+
+* *-f* :
+  Proceed with the edit operation even if the config is unchanged
+
+* *-c* _CONFIG_ :
+  The updated config to use
+
+
+== EXAMPLES
+
+    clevis luks list -d /dev/sda1
+    1: tang '{"url":"addr"}'
+
+As we can see in the example above, */dev/sda1* has one slots bound, in this case, to a _tang_ pin.
+
+We can edit this binding by issuing the following command:
+
+    clevis luks edit -d /dev/sda1 -s 1
+
+This will open a text editor -- the one set in the $EDITOR environment variable, or _vi_, as a fallback -- with the current
+configuration of this binding to be edited. In this case, we should have the following:
+
+    {
+        "url": "addr"
+    }
+
+Once at the editor, we can edit the pin configuration. For _tang_, we could edit the _url_, for instance. After completing the change,
+save the file and exit. The updated configuration will be validated for JSON, and if there are no errors, you will be shown the
+updated configuration and prompted whether to proceed.
+
+By proceeding, the binding will be updated. There may be required to provide a valid LUKS passphrase for the device.
+
+In the second example, we will update the same device and slot, but we will be providing the updated configuration as well:
+
+    clevis luks edit -d /dev/sda1 -s 1 -c '{"url":"new-addr-here"}'
+
+In this case, the binding update will be done in non-interactive mode. Note that it may also be required to provide a LUKS
+passphrase for the device.
+
+== SEE ALSO
+
+link:clevis-luks-list.1.adoc[*clevis-luks-list*(1)],

--- a/src/luks/meson.build
+++ b/src/luks/meson.build
@@ -49,6 +49,7 @@ if libcryptsetup.found() and luksmeta.found() and pwmake.found()
   mans += join_paths(meson.current_source_dir(), 'clevis-luks-report.1')
 
   bins += join_paths(meson.current_source_dir(), 'clevis-luks-edit')
+  mans += join_paths(meson.current_source_dir(), 'clevis-luks-edit.1')
 else
   warning('Will not install LUKS support due to missing dependencies!')
 endif

--- a/src/luks/meson.build
+++ b/src/luks/meson.build
@@ -47,6 +47,8 @@ if libcryptsetup.found() and luksmeta.found() and pwmake.found()
 
   bins += join_paths(meson.current_source_dir(), 'clevis-luks-report')
   mans += join_paths(meson.current_source_dir(), 'clevis-luks-report.1')
+
+  bins += join_paths(meson.current_source_dir(), 'clevis-luks-edit')
 else
   warning('Will not install LUKS support due to missing dependencies!')
 endif

--- a/src/luks/tests/edit-tang-luks1
+++ b/src/luks/tests/edit-tang-luks1
@@ -1,0 +1,118 @@
+#!/bin/bash -ex
+# vim: set ts=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+TEST=$(basename "${0}")
+. tests-common-functions
+
+. clevis-luks-common-functions
+
+on_exit() {
+    local d
+    for d in "${TMP}" "${TMP2}"; do
+        [ ! -d "${d}" ] && continue
+        tang_stop "${d}"
+        rm -rf "${d}"
+    done
+}
+
+trap 'on_exit' EXIT
+trap 'on_exit' ERR
+
+TMP="$(mktemp -d)"
+
+port=$(get_random_port)
+tang_run "${TMP}" "${port}" &
+tang_wait_until_ready "${port}"
+
+url="http://${TANG_HOST}:${port}"
+
+cfg=$(printf '{"url":"%s"}' "${url}")
+
+# LUKS1.
+DEV="${TMP}/luks1-device"
+new_device "luks1" "${DEV}"
+
+if ! clevis luks bind -y -d "${DEV}" tang "${cfg}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: Bind should have succeeded."
+fi
+
+# Now let's try to change the config but using the same one we already have.
+if clevis luks edit -d "${DEV}" -s 1 -c "${cfg}"; then
+    error "${TEST}: edit should have failed because the config is the same."
+fi
+
+# And now, just a broken config.
+new_cfg=$(printf '{"url&:"%s"}' "${url}")
+if clevis luks edit -d "${DEV}" -s 1 -c "${new_cfg}"; then
+    error "${TEST}: edit should have failed because of invalid JSON"
+fi
+
+# Now let's have another tang instance running and change the config to use
+# the new one.
+port2=$(get_random_port)
+TMP2="$(mktemp -d)"
+tang_run "${TMP2}" "${port2}" &
+tang_wait_until_ready "${port2}"
+new_url="http://${TANG_HOST}:${port2}"
+new_cfg=$(printf '{"url":"%s"}' "${new_url}")
+
+if ! clevis luks edit -d "${DEV}" -s 1 -c "${new_cfg}"; then
+    error "${TEST}: edit should have succeeded."
+fi
+
+# Now we test an invalid server.
+new_cfg='{"url":"localhost:1"}'
+
+if clevis luks edit -d "${DEV}" -s 1 -c "${new_cfg}"; then
+    error "${TEST}: edit should not have succeeded with a wrong server."
+fi
+
+# Make sure we can still unlock the device.
+if ! clevis_luks_unlock_device "${DEV}" >/dev/null; then
+    error "${TEST}: we should have been able to unlock the device"
+fi
+
+# And now let's use sss and start with a single tang server, then add a second
+# one.
+new_device "luks1" "${DEV}"
+cfg=$(printf '{"t":1,"pins":{"tang":[{"url":"%s"}]}}' "${url}")
+if ! clevis luks bind -y -d "${DEV}" sss "${cfg}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: Bind should have succeeded."
+fi
+new_cfg=$(printf '{"t":1,"pins":{"tang":[{"url":"%s"},{"url":"%s"}]}}' \
+          "${url}" "${new_url}")
+
+if ! clevis luks edit -d "${DEV}" -s 1 -c "${new_cfg}"; then
+    error "${TEST}: edit should have succeeded and added a new tang server"
+fi
+
+# Now let's change the threshold to 2.
+new_cfg=$(printf '{"t":2,"pins":{"tang":[{"url":"%s"},{"url":"%s"}]}}' \
+          "${url}" "${new_url}")
+
+if ! clevis luks edit -d "${DEV}" -s 1 -c "${new_cfg}"; then
+    error "${TEST}: edit should have succeeded and added a new tang server"
+fi
+
+# And finally, let's try a broken config, with a wrong threshold.
+new_cfg=$(printf '{"t":3,"pins":{"tang":[{"url":"%s"},{"url":"%s"}]}}' \
+          "${url}" "${new_url}")
+if clevis luks edit -d "${DEV}" -s 1 -c "${new_cfg}"; then
+    error "${TEST}: edit should have failed because threshold > number of servers"
+fi

--- a/src/luks/tests/edit-tang-luks2
+++ b/src/luks/tests/edit-tang-luks2
@@ -1,0 +1,118 @@
+#!/bin/bash -ex
+# vim: set ts=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+TEST=$(basename "${0}")
+. tests-common-functions
+
+. clevis-luks-common-functions
+
+on_exit() {
+    local d
+    for d in "${TMP}" "${TMP2}"; do
+        [ ! -d "${d}" ] && continue
+        tang_stop "${d}"
+        rm -rf "${d}"
+    done
+}
+
+trap 'on_exit' EXIT
+trap 'on_exit' ERR
+
+TMP="$(mktemp -d)"
+
+port=$(get_random_port)
+tang_run "${TMP}" "${port}" &
+tang_wait_until_ready "${port}"
+
+url="http://${TANG_HOST}:${port}"
+
+cfg=$(printf '{"url":"%s"}' "${url}")
+
+# LUKS2.
+DEV="${TMP}/luks2-device"
+new_device "luks2" "${DEV}"
+
+if ! clevis luks bind -y -d "${DEV}" tang "${cfg}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: Bind should have succeeded."
+fi
+
+# Now let's try to change the config but using the same one we already have.
+if clevis luks edit -d "${DEV}" -s 1 -c "${cfg}"; then
+    error "${TEST}: edit should have failed because the config is the same."
+fi
+
+# And now, just a broken config.
+new_cfg=$(printf '{"url&:"%s"}' "${url}")
+if clevis luks edit -d "${DEV}" -s 1 -c "${new_cfg}"; then
+    error "${TEST}: edit should have failed because of invalid JSON"
+fi
+
+# Now let's have another tang instance running and change the config to use
+# the new one.
+port2=$(get_random_port)
+TMP2="$(mktemp -d)"
+tang_run "${TMP2}" "${port2}" &
+tang_wait_until_ready "${port2}"
+new_url="http://${TANG_HOST}:${port2}"
+new_cfg=$(printf '{"url":"%s"}' "${new_url}")
+
+if ! clevis luks edit -d "${DEV}" -s 1 -c "${new_cfg}"; then
+    error "${TEST}: edit should have succeeded."
+fi
+
+# Now we test an invalid server.
+new_cfg='{"url":"localhost:1"}'
+
+if clevis luks edit -d "${DEV}" -s 1 -c "${new_cfg}"; then
+    error "${TEST}: edit should not have succeeded with a wrong server."
+fi
+
+# Make sure we can still unlock the device.
+if ! clevis_luks_unlock_device "${DEV}" >/dev/null; then
+    error "${TEST}: we should have been able to unlock the device"
+fi
+
+# And now let's use sss and start with a single tang server, then add a second
+# one.
+new_device "luks2" "${DEV}"
+cfg=$(printf '{"t":1,"pins":{"tang":[{"url":"%s"}]}}' "${url}")
+if ! clevis luks bind -y -d "${DEV}" sss "${cfg}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: Bind should have succeeded."
+fi
+new_cfg=$(printf '{"t":1,"pins":{"tang":[{"url":"%s"},{"url":"%s"}]}}' \
+          "${url}" "${new_url}")
+
+if ! clevis luks edit -d "${DEV}" -s 1 -c "${new_cfg}"; then
+    error "${TEST}: edit should have succeeded and added a new tang server"
+fi
+
+# Now let's change the threshold to 2.
+new_cfg=$(printf '{"t":2,"pins":{"tang":[{"url":"%s"},{"url":"%s"}]}}' \
+          "${url}" "${new_url}")
+
+if ! clevis luks edit -d "${DEV}" -s 1 -c "${new_cfg}"; then
+    error "${TEST}: edit should have succeeded and added a new tang server"
+fi
+
+# And finally, let's try a broken config, with a wrong threshold.
+new_cfg=$(printf '{"t":3,"pins":{"tang":[{"url":"%s"},{"url":"%s"}]}}' \
+          "${url}" "${new_url}")
+if clevis luks edit -d "${DEV}" -s 1 -c "${new_cfg}"; then
+    error "${TEST}: edit should have failed because threshold > number of servers"
+fi

--- a/src/luks/tests/meson.build
+++ b/src/luks/tests/meson.build
@@ -92,6 +92,7 @@ if has_tang
   test('regen-not-inplace-luks1', find_program('regen-not-inplace-luks1'), env: env, timeout: 90)
   test('report-tang-luks1', find_program('report-tang-luks1'), env: env, timeout: 90)
   test('report-sss-luks1', find_program('report-sss-luks1'), env: env, timeout: 90)
+  test('edit-tang-luks1', find_program('edit-tang-luks1'), env: env, timeout: 150)
 endif
 
 test('backup-restore-luks1', find_program('backup-restore-luks1'), env: env)
@@ -118,6 +119,7 @@ if luksmeta_data.get('OLD_CRYPTSETUP') == '0'
     test('regen-not-inplace-luks2', find_program('regen-not-inplace-luks2'), env: env, timeout: 120)
     test('report-tang-luks2', find_program('report-tang-luks2'), env: env, timeout: 120)
     test('report-sss-luks2', find_program('report-sss-luks2'), env: env, timeout: 120)
+    test('edit-tang-luks2', find_program('edit-tang-luks2'), env: env, timeout: 210)
   endif
 
 test('backup-restore-luks2', find_program('backup-restore-luks2'), env: env, timeout: 120)


### PR DESCRIPTION
`clevis luks edit` can be used to edit an existing binding, e.g., with
tang pins, one is able to edit and modify the URL address -- other pins
allow changing different attributes.

General usage is the following: `clevis luks edit -d DEV -s SLT`

The above command will edit the binding in DEV:SLT.

Tests and man page added as well.