### PR TITLE
tang: default JWK thumbprint is now SHA-256 / deprecate SHA-1

### DIFF
--- a/src/luks/clevis-luks-common-functions.in
+++ b/src/luks/clevis-luks-common-functions.in
@@ -323,7 +323,7 @@ clevis_luks_unlock_device_by_slot() {
         return 1
     fi
 
-    if ! passphrase="$(printf '%s' "${jwe}" | clevis decrypt 2>/dev/null)" \
+    if ! passphrase="$(printf '%s' "${jwe}" | clevis decrypt)" \
                        || [ -z "${passphrase}" ]; then
         return 1
     fi

--- a/src/pins/tang/clevis-decrypt-tang
+++ b/src/pins/tang/clevis-decrypt-tang
@@ -50,10 +50,36 @@ if ! kid="$(jose fmt -j- -Og kid -Su- <<< "$jhd")"; then
     exit 1
 fi
 
-if ! srv="$(jose fmt -j- -Og clevis -g tang -g adv -Oo- <<< "$jhd" \
-        | jose jwk thp -i- -f "$kid")"; then
+# Tang advertisement validation.
+if ! keys="$(jose fmt -j- -Og clevis -g tang -g adv -Oo- <<< "${jhd}")"; then
     echo "JWE missing required 'clevis.tang.adv' header parameter!" >&2
     exit 1
+fi
+
+# Check if the thumbprint we have in `kid' is in the advertised keys.
+CLEVIS_DEFAULT_THP_ALG=S256       # SHA-256.
+CLEVIS_DEFAULT_THP_LEN=43         # Length of SHA-256 thumbprint.
+CLEVIS_ALTERNATIVE_THP_ALGS=S1    # SHA-1.
+
+# Issue a warning if we are using a hash that has a shorter length than the
+# default one.
+if [ "${#kid}" -lt "${CLEVIS_DEFAULT_THP_LEN}" ]; then
+    echo "WARNING: tang using a deprecated hash for the JWK thumbprints" >&2
+fi
+
+if ! srv="$(jose jwk thp -i- -f "${kid}" -a "${CLEVIS_DEFAULT_THP_ALG}" \
+            <<< "${keys}")"; then
+    # `kid' thumprint not in the advertised keys, but it's possible it was
+    # generated using a different algorithm than the default one.
+    # Let us try the alternative supported algorithms to make sure `kid'
+    # really is not part of the advertised keys.
+    for alg in ${CLEVIS_ALTERNATIVE_THP_ALGS}; do
+        srv="$(jose jwk thp -i- -f "$kid" -a "${alg}" <<< "${keys}")" && break
+    done
+    if [ -z "${srv}" ]; then
+        echo "JWE header validation of 'clevis.tang.adv' failed: key thumbprint does not match" >&2
+        exit 1
+    fi
 fi
 
 if ! url="$(jose fmt -j- -Og clevis -g tang -g url -Su- <<< "$jhd")"; then

--- a/src/pins/tang/clevis-encrypt-tang
+++ b/src/pins/tang/clevis-encrypt-tang
@@ -64,6 +64,9 @@ if ! cfg="$(jose fmt -j- -Oo- <<< "$1" 2>/dev/null)"; then
     exit 1
 fi
 
+CLEVIS_DEFAULT_THP_ALG=S256       # SHA-256.
+CLEVIS_ALTERNATIVE_THP_ALGS=S1    # SHA-1.
+
 trust=
 [ -n "${2}" ] && [ "${2}" == "-y" ] && trust=yes
 
@@ -112,15 +115,25 @@ if [ -z "${trust}" ]; then
     if [ -z "$thp" ]; then
         echo "The advertisement contains the following signing keys:" >&2
         echo >&2
-        jose jwk thp -i- <<< "$ver" >&2
+        jose jwk thp -i- -a "${CLEVIS_DEFAULT_THP_ALG}" <<< "$ver" >&2
         echo >&2
         read -r -p "Do you wish to trust these keys? [ynYN] " ans < /dev/tty
         [[ "$ans" =~ ^[yY]$ ]] || exit 1
 
     elif [ "$thp" != "any" ] && \
-        ! jose jwk thp -i- -f "$thp" -o /dev/null <<< "$ver"; then
-        echo "Trusted JWK '$thp' did not sign the advertisement!" >&2
-        exit 1
+        ! jose jwk thp -i- -f "${thp}" -a "${CLEVIS_DEFAULT_THP_ALG}" \
+          <<< "$ver"; then
+        # Thumbprint of trusted JWK did not match the signature. Let's check
+        # alternative thumbprints generated with clevis supported hash
+        # algorithms to be sure.
+        for alg in ${CLEVIS_ALTERNATIVE_THP_ALGS}; do
+            srv="$(jose jwk thp -i- -f "${thp}" -a "${alg}" <<< "${ver}")" \
+                   && break
+        done
+        if [ -z "${srv}" ]; then
+            echo "Trusted JWK '$thp' did not sign the advertisement!" >&2
+            exit 1
+        fi
     fi
 fi
 
@@ -139,7 +152,7 @@ fi
 
 jwk="$(jose fmt -j- -Od key_ops -o- <<< "$jwk")"
 jwk="$(jose fmt -j- -Od alg -o- <<< "$jwk")"
-kid="$(jose jwk thp -i- <<< "$jwk")"
+kid="$(jose jwk thp -i- -a "${CLEVIS_DEFAULT_THP_ALG}"  <<< "$jwk")"
 jwe='{"protected":{"alg":"ECDH-ES","enc":"A256GCM","clevis":{"pin":"tang","tang":{}}}}'
 jwe="$(jose fmt -j "$jwe" -g protected -q "$kid" -s kid -UUo-)"
 jwe="$(jose fmt -j "$jwe" -g protected -g clevis -g tang -q "$url" -s url -UUUUo-)"

--- a/src/pins/tang/tests/default-thp-alg
+++ b/src/pins/tang/tests/default-thp-alg
@@ -1,0 +1,110 @@
+#!/bin/bash
+set -exo pipefail
+# vim: set ts=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# Author: Sergio Correia <scorreia@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+. tang-common-test-functions
+
+TEST=$(basename "${0}")
+
+on_exit() {
+    exit_status=$?
+    tang_stop "${TMP}"
+    [ -d "${TMP}" ] && rm -rf "${TMP}"
+    exit "${exit_status}"
+}
+
+trap 'on_exit' EXIT
+
+TMP="$(mktemp -d)"
+
+port=$(tang_new_random_port)
+tang_run "${TMP}" "${port}"
+
+url="http://localhost:${port}"
+data="just a sample text"
+
+# Get the advertisement and extract the keys.
+adv="$(tang_get_adv "${port}")"
+
+jwks="$(jose fmt --json="${adv}" --get payload --b64load --output=-)"
+enc="$(printf '%s' "${jwks}" | jose jwk use --input=- --required \
+       --use deriveKey --output=-)"
+
+jose fmt --json="${enc}" --get keys --array \
+      || enc="$(printf '{"keys": [%s]}' "${enc}")"
+
+jwk="$(jose fmt --json="${enc}" --get keys --array --foreach=- \
+       | jose fmt --json=- --delete key_ops --delete alg --output=-)"
+
+jwe_t='{"protected":{"alg":"ECDH-ES","enc":"A256GCM","clevis":{"pin":"tang","tang":{}}}}'
+jwe_t="$(jose fmt --json="${jwe_t}" --get protected --get clevis --get tang --quote "${url}" --set url -UUUUo-)"
+jwe_t="$(printf '%s' "${jwks}" | jose fmt --json="${jwe_t}" --get protected --get clevis --get tang --json=- --set adv -UUUUo-)"
+
+# We currently support SHA-1 (legacy) and SHA-256.
+CLEVIS_SUPPORTED_THP_ALGS="S1 S256"
+# Now we will use every hash algorithm supported by jose to create a thumbprint
+# for `kid', then we do the encoding and verify clevis decrypt can decode it
+# correctly.
+for alg in ${CLEVIS_SUPPORTED_THP_ALGS}; do
+    kid="$(printf '%s' "${jwk}" | jose jwk thp -a "${alg}" --input=-)"
+    jwe="$(jose fmt --json="${jwe_t}" --get protected --quote "${kid}" -s kid -UUo-)"
+
+    encoded=$(printf '%s%s' "${jwk}" "${data}" \
+              | jose jwe enc --input="${jwe}" --key=- --detached=- --compact)
+
+    if ! decoded="$(printf '%s' "${encoded}" | clevis decrypt)"; then
+        tang_error "${TEST}: decoding is expected to work (alg = ${alg})"
+    fi
+
+    if  [ "${decoded}" != "${data}" ]; then
+        tang_error "${TEST}: tang decrypt should have succeeded decoded[${decoded}] data[${data}] (alg = ${alg})"
+    fi
+done
+
+# Now let's test encryption providing the thp in the configuration.
+for alg in ${CLEVIS_SUPPORTED_THP_ALGS}; do
+    thp="$(jose fmt --json="${adv}" -g payload -y -o- \
+           | jose jwk use -i- -r -u verify -o- \
+           | jose jwk thp -i- -a "${alg}")"
+    cfg="$(printf '{"url":"%s", "thp":"%s"}' "${url}" "${thp}")"
+    if ! echo foo | clevis encrypt tang "${cfg}" >/dev/null; then
+        tang_error "${TEST}: tang encryption should have succeeded when providing the thp (${thp}) with any supported algorithm (${alg})"
+    fi
+done
+
+# Let's also try some unsupported thp hash algorithms.
+UNSUPPORTED="S224 S384 S512" # SHA-224, SHA-384, SHA-512.
+for alg in ${UNSUPPORTED}; do
+    thp="$(jose fmt --json="${adv}" -g payload -y -o- \
+           | jose jwk use -i- -r -u verify -o- \
+           | jose jwk thp -i- -a "${alg}")"
+    cfg="$(printf '{"url":"%s", "thp":"%s"}' "${url}" "${thp}")"
+    if echo foo | clevis encrypt tang "${cfg}" >/dev/null; then
+        tang_error "${TEST}: tang encryption should have failed when providing the thp (${thp}) with an unsupported algorithm (${alg})"
+    fi
+done
+
+# Now let's try some bad values for thp.
+for thp in "" "foo" "invalid"; do
+    cfg="$(printf '{"url":"%s", "thp":"%s"}' "${url}" "${thp}")"
+    if echo foo | clevis encrypt tang "${cfg}" >/dev/null; then
+        tang_error "${TEST}: tang encryption expected to fail when providing a bad thp"
+    fi
+done

--- a/src/pins/tang/tests/meson.build
+++ b/src/pins/tang/tests/meson.build
@@ -63,3 +63,4 @@ env.prepend('PATH',
 
 test('pin-tang', find_program('pin-tang'), env: env)
 test('tang-validate-adv', find_program('tang-validate-adv'), env: env)
+test('default-thp-alg', find_program('default-thp-alg'), env: env)


### PR DESCRIPTION
During the encryption using tang, the clevis metadata stores the
thumbprint of the exchange key in the `kid' attribute. This thumbprint
uses jose default thumbprint hash algorithm -- SHA1 as of now.

When decrypting, we validate that the key with thumbprint represented by
`kid' is present in the advertisement. At this point, jose then uses its
default hash algorithm to do the checking. If jose default thumbprint
hash algorithm changes and we have a different default than what was used
to calculate `kid' at encryption time, this verification will fail, and
so does the decryption itself.

To handle a possible change in jose default thumbprint hash algorithm,
this verification was extended to try out every jose supported hash
algorithms, if the validation of `kid' fails with the default one.