### PR TITLE
Move tang tests to src/pins/tang/tests

### DIFF
--- a/.github/workflows/install-dependencies
+++ b/.github/workflows/install-dependencies
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-COMMON="meson curl git make file bzip2 jose tang cryptsetup jq ${CC}"
+COMMON="meson curl git make file bzip2 jose tang cryptsetup jq socat ${CC}"
 
 case "${DISTRO}" in
 debian:*|ubuntu:*)
@@ -33,7 +33,7 @@ fedora:*)
     printf 'max_parallel_downloads=10\nfastestmirror=1\n' >> /etc/dnf/dnf.conf
     dnf -y clean all
     dnf -y --setopt=deltarpm=0 update
-    dnf -y install dnf-utils jq
+    dnf -y install dnf-utils jq socat
     dnf -y builddep clevis
     ;;
 

--- a/src/luks/tests/assume-yes
+++ b/src/luks/tests/assume-yes
@@ -33,11 +33,10 @@ trap 'on_exit' ERR
 
 TMP="$(mktemp -d)"
 
-port=$(get_random_port)
-tang_run "${TMP}" "${port}" &
-tang_wait_until_ready "${port}"
+port=$(tang_new_random_port)
+tang_run "${TMP}" "${port}"
 
-url="http://${TANG_HOST}:${port}"
+url="http://localhost:${port}"
 cfg=$(printf '{"url":"%s"}' "$url")
 
 test_tang() {

--- a/src/luks/tests/assume-yes-luks2
+++ b/src/luks/tests/assume-yes-luks2
@@ -33,11 +33,10 @@ trap 'on_exit' ERR
 
 TMP="$(mktemp -d)"
 
-port=$(get_random_port)
-tang_run "${TMP}" "${port}" &
-tang_wait_until_ready "${port}"
+port=$(tang_new_random_port)
+tang_run "${TMP}" "${port}"
 
-url="http://${TANG_HOST}:${port}"
+url="http://localhost:${port}"
 cfg=$(printf '{"url":"%s"}' "$url")
 
 # LUKS2.

--- a/src/luks/tests/backup-restore-luks1
+++ b/src/luks/tests/backup-restore-luks1
@@ -31,7 +31,7 @@ trap 'on_exit' EXIT
 TMP="$(mktemp -d)"
 
 ADV="${TMP}/adv.jws"
-create_tang_adv "${ADV}"
+tang_create_adv "${TMP}" "${ADV}"
 CFG="$(printf '{"url":"foobar","adv":"%s"}' "$ADV")"
 
 # LUKS1.

--- a/src/luks/tests/backup-restore-luks2
+++ b/src/luks/tests/backup-restore-luks2
@@ -31,7 +31,7 @@ trap 'on_exit' EXIT
 TMP="$(mktemp -d)"
 
 ADV="${TMP}/adv.jws"
-create_tang_adv "${ADV}"
+tang_create_adv "${TMP}" "${ADV}"
 CFG="$(printf '{"url":"foobar","adv":"%s"}' "$ADV")"
 
 # LUKS1.

--- a/src/luks/tests/bind-already-used-luksmeta-slot
+++ b/src/luks/tests/bind-already-used-luksmeta-slot
@@ -31,7 +31,7 @@ trap 'exit' ERR
 TMP="$(mktemp -d)"
 
 ADV="${TMP}/adv.jws"
-create_tang_adv "${ADV}"
+tang_create_adv "${TMP}" "${ADV}"
 CFG="$(printf '{"url":"foobar","adv":"%s"}' "$ADV")"
 
 # LUKS1.

--- a/src/luks/tests/bind-key-file-non-interactive-luks1
+++ b/src/luks/tests/bind-key-file-non-interactive-luks1
@@ -31,7 +31,7 @@ trap 'exit' ERR
 TMP="$(mktemp -d)"
 
 ADV="${TMP}/adv.jws"
-create_tang_adv "${ADV}"
+tang_create_adv "${TMP}" "${ADV}"
 CFG="$(printf '{"url":"foobar","adv":"%s"}' "$ADV")"
 UUID="cb6e8904-81ff-40da-a84a-07ab9ab5715e"
 KEYFILE="${TMP}/key"

--- a/src/luks/tests/bind-luks1
+++ b/src/luks/tests/bind-luks1
@@ -31,7 +31,7 @@ trap 'exit' ERR
 TMP="$(mktemp -d)"
 
 ADV="${TMP}/adv.jws"
-create_tang_adv "${ADV}"
+tang_create_adv "${TMP}" "${ADV}"
 CFG="$(printf '{"url":"foobar","adv":"%s"}' "$ADV")"
 
 # LUKS1.

--- a/src/luks/tests/bind-luks2
+++ b/src/luks/tests/bind-luks2
@@ -35,7 +35,7 @@ fi
 TMP="$(mktemp -d)"
 
 ADV="${TMP}/adv.jws"
-create_tang_adv "${ADV}"
+tang_create_adv "${TMP}" "${ADV}"
 CFG="$(printf '{"url":"foobar","adv":"%s"}' "$ADV")"
 
 # LUKS2.

--- a/src/luks/tests/bind-pass-with-newline-keyfile-luks1
+++ b/src/luks/tests/bind-pass-with-newline-keyfile-luks1
@@ -31,7 +31,7 @@ trap 'exit' ERR
 TMP="$(mktemp -d)"
 
 ADV="${TMP}/adv.jws"
-create_tang_adv "${ADV}"
+tang_create_adv "${TMP}" "${ADV}"
 CFG="$(printf '{"url":"foobar","adv":"%s"}' "$ADV")"
 
 # LUKS1.

--- a/src/luks/tests/bind-pass-with-newline-luks1
+++ b/src/luks/tests/bind-pass-with-newline-luks1
@@ -31,7 +31,7 @@ trap 'exit' ERR
 TMP="$(mktemp -d)"
 
 ADV="${TMP}/adv.jws"
-create_tang_adv "${ADV}"
+tang_create_adv "${TMP}" "${ADV}"
 CFG="$(printf '{"url":"foobar","adv":"%s"}' "$ADV")"
 
 # LUKS1.

--- a/src/luks/tests/bind-wrong-pass-luks1
+++ b/src/luks/tests/bind-wrong-pass-luks1
@@ -31,7 +31,7 @@ trap 'exit' ERR
 TMP="$(mktemp -d)"
 
 ADV="${TMP}/adv.jws"
-create_tang_adv "${ADV}"
+tang_create_adv "${TMP}" "${ADV}"
 CFG="$(printf '{"url":"foobar","adv":"%s"}' "$ADV")"
 
 # LUKS1.

--- a/src/luks/tests/bind-wrong-pass-luks2
+++ b/src/luks/tests/bind-wrong-pass-luks2
@@ -35,7 +35,7 @@ fi
 TMP="$(mktemp -d)"
 
 ADV="${TMP}/adv.jws"
-create_tang_adv "${ADV}"
+tang_create_adv "${TMP}" "${ADV}"
 CFG="$(printf '{"url":"foobar","adv":"%s"}' "$ADV")"
 
 # LUKS2.

--- a/src/luks/tests/edit-tang-luks1
+++ b/src/luks/tests/edit-tang-luks1
@@ -36,11 +36,10 @@ trap 'on_exit' ERR
 
 TMP="$(mktemp -d)"
 
-port=$(get_random_port)
-tang_run "${TMP}" "${port}" &
-tang_wait_until_ready "${port}"
+port=$(tang_new_random_port)
+tang_run "${TMP}" "${port}"
 
-url="http://${TANG_HOST}:${port}"
+url="http://localhost:${port}"
 
 cfg=$(printf '{"url":"%s"}' "${url}")
 
@@ -65,11 +64,10 @@ fi
 
 # Now let's have another tang instance running and change the config to use
 # the new one.
-port2=$(get_random_port)
+port2=$(tang_new_random_port)
 TMP2="$(mktemp -d)"
-tang_run "${TMP2}" "${port2}" &
-tang_wait_until_ready "${port2}"
-new_url="http://${TANG_HOST}:${port2}"
+tang_run "${TMP2}" "${port2}"
+new_url="http://localhost:${port2}"
 new_cfg=$(printf '{"url":"%s"}' "${new_url}")
 
 if ! clevis luks edit -d "${DEV}" -s 1 -c "${new_cfg}"; then

--- a/src/luks/tests/edit-tang-luks2
+++ b/src/luks/tests/edit-tang-luks2
@@ -36,11 +36,10 @@ trap 'on_exit' ERR
 
 TMP="$(mktemp -d)"
 
-port=$(get_random_port)
-tang_run "${TMP}" "${port}" &
-tang_wait_until_ready "${port}"
+port=$(tang_new_random_port)
+tang_run "${TMP}" "${port}"
 
-url="http://${TANG_HOST}:${port}"
+url="http://localhost:${port}"
 
 cfg=$(printf '{"url":"%s"}' "${url}")
 
@@ -65,11 +64,10 @@ fi
 
 # Now let's have another tang instance running and change the config to use
 # the new one.
-port2=$(get_random_port)
+port2=$(tang_new_random_port)
 TMP2="$(mktemp -d)"
-tang_run "${TMP2}" "${port2}" &
-tang_wait_until_ready "${port2}"
-new_url="http://${TANG_HOST}:${port2}"
+tang_run "${TMP2}" "${port2}"
+new_url="http://localhost:${port2}"
 new_cfg=$(printf '{"url":"%s"}' "${new_url}")
 
 if ! clevis luks edit -d "${DEV}" -s 1 -c "${new_cfg}"; then

--- a/src/luks/tests/list-recursive-luks1
+++ b/src/luks/tests/list-recursive-luks1
@@ -31,7 +31,7 @@ trap 'exit' ERR
 TMP="$(mktemp -d)"
 
 ADV="${TMP}/adv.jws"
-create_tang_adv "${ADV}"
+tang_create_adv "${TMP}" "${ADV}"
 PIN="sss"
 CFG=$(printf '
 {

--- a/src/luks/tests/list-recursive-luks2
+++ b/src/luks/tests/list-recursive-luks2
@@ -31,7 +31,7 @@ trap 'exit' ERR
 TMP="$(mktemp -d)"
 
 ADV="${TMP}/adv.jws"
-create_tang_adv "${ADV}"
+tang_create_adv "${TMP}" "${ADV}"
 PIN="sss"
 CFG=$(printf '
 {

--- a/src/luks/tests/list-sss-tang-luks1
+++ b/src/luks/tests/list-sss-tang-luks1
@@ -31,7 +31,7 @@ trap 'exit' ERR
 TMP="$(mktemp -d)"
 
 ADV="${TMP}/adv.jws"
-create_tang_adv "${ADV}"
+tang_create_adv "${TMP}" "${ADV}"
 PIN="sss"
 CFG=$(printf '
 {

--- a/src/luks/tests/list-sss-tang-luks2
+++ b/src/luks/tests/list-sss-tang-luks2
@@ -31,7 +31,7 @@ trap 'exit' ERR
 TMP="$(mktemp -d)"
 
 ADV="${TMP}/adv.jws"
-create_tang_adv "${ADV}"
+tang_create_adv "${TMP}" "${ADV}"
 PIN="sss"
 CFG=$(printf '
 {

--- a/src/luks/tests/list-tang-luks1
+++ b/src/luks/tests/list-tang-luks1
@@ -31,7 +31,7 @@ trap 'exit' ERR
 TMP="$(mktemp -d)"
 
 ADV="${TMP}/adv.jws"
-create_tang_adv "${ADV}"
+tang_create_adv "${TMP}" "${ADV}"
 PIN="tang"
 CFG=$(printf '{"url": "ADDR","adv": "%s"}' "${ADV}")
 

--- a/src/luks/tests/list-tang-luks2
+++ b/src/luks/tests/list-tang-luks2
@@ -31,7 +31,7 @@ trap 'exit' ERR
 TMP="$(mktemp -d)"
 
 ADV="${TMP}/adv.jws"
-create_tang_adv "${ADV}"
+tang_create_adv "${TMP}" "${ADV}"
 PIN="tang"
 CFG=$(printf '{"url": "ADDR","adv": "%s"}' "${ADV}")
 

--- a/src/luks/tests/meson.build
+++ b/src/luks/tests/meson.build
@@ -1,39 +1,6 @@
 # We use jq for comparing the pin config in the clevis luks list tests.
 jq = find_program('jq', required: false)
 
-# We use systemd-socket-activate for running test tang servers.
-actv = find_program(
-  'systemd-socket-activate',
-  'systemd-activate',
-  join_paths('/', 'usr', 'lib', 'systemd', 'systemd-activate'),
-  required: false
-)
-
-kgen = find_program(
-  join_paths(libexecdir, 'tangd-keygen'),
-  join_paths(get_option('prefix'), get_option('libdir'), 'tangd-keygen'),
-  join_paths(get_option('prefix'), get_option('libexecdir'), 'tangd-keygen'),
-  join_paths('/', 'usr', get_option('libdir'), 'tangd-keygen'),
-  join_paths('/', 'usr', get_option('libexecdir'), 'tangd-keygen'),
-  required: false
-)
-updt = find_program(
-  join_paths(libexecdir, 'tangd-update'),
-  join_paths(get_option('prefix'), get_option('libdir'), 'tangd-update'),
-  join_paths(get_option('prefix'), get_option('libexecdir'), 'tangd-update'),
-  join_paths('/', 'usr', get_option('libdir'), 'tangd-update'),
-  join_paths('/', 'usr', get_option('libexecdir'), 'tangd-update'),
-  required: false
-)
-tang = find_program(
-  join_paths(libexecdir, 'tangd'),
-  join_paths(get_option('prefix'), get_option('libdir'), 'tangd'),
-  join_paths(get_option('prefix'), get_option('libexecdir'), 'tangd'),
-  join_paths('/', 'usr', get_option('libdir'), 'tangd'),
-  join_paths('/', 'usr', get_option('libexecdir'), 'tangd'),
-  required: false
-)
-
 common_functions = configure_file(input: 'tests-common-functions.in',
   output: 'tests-common-functions',
   configuration: luksmeta_data,
@@ -53,18 +20,10 @@ env.prepend('PATH',
   join_paths(meson.build_root(), 'src', 'luks'),
   join_paths(meson.build_root(), 'src', 'pins', 'sss'),
   join_paths(meson.build_root(), 'src', 'pins', 'tang'),
+  join_paths(meson.build_root(), 'src', 'pins', 'tang', 'tests'),
   join_paths(meson.build_root(), 'src', 'pins', 'tpm2'),
   separator: ':'
 )
-
-has_tang = false
-if actv.found() and kgen.found() and updt.found() and tang.found()
-  has_tang = true
-  env.set('SD_ACTIVATE', actv.path())
-  env.set('TANGD_KEYGEN', kgen.path())
-  env.set('TANGD_UPDATE', updt.path())
-  env.set('TANGD', tang.path())
-endif
 
 test('bind-wrong-pass-luks1', find_program('bind-wrong-pass-luks1'), env: env)
 test('bind-luks1', find_program('bind-luks1'), env: env)
@@ -85,15 +44,13 @@ else
   warning('Will not run "clevis luks list" tests due to missing jq dependency')
 endif
 
-if has_tang
-  test('unlock-tang-luks1', find_program('unlock-tang-luks1'), env: env, timeout: 90)
-  test('assume-yes', find_program('assume-yes'), env: env, timeout: 60)
-  test('regen-inplace-luks1', find_program('regen-inplace-luks1'), env: env, timeout: 90)
-  test('regen-not-inplace-luks1', find_program('regen-not-inplace-luks1'), env: env, timeout: 90)
-  test('report-tang-luks1', find_program('report-tang-luks1'), env: env, timeout: 90)
-  test('report-sss-luks1', find_program('report-sss-luks1'), env: env, timeout: 90)
-  test('edit-tang-luks1', find_program('edit-tang-luks1'), env: env, timeout: 150)
-endif
+test('unlock-tang-luks1', find_program('unlock-tang-luks1'), env: env, timeout: 90)
+test('assume-yes', find_program('assume-yes'), env: env, timeout: 60)
+test('regen-inplace-luks1', find_program('regen-inplace-luks1'), env: env, timeout: 90)
+test('regen-not-inplace-luks1', find_program('regen-not-inplace-luks1'), env: env, timeout: 90)
+test('report-tang-luks1', find_program('report-tang-luks1'), env: env, timeout: 90)
+test('report-sss-luks1', find_program('report-sss-luks1'), env: env, timeout: 90)
+test('edit-tang-luks1', find_program('edit-tang-luks1'), env: env, timeout: 150)
 
 test('backup-restore-luks1', find_program('backup-restore-luks1'), env: env, timeout: 60)
 
@@ -112,15 +69,13 @@ if luksmeta_data.get('OLD_CRYPTSETUP') == '0'
     test('list-sss-tang-luks2', find_program('list-sss-tang-luks2'), env: env, timeout: 60)
   endif
 
-  if has_tang
-    test('unlock-tang-luks2', find_program('unlock-tang-luks2'), env: env, timeout: 120)
-    test('assume-yes-luks2', find_program('assume-yes-luks2'), env: env, timeout: 90)
-    test('regen-inplace-luks2', find_program('regen-inplace-luks2'), env: env, timeout: 120)
-    test('regen-not-inplace-luks2', find_program('regen-not-inplace-luks2'), env: env, timeout: 120)
-    test('report-tang-luks2', find_program('report-tang-luks2'), env: env, timeout: 120)
-    test('report-sss-luks2', find_program('report-sss-luks2'), env: env, timeout: 120)
-    test('edit-tang-luks2', find_program('edit-tang-luks2'), env: env, timeout: 210)
-  endif
+  test('unlock-tang-luks2', find_program('unlock-tang-luks2'), env: env, timeout: 120)
+  test('assume-yes-luks2', find_program('assume-yes-luks2'), env: env, timeout: 90)
+  test('regen-inplace-luks2', find_program('regen-inplace-luks2'), env: env, timeout: 120)
+  test('regen-not-inplace-luks2', find_program('regen-not-inplace-luks2'), env: env, timeout: 120)
+  test('report-tang-luks2', find_program('report-tang-luks2'), env: env, timeout: 120)
+  test('report-sss-luks2', find_program('report-sss-luks2'), env: env, timeout: 120)
+  test('edit-tang-luks2', find_program('edit-tang-luks2'), env: env, timeout: 210)
 
-test('backup-restore-luks2', find_program('backup-restore-luks2'), env: env, timeout: 120)
+  test('backup-restore-luks2', find_program('backup-restore-luks2'), env: env, timeout: 120)
 endif

--- a/src/luks/tests/regen-inplace-luks1
+++ b/src/luks/tests/regen-inplace-luks1
@@ -32,11 +32,10 @@ trap 'on_exit' EXIT
 
 TMP=$(mktemp -d)
 
-port=$(get_random_port)
-tang_run "${TMP}" "${port}" &
-tang_wait_until_ready "${port}"
+port=$(tang_new_random_port)
+tang_run "${TMP}" "${port}"
 
-url="http://${TANG_HOST}:${port}"
+url="http://localhost:${port}"
 adv="${TMP}/adv"
 tang_get_adv "${port}" "${adv}"
 

--- a/src/luks/tests/regen-inplace-luks2
+++ b/src/luks/tests/regen-inplace-luks2
@@ -32,11 +32,10 @@ trap 'on_exit' EXIT
 
 TMP=$(mktemp -d)
 
-port=$(get_random_port)
-tang_run "${TMP}" "${port}" &
-tang_wait_until_ready "${port}"
+port=$(tang_new_random_port)
+tang_run "${TMP}" "${port}"
 
-url="http://${TANG_HOST}:${port}"
+url="http://localhost:${port}"
 adv="${TMP}/adv"
 tang_get_adv "${port}" "${adv}"
 

--- a/src/luks/tests/regen-not-inplace-luks1
+++ b/src/luks/tests/regen-not-inplace-luks1
@@ -32,11 +32,10 @@ trap 'on_exit' EXIT
 
 export TMP=$(mktemp -d)
 
-port=$(get_random_port)
-tang_run "${TMP}" "${port}" &
-tang_wait_until_ready "${port}"
+port=$(tang_new_random_port)
+tang_run "${TMP}" "${port}"
 
-url="http://${TANG_HOST}:${port}"
+url="http://localhost:${port}"
 adv="${TMP}/adv"
 tang_get_adv "${port}" "${adv}"
 

--- a/src/luks/tests/regen-not-inplace-luks2
+++ b/src/luks/tests/regen-not-inplace-luks2
@@ -32,11 +32,10 @@ trap 'on_exit' EXIT
 
 export TMP=$(mktemp -d)
 
-port=$(get_random_port)
-tang_run "${TMP}" "${port}" &
-tang_wait_until_ready "${port}"
+port=$(tang_new_random_port)
+tang_run "${TMP}" "${port}"
 
-url="http://${TANG_HOST}:${port}"
+url="http://localhost:${port}"
 adv="${TMP}/adv"
 tang_get_adv "${port}" "${adv}"
 

--- a/src/luks/tests/report-sss-luks1
+++ b/src/luks/tests/report-sss-luks1
@@ -32,11 +32,10 @@ trap 'on_exit' EXIT
 
 TMP=$(mktemp -d)
 
-port=$(get_random_port)
-tang_run "${TMP}" "${port}" &
-tang_wait_until_ready "${port}"
+port=$(tang_new_random_port)
+tang_run "${TMP}" "${port}"
 
-url="http://${TANG_HOST}:${port}"
+url="http://localhost:${port}"
 adv="${TMP}/adv"
 tang_get_adv "${port}" "${adv}"
 

--- a/src/luks/tests/report-sss-luks2
+++ b/src/luks/tests/report-sss-luks2
@@ -32,11 +32,10 @@ trap 'on_exit' EXIT
 
 TMP=$(mktemp -d)
 
-port=$(get_random_port)
-tang_run "${TMP}" "${port}" &
-tang_wait_until_ready "${port}"
+port=$(tang_new_random_port)
+tang_run "${TMP}" "${port}"
 
-url="http://${TANG_HOST}:${port}"
+url="http://localhost:${port}"
 adv="${TMP}/adv"
 tang_get_adv "${port}" "${adv}"
 

--- a/src/luks/tests/report-tang-luks1
+++ b/src/luks/tests/report-tang-luks1
@@ -32,11 +32,10 @@ trap 'on_exit' EXIT
 
 TMP=$(mktemp -d)
 
-port=$(get_random_port)
-tang_run "${TMP}" "${port}" &
-tang_wait_until_ready "${port}"
+port=$(tang_new_random_port)
+tang_run "${TMP}" "${port}"
 
-url="http://${TANG_HOST}:${port}"
+url="http://localhost:${port}"
 adv="${TMP}/adv"
 tang_get_adv "${port}" "${adv}"
 

--- a/src/luks/tests/report-tang-luks2
+++ b/src/luks/tests/report-tang-luks2
@@ -32,11 +32,10 @@ trap 'on_exit' EXIT
 
 TMP=$(mktemp -d)
 
-port=$(get_random_port)
-tang_run "${TMP}" "${port}" &
-tang_wait_until_ready "${port}"
+port=$(tang_new_random_port)
+tang_run "${TMP}" "${port}"
 
-url="http://${TANG_HOST}:${port}"
+url="http://localhost:${port}"
 adv="${TMP}/adv"
 tang_get_adv "${port}" "${adv}"
 

--- a/src/luks/tests/tests-common-functions.in
+++ b/src/luks/tests/tests-common-functions.in
@@ -18,6 +18,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+. tang-common-test-functions
+
 error() {
     echo "${1}" >&2
     exit 1
@@ -32,20 +34,6 @@ skip_test() {
 # Support is determined at build time.
 luks2_supported() {
     return @OLD_CRYPTSETUP@
-}
-
-# Creates a tang adv to be used in the test.
-create_tang_adv() {
-    local adv="${1}"
-    local SIG="${TMP}/sig.jwk"
-    jose jwk gen -i '{"alg":"ES512"}' > "${SIG}"
-
-    local EXC="${TMP}/exc.jwk"
-    jose jwk gen -i '{"alg":"ECMR"}' > "${EXC}"
-
-    local TEMPLATE='{"protected":{"cty":"jwk-set+json"}}'
-    jose jwk pub -s -i "${SIG}" -i "${EXC}" \
-        | jose jws sig -I- -s "${TEMPLATE}" -k "${SIG}" -o "${adv}"
 }
 
 # Creates a new LUKS1 or LUKS2 device to be used.
@@ -236,132 +224,4 @@ compare_luks2_metadata() {
     return 0
 }
 
-
-# Get a random port to be used with a test tang server.
-get_random_port() {
-    shuf -i 1024-65535 -n 1
-}
-
-# Removes tang rotated keys from the test server.
-tang_remove_rotated_keys() {
-    local basedir="${1}"
-
-    if [ -z "${basedir}" ]; then
-        echo "Please pass a valid base directory for tang"
-        return 1
-    fi
-
-    [ -z "${TANGD_UPDATE}" ] && skip_test "WARNING: TANGD_UPDATE is not defined."
-
-    local db="${basedir}/db"
-    local cache="${basedir}/cache"
-    mkdir -p "${db}"
-    mkdir -p "${cache}"
-
-    pushd "${db}"
-        find . -name ".*.jwk" -exec rm -f {} \;
-    popd
-
-    "${TANGD_UPDATE}" "${db}" "${cache}"
-    return 0
-}
-
-# Creates new keys for the test tang server.
-tang_new_keys() {
-    local basedir="${1}"
-    local rotate="${2}"
-
-    if [ -z "${basedir}" ]; then
-        echo "Please pass a valid base directory for tang"
-        return 1
-    fi
-
-    [ -z "${TANGD_KEYGEN}" ] && skip_test "WARNING: TANGD_KEYGEN is not defined."
-    [ -z "${TANGD_UPDATE}" ] && skip_test "WARNING: TANGD_UPDATE is not defined."
-
-    local db="${basedir}/db"
-    local cache="${basedir}/cache"
-    mkdir -p "${db}"
-
-    if [ -n "${rotate}" ]; then
-        pushd "${db}"
-            local k
-            k=$(find . -name "*.jwk" | wc -l)
-            if [ "${k}" -gt 0 ]; then
-                for k in *.jwk; do
-                    mv -f -- "${k}" ".${k}"
-                done
-            fi
-        popd
-    fi
-
-    "${TANGD_KEYGEN}" "${db}"
-    "${TANGD_UPDATE}" "${db}" "${cache}"
-
-    return 0
-}
-
-# Start a test tang server.
-tang_run() {
-    local basedir="${1}"
-    local port="${2}"
-
-    if [ -z "${basedir}" ]; then
-        echo "Please pass a valid base directory for tang" >&2
-        return 1
-    fi
-
-    if [ -z "${port}" ]; then
-        echo "Please pass a valid port for tang" >&2
-        return 1
-    fi
-
-    if ! tang_new_keys "${basedir}"; then
-        echo "Error creating new keys for tang server" >&2
-        return 1
-    fi
-
-    local KEYS="${basedir}/cache"
-    local inetd='--inetd'
-    [ "${SD_ACTIVATE##*/}" = "systemd-activate" ] && inetd=
-
-    local pid pidfile
-    pidfile="${basedir}/tang.pid"
-
-    "${SD_ACTIVATE}" ${inetd} -l "${TANG_HOST}":"${port}" \
-            -a "${TANGD}" "${KEYS}" &
-    pid=$!
-    echo "${pid}" > "${pidfile}"
-}
-
-# Stop tang server.
-tang_stop() {
-    local basedir="${1}"
-    local pidfile="${basedir}/tang.pid"
-    [ -f "${pidfile}" ] || return 0
-
-    local pid
-    pid=$(<"${pidfile}")
-    kill "${pid}"
-}
-
-# Wait for the tang server to be operational.
-tang_wait_until_ready() {
-   local port="${1}"
-   while ! curl --output /dev/null --silent --fail \
-                http://"${TANG_HOST}":"${port}"/adv; do
-       sleep 0.1
-       echo -n . >&2
-   done
-}
-
-# Get tang advertisement.
-tang_get_adv() {
-    local port="${1}"
-    local adv="${2}"
-
-    curl -o "${adv}" http://"${TANG_HOST}":"${port}"/adv
-}
-
-export TANG_HOST=127.0.0.1
 export DEFAULT_PASS='just-some-test-password-here'

--- a/src/luks/tests/unbind-luks1
+++ b/src/luks/tests/unbind-luks1
@@ -30,7 +30,7 @@ trap 'exit' ERR
 
 TMP="$(mktemp -d)"
 ADV="${TMP}/adv.jws"
-create_tang_adv "${ADV}"
+tang_create_adv "${TMP}" "${ADV}"
 CFG="$(printf '{"url":"foobar","adv":"%s"}' "$ADV")"
 
 # LUKS1.

--- a/src/luks/tests/unbind-luks2
+++ b/src/luks/tests/unbind-luks2
@@ -34,7 +34,7 @@ fi
 
 TMP="$(mktemp -d)"
 ADV="${TMP}/adv.jws"
-create_tang_adv "${ADV}"
+tang_create_adv "${TMP}" "${ADV}"
 CFG="$(printf '{"url":"foobar","adv":"%s"}' "$ADV")"
 
 # LUKS2.

--- a/src/luks/tests/unlock-tang-luks1
+++ b/src/luks/tests/unlock-tang-luks1
@@ -33,11 +33,10 @@ trap 'on_exit' ERR
 
 TMP="$(mktemp -d)"
 
-port=$(get_random_port)
-tang_run "${TMP}" "${port}" &
-tang_wait_until_ready "${port}"
+port=$(tang_new_random_port)
+tang_run "${TMP}" "${port}"
 
-url="http://${TANG_HOST}:${port}"
+url="http://localhost:${port}"
 adv="${TMP}/adv"
 tang_get_adv "${port}" "${adv}"
 

--- a/src/luks/tests/unlock-tang-luks2
+++ b/src/luks/tests/unlock-tang-luks2
@@ -33,11 +33,10 @@ trap 'on_exit' ERR
 
 TMP="$(mktemp -d)"
 
-port=$(get_random_port)
-tang_run "${TMP}" "${port}" &
-tang_wait_until_ready "${port}"
+port=$(tang_new_random_port)
+tang_run "${TMP}" "${port}"
 
-url="http://${TANG_HOST}:${port}"
+url="http://localhost:${port}"
 adv="${TMP}/adv"
 tang_get_adv "${port}" "${adv}"
 

--- a/src/pins/tang/meson.build
+++ b/src/pins/tang/meson.build
@@ -1,33 +1,3 @@
-actv = find_program(
-  'systemd-socket-activate',
-  'systemd-activate',
-  join_paths('/', 'usr', 'lib', 'systemd', 'systemd-activate'),
-  required: false
-)
-kgen = find_program(
-  join_paths(libexecdir, 'tangd-keygen'),
-  join_paths(get_option('prefix'), get_option('libdir'), 'tangd-keygen'),
-  join_paths(get_option('prefix'), get_option('libexecdir'), 'tangd-keygen'),
-  join_paths('/', 'usr', get_option('libdir'), 'tangd-keygen'),
-  join_paths('/', 'usr', get_option('libexecdir'), 'tangd-keygen'),
-  required: false
-)
-updt = find_program(
-  join_paths(libexecdir, 'tangd-update'),
-  join_paths(get_option('prefix'), get_option('libdir'), 'tangd-update'),
-  join_paths(get_option('prefix'), get_option('libexecdir'), 'tangd-update'),
-  join_paths('/', 'usr', get_option('libdir'), 'tangd-update'),
-  join_paths('/', 'usr', get_option('libexecdir'), 'tangd-update'),
-  required: false
-)
-tang = find_program(
-  join_paths(libexecdir, 'tangd'),
-  join_paths(get_option('prefix'), get_option('libdir'), 'tangd'),
-  join_paths(get_option('prefix'), get_option('libexecdir'), 'tangd'),
-  join_paths('/', 'usr', get_option('libdir'), 'tangd'),
-  join_paths('/', 'usr', get_option('libexecdir'), 'tangd'),
-  required: false
-)
 curl = find_program('curl', required: false)
 
 if curl.found()
@@ -35,22 +5,7 @@ if curl.found()
   bins += join_paths(meson.current_source_dir(), 'clevis-encrypt-tang')
   mans += join_paths(meson.current_source_dir(), 'clevis-encrypt-tang.1')
 
-  if actv.found() and kgen.found() and updt.found() and tang.found()
-    env = environment()
-    env.set('SD_ACTIVATE', actv.path())
-    env.set('TANGD_KEYGEN', kgen.path())
-    env.set('TANGD_UPDATE', updt.path())
-    env.set('TANGD', tang.path())
-    env.prepend('PATH',
-      join_paths(meson.source_root(), 'src'),
-      meson.current_source_dir(),
-      separator: ':'
-    )
-
-    test('pin-tang', find_program('./pin-tang'), env: env)
-  else
-    warning('Will not run tang tests due to missing dependencies!')
-  endif
+  subdir('tests')
 else
   warning('Will not install tang pin due to missing dependencies!')
 endif

--- a/src/pins/tang/tests/meson.build
+++ b/src/pins/tang/tests/meson.build
@@ -1,0 +1,64 @@
+kgen = find_program(
+  join_paths(libexecdir, 'tangd-keygen'),
+  join_paths(get_option('prefix'), get_option('libdir'), 'tangd-keygen'),
+  join_paths(get_option('prefix'), get_option('libexecdir'), 'tangd-keygen'),
+  join_paths('/', 'usr', get_option('libdir'), 'tangd-keygen'),
+  join_paths('/', 'usr', get_option('libexecdir'), 'tangd-keygen'),
+  required: false
+)
+updt = find_program(
+  join_paths(libexecdir, 'tangd-update'),
+  join_paths(get_option('prefix'), get_option('libdir'), 'tangd-update'),
+  join_paths(get_option('prefix'), get_option('libexecdir'), 'tangd-update'),
+  join_paths('/', 'usr', get_option('libdir'), 'tangd-update'),
+  join_paths('/', 'usr', get_option('libexecdir'), 'tangd-update'),
+  required: false
+)
+tang = find_program(
+  join_paths(libexecdir, 'tangd'),
+  join_paths(get_option('prefix'), get_option('libdir'), 'tangd'),
+  join_paths(get_option('prefix'), get_option('libexecdir'), 'tangd'),
+  join_paths('/', 'usr', get_option('libdir'), 'tangd'),
+  join_paths('/', 'usr', get_option('libexecdir'), 'tangd'),
+  required: false
+)
+
+socat = find_program('socat', required: false)
+
+tang_data = configuration_data()
+tang_data.set('SOCAT', '')
+tang_data.set('TANGD_KEYGEN', '')
+tang_data.set('TANGD_UPDATE', '')
+tang_data.set('TANGD', '')
+
+if socat.found()
+  tang_data.set('SOCAT', socat.path())
+endif
+
+if kgen.found()
+  tang_data.set('TANGD_KEYGEN', kgen.path())
+endif
+
+if tang.found()
+  tang_data.set('TANGD', tang.path())
+endif
+
+if updt.found()
+  tang_data.set('TANGD_UPDATE', updt.path())
+endif
+
+tang_tests_common = configure_file(
+  input: 'tang-common-test-functions.in',
+  output: 'tang-common-test-functions',
+  configuration: tang_data
+)
+
+env = environment()
+env.prepend('PATH',
+  join_paths(meson.source_root(), 'src'),
+  join_paths(meson.source_root(), 'src', 'pins', 'tang'),
+  join_paths(meson.build_root(), 'src', 'pins', 'tang', 'tests'),
+  separator: ':'
+)
+
+test('pin-tang', find_program('pin-tang'), env: env)

--- a/src/pins/tang/tests/pin-tang
+++ b/src/pins/tang/tests/pin-tang
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash -xe
 # vim: set tabstop=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
 #
 # Copyright (c) 2016 Red Hat, Inc.
@@ -18,34 +18,26 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-function on_exit() {
-    if [ "$PID" ]; then kill $PID; wait $PID || true; fi
+. tang-common-test-functions
+
+on_exit() {
+    exit_status=$?
+    tang_stop "${TMP}"
     [ -d "$TMP" ] && rm -rf "$TMP"
+    exit "${exit_status}"
 }
 
 trap 'on_exit' EXIT
-trap 'exit' ERR
 
 TMP="$(mktemp -d)"
-mkdir -p "$TMP"/db
-mkdir -p "$TMP"/cache
 
-# Generate the server keys
-"${TANGD_KEYGEN}" "$TMP"/db sig exc
-"${TANGD_UPDATE}" "$TMP"/db "$TMP"/cache
+port=$(tang_new_random_port)
 
-# Start the server
-port="$(shuf -i 1024-65536 -n 1)"
-
-inetd='--inetd'
-[ "${SD_ACTIVATE##*/}" = "systemd-activate" ] && inetd=
-
-"$SD_ACTIVATE" $inetd -l 127.0.0.1:"$port" -a "$TANGD" "$TMP"/cache &
-PID=$!
-sleep 0.25
+tang_run "${TMP}" "${port}" sig exc
 
 thp="$(jose jwk thp -i "$TMP/db/sig.jwk")"
-adv="$TMP/cache/default.jws"
+adv="${TMP}/adv.jws"
+tang_get_adv "${port}" "${adv}"
 url="http://localhost:${port}"
 
 cfg="$(printf '{"url":"%s","adv":"%s"}' "$url" "$adv")"
@@ -58,8 +50,6 @@ enc="$(echo -n "hi" | clevis encrypt tang "$cfg")"
 dec="$(echo -n "$enc" | clevis decrypt)"
 test "$dec" == "hi"
 
-kill -9 $PID
-! wait $PID
-unset PID
+tang_stop "${TMP}"
 
 ! echo "$enc" | clevis decrypt

--- a/src/pins/tang/tests/tang-common-test-functions.in
+++ b/src/pins/tang/tests/tang-common-test-functions.in
@@ -1,0 +1,188 @@
+#!/bin/bash -ex
+# vim: set ts=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+SOCAT="@SOCAT@"
+TANGD_KEYGEN="@TANGD_KEYGEN@"
+TANGD_UPDATE="@TANGD_UPDATE@"
+TANGD="@TANGD@"
+
+tang_error() {
+    echo "${1}" >&2
+    exit 1
+}
+
+tang_skip() {
+    echo "${1}" >&2
+    exit 77
+}
+
+tang_sanity_check() {
+    [ -n "${SOCAT}" ] && [ -n "${TANGD_KEYGEN}" ] && \
+        [ -n "${TANGD}" ] && return 0
+    tang_skip "tang is not enabled/supported. Check if you have met all the requirements"
+}
+
+# Creates a tang adv to be used in the tests.
+tang_create_adv() {
+    local basedir="${1}"
+    local adv="${2:-/dev/stdout}"
+
+    local SIG="${basedir}/sig.jwk"
+    jose jwk gen --input='{"alg":"ES512"}' --output="${SIG}"
+
+    local EXC="${basedir}/exc.jwk"
+    jose jwk gen --input='{"alg":"ECMR"}' --output="${EXC}"
+
+    local TEMPLATE='{"protected":{"cty":"jwk-set+json"}}'
+    jose jwk pub --set --input="${SIG}" --input="${EXC}" \
+        | jose jws sig --detached=- --signature="${TEMPLATE}" \
+                       --key="${SIG}" --output="${adv}"
+}
+
+# Get a random port to be used with a test tang server.
+tang_new_random_port() {
+    tang_sanity_check
+    shuf -i 1024-65535 -n 1
+}
+
+# Removes tang rotated keys from the test server.
+tang_remove_rotated_keys() {
+    tang_sanity_check
+    local basedir="${1}"
+
+    [ -z "${basedir}" ] && \
+        tang_error "tang_remove_rotated_keys: please specify 'basedir'"
+
+    local db="${basedir}/db"
+
+    mkdir -p "${db}"
+    pushd "${db}"
+        find . -name ".*.jwk" -exec rm -f {} \;
+    popd
+
+    [ -n "${TANGD_UPDATE}" ] && "${TANGD_UPDATE}" "${db}" "${basedir}/cache"
+    return 0
+}
+
+# Creates new keys for the test tang server.
+tang_new_keys() {
+    tang_sanity_check
+    local basedir="${1}"
+    local rotate="${2:-}"
+    local sig_name="${3:-}"
+    local exc_name="${4:-}"
+
+    [ -z "${basedir}" ] && tang_error "tang_new_keys: please specify 'basedir'"
+
+    local db="${basedir}/db"
+    mkdir -p "${db}"
+
+    if [ -n "${rotate}" ]; then
+        pushd "${db}"
+            local k
+            k=$(find . -name "*.jwk" | wc -l)
+            if [ "${k}" -gt 0 ]; then
+                for k in *.jwk; do
+                    mv -f -- "${k}" ".${k}"
+                done
+            fi
+        popd
+    fi
+
+    "${TANGD_KEYGEN}" "${db}" ${sig_name} ${exc_name}
+    [ -n "${TANGD_UPDATE}" ] && "${TANGD_UPDATE}" "${db}" "${basedir}/cache"
+
+    return 0
+}
+
+# Wait for the tang server to be operational.
+tang_wait_until_ready() {
+    tang_sanity_check
+    local port="${1}"
+
+    [ -z "${port}" ] && \
+        tang_error "tang_wait_until_ready: please specify 'port'"
+
+    local max_timeout_in_s=5
+    local start elapsed
+    start="${SECONDS}"
+    while ! curl --output /dev/null --silent --fail \
+                "http://localhost:${port}/adv"; do
+        elapsed=$((SECONDS - start))
+        if [ "${elapsed}" -gt "${max_timeout_in_s}" ]; then
+            tang_error "Timeout (${max_timeout_in_s}s) waiting for tang server"
+        fi
+        sleep 0.1
+        echo -n . >&2
+    done
+}
+
+# Start a test tang server.
+tang_run() {
+    tang_sanity_check
+    local basedir="${1}"
+    local port="${2}"
+    local sig_name="${3:-}"
+    local exc_name="${4:-}"
+
+    [ -z "${basedir}" ] && tang_error "tang_run: please specify 'basedir'"
+    [ -z "${port}" ] && tang_error "tang_run: please specify 'port'"
+
+    if ! tang_new_keys "${basedir}" "" "${sig_name}" "${exc_name}"; then
+        tang_error "Error creating new keys for tang server"
+    fi
+
+    local KEYS="${basedir}/cache"
+    [ -z "${TANGD_UPDATE}" ] && KEYS="${basedir}/db"
+
+    local pid pidfile
+    pidfile="${basedir}/tang.pid"
+
+    "${SOCAT}" -v -v TCP-LISTEN:${port},reuseaddr,fork \
+               exec:"${TANGD} ${KEYS}" &
+
+    pid=$!
+    echo "${pid}" > "${pidfile}"
+    tang_wait_until_ready "${port}"
+}
+
+# Stop tang server.
+tang_stop() {
+    tang_sanity_check
+    local basedir="${1}"
+    [ -z "${basedir}" ] && tang_error "tang_stop: please specify 'basedir'"
+
+    local pidfile="${basedir}/tang.pid"
+    [ -f "${pidfile}" ] || return 0
+
+    local pid
+    pid=$(<"${pidfile}")
+    kill -9 "${pid}" 2>/dev/null || :
+}
+
+# Get tang advertisement.
+tang_get_adv() {
+    tang_sanity_check
+    local port="${1}"
+    local adv="${2:-/dev/stdout}"
+
+    [ -z "${port}" ] && tang_error "tang_get_adv: please specify 'port'"
+    curl -L -o "${adv}" "http://localhost:${port}/adv"
+}


### PR DESCRIPTION
So that we can organize them better.
We also have now some tang test functions that can be reused in other tests, such as the ones in src/luks/tests.