### PR TITLE
systemd: drop ncat dependency

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,7 +22,6 @@ following sections describe them for the supported platforms.
 * [tang](https://github.com/latchset/tang)
 * [curl](https://github.com/curl/curl)
 * [tpm2-tools](https://github.com/tpm2-software/tpm2-tools)
-* [ncat](https://nmap.org/ncat/) (for clevis-luks-askpass)
 
 ### Fedora
 

--- a/src/luks/systemd/clevis-luks-askpass.in
+++ b/src/luks/systemd/clevis-luks-askpass.in
@@ -58,7 +58,7 @@ while true; do
         fi
 
         uuid="$(cryptsetup luksUUID "${d}")"
-        if ! printf '+%s' "${pt}" | ncat -U -u --send-only "${s}"; then
+        if ! printf '%s' "${pt}" | @SYSTEMD_REPLY_PASS@ 1 "${s}"; then
             echo "Unable to unlock ${d} (UUID=${uuid}) with recovered passphrase" >&2
             continue
         fi

--- a/src/luks/systemd/dracut/clevis/module-setup.sh.in
+++ b/src/luks/systemd/dracut/clevis/module-setup.sh.in
@@ -36,6 +36,7 @@ install() {
 
     inst_multiple \
         /etc/services \
+        @SYSTEMD_REPLY_PASS@ \
         @libexecdir@/clevis-luks-askpass \
         clevis-luks-common-functions \
         grep sed cut \
@@ -45,8 +46,7 @@ install() {
         luksmeta \
         clevis \
         mktemp \
-        jose \
-        ncat
+        jose
 
     dracut_need_initqueue
 }

--- a/src/luks/systemd/meson.build
+++ b/src/luks/systemd/meson.build
@@ -1,6 +1,15 @@
 systemd = dependency('systemd', required: false)
 
-if systemd.found()
+sd_reply_pass = find_program(
+  join_paths(get_option('prefix'), get_option('libdir'), 'systemd', 'systemd-reply-password'),
+  join_paths(get_option('prefix'), 'lib', 'systemd', 'systemd-reply-password'),
+  join_paths('/', 'usr', get_option('libdir'), 'systemd', 'systemd-reply-password'),
+  join_paths('/', 'usr', 'lib', 'systemd', 'systemd-reply-password'),
+  required: false
+)
+
+if systemd.found() and sd_reply_pass.found()
+  data.set('SYSTEMD_REPLY_PASS', sd_reply_pass.path())
   subdir('dracut')
 
   unitdir = systemd.get_pkgconfig_variable('systemdsystemunitdir')
@@ -12,8 +21,14 @@ if systemd.found()
     configuration: data,
   )
 
+  configure_file(
+    input: 'clevis-luks-askpass.in',
+    output: 'clevis-luks-askpass',
+    install_dir: libexecdir,
+    configuration: data
+  )
+
   install_data('clevis-luks-askpass.path', install_dir: unitdir)
-  install_data('clevis-luks-askpass', install_dir: libexecdir)
 else
   warning('Will not install systemd support due to missing dependencies!')
 endif


### PR DESCRIPTION
When using systemd, i.e., clevis-luks-askpass, we use ncat to send
the decrypted password to the systemd socket as per systemd's password
agents specification [1].

However, systemd itself has a utility that does exactly that,
systemd-reply-password.

In this commit we drop the ncat dependency and instead use
systemd-reply-password in clevis-luks-askpass.

Resolves: #258 

[1] https://systemd.io/PASSWORD_AGENTS/