### PR TITLE
dracut: add rd.neednet for hostonly-cmdline and tang bindings present

### DIFF
--- a/src/luks/clevis-luks-common-functions
+++ b/src/luks/clevis-luks-common-functions
@@ -386,6 +386,7 @@ clevis_is_luks_device_by_uuid_open() {
 # clevis_devices_to_unlock() returns a list of devices to be unlocked, as per
 # the info from crypttab.
 clevis_devices_to_unlock() {
+    local list_open_devices="${1:-}"
     [ ! -r /etc/crypttab ] && return 1
 
     local dev clevis_devices crypt_device dev_uuid bindings
@@ -408,10 +409,12 @@ clevis_devices_to_unlock() {
             continue
         fi
 
-        # Check if this device is already open.
-        dev_uuid="$(cryptsetup luksUUID "${dev}")"
-        if clevis_is_luks_device_by_uuid_open "${dev_uuid}"; then
-            continue
+        if [ -z "${list_open_devices}" ]; then
+            # Check if this device is already open.
+            dev_uuid="$(cryptsetup luksUUID "${dev}")"
+            if clevis_is_luks_device_by_uuid_open "${dev_uuid}"; then
+                continue
+            fi
         fi
 
         clevis_devices="${clevis_devices} ${dev}"

--- a/src/luks/systemd/dracut/clevis-pin-tang/module-setup.sh.in
+++ b/src/luks/systemd/dracut/clevis-pin-tang/module-setup.sh.in
@@ -23,7 +23,22 @@ depends() {
     return 0
 }
 
+have_tang_bindings() {
+    . clevis-luks-common-functions
+    local dev
+    for dev in $(clevis_devices_to_unlock "list-open-devices"); do
+        if clevis luks list -d "${dev}" | grep -q tang; then
+            return 0
+        fi
+    done
+    return 1
+}
+
 install() {
+    if [ "${hostonly_cmdline}" = "yes" ] && have_tang_bindings; then
+        echo "rd.neednet=1" > "${initdir}/etc/cmdline.d/99clevis-pin-tang.conf"
+    fi
+
     inst_multiple \
 	clevis-decrypt-tang \
 	curl


### PR DESCRIPTION
Following c52caeb4 (dracut: drop rd.neednet=1 injection), we do not
automatically inject rd.neednet=1 to dracut's cmdline anymore, to
better support generic initrds.

However, when building host-specific initrds and specifying the
--hostonly-cmdline switch we will now add rd.neednet=1 *if* there
are any tang bindings in the devices listed in crypttab.