### PR TITLE
Reuse system TPM2TOOLS_TCTI envvar if it is set

### DIFF
--- a/src/pins/tpm2/clevis-decrypt-tpm2
+++ b/src/pins/tpm2/clevis-decrypt-tpm2
@@ -142,6 +142,7 @@ if [ -n "$fail" ]; then
     echo "Creating TPM2 primary key failed!" >&2
     exit 1
 fi
+tpm2_flushcontext -t
 
 case "$TPM2TOOLS_VERSION" in
     3) tpm2_load -Q -c "$TMP"/primary.context -u "$TMP"/jwk.pub -r "$TMP"/jwk.priv \
@@ -154,6 +155,7 @@ if [ -n "$fail" ]; then
     echo "Loading jwk to TPM2 failed!" >&2
     exit 1
 fi
+tpm2_flushcontext -t
 
 case "$TPM2TOOLS_VERSION" in
     3) jwk="$(tpm2_unseal -c "$TMP"/load.context ${pcr_spec:+-L $pcr_spec})" || fail=$?;;
@@ -164,6 +166,7 @@ if [ -n "$fail" ]; then
     echo "Unsealing jwk from TPM failed!" >&2
     exit 1
 fi
+tpm2_flushcontext -t
 
 (echo -n "$jwk$hdr."; /bin/cat) | jose jwe dec -k- -i-
 exit $?

--- a/src/pins/tpm2/clevis-decrypt-tpm2
+++ b/src/pins/tpm2/clevis-decrypt-tpm2
@@ -54,26 +54,28 @@ if [[ $TPM2TOOLS_VERSION -lt 3 ]] || [[ $TPM2TOOLS_VERSION -gt 5 ]]; then
     exit 1
 fi
 
-# Old environment variables for tpm2-tools 3.0
-export TPM2TOOLS_TCTI_NAME=device
-export TPM2TOOLS_DEVICE_FILE=
-for dev in /dev/tpmrm?; do
-    [ -e "$dev" ] || continue
-    TPM2TOOLS_DEVICE_FILE="$dev"
-    break
-done
+if [ -z "$TPM2TOOLS_TCTI" ]; then
+    # Old environment variables for tpm2-tools 3.0
+    export TPM2TOOLS_TCTI_NAME=device
+    export TPM2TOOLS_DEVICE_FILE=
+    for dev in /dev/tpmrm?; do
+        [ -e "$dev" ] || continue
+        TPM2TOOLS_DEVICE_FILE="$dev"
+        break
+    done
 
-# New environment variable for tpm2-tools >= 3.1
-export TPM2TOOLS_TCTI="$TPM2TOOLS_TCTI_NAME:$TPM2TOOLS_DEVICE_FILE"
+    # New environment variable for tpm2-tools >= 3.1
+    export TPM2TOOLS_TCTI="$TPM2TOOLS_TCTI_NAME:$TPM2TOOLS_DEVICE_FILE"
 
-if [ -z "$TPM2TOOLS_DEVICE_FILE" ]; then
-    echo "A TPM2 device with the in-kernel resource manager is needed!" >&2
-    exit 1
-fi
+    if [ -z "$TPM2TOOLS_DEVICE_FILE" ]; then
+        echo "A TPM2 device with the in-kernel resource manager is needed!" >&2
+        exit 1
+    fi
 
-if ! [[ -r "$TPM2TOOLS_DEVICE_FILE" && -w "$TPM2TOOLS_DEVICE_FILE" ]]; then
-    echo "The $TPM2TOOLS_DEVICE_FILE device must be readable and writable!" >&2
-    exit 1
+    if ! [[ -r "$TPM2TOOLS_DEVICE_FILE" && -w "$TPM2TOOLS_DEVICE_FILE" ]]; then
+        echo "The $TPM2TOOLS_DEVICE_FILE device must be readable and writable!" >&2
+        exit 1
+    fi
 fi
 
 read -r -d . hdr

--- a/src/pins/tpm2/clevis-encrypt-tpm2
+++ b/src/pins/tpm2/clevis-encrypt-tpm2
@@ -160,6 +160,7 @@ if [ -n "$fail" ]; then
     echo "Creating TPM2 primary key failed!" >&2
     exit 1
 fi
+tpm2_flushcontext -t
 
 policy_options=()
 if [ -n "$pcr_ids" ]; then
@@ -173,6 +174,7 @@ if [ -n "$pcr_ids" ]; then
             echo "Creating PCR hashes file failed!" >&2
             exit 1
         fi
+        tpm2_flushcontext -t
     else
         if ! jose b64 dec -i- -O "$TMP"/pcr.digest <<< "$pcr_digest"; then
             echo "Error decoding PCR digest!" >&2
@@ -191,6 +193,7 @@ if [ -n "$pcr_ids" ]; then
         echo "create policy fail, please check the environment or parameters!"
         exit 1
     fi
+    tpm2_flushcontext -t
 
     policy_options+=(-L "$TMP/pcr.policy")
 else
@@ -208,6 +211,7 @@ if [ -n "$fail" ]; then
     echo "Creating TPM2 object for jwk failed!" >&2
     exit 1
 fi
+tpm2_flushcontext -t
 
 if ! jwk_pub="$(jose b64 enc -I "$TMP"/jwk.pub)"; then
     echo "Encoding jwk.pub in Base64 failed!" >&2

--- a/src/pins/tpm2/clevis-encrypt-tpm2
+++ b/src/pins/tpm2/clevis-encrypt-tpm2
@@ -76,26 +76,28 @@ if [[ $TPM2TOOLS_VERSION -lt 3 ]] || [[ $TPM2TOOLS_VERSION -gt 5 ]]; then
     exit 1
 fi
 
-# Old environment variables for tpm2-tools 3.0
-export TPM2TOOLS_TCTI_NAME=device
-export TPM2TOOLS_DEVICE_FILE=
-for dev in /dev/tpmrm?; do
-    [ -e "$dev" ] || continue
-    TPM2TOOLS_DEVICE_FILE="$dev"
-    break
-done
+if [ -z "$TPM2TOOLS_TCTI" ]; then
+    # Old environment variables for tpm2-tools 3.0
+    export TPM2TOOLS_TCTI_NAME=device
+    export TPM2TOOLS_DEVICE_FILE=
+    for dev in /dev/tpmrm?; do
+        [ -e "$dev" ] || continue
+        TPM2TOOLS_DEVICE_FILE="$dev"
+        break
+    done
 
-# New environment variable for tpm2-tools >= 3.1
-export TPM2TOOLS_TCTI="$TPM2TOOLS_TCTI_NAME:$TPM2TOOLS_DEVICE_FILE"
+    # New environment variable for tpm2-tools >= 3.1
+    export TPM2TOOLS_TCTI="$TPM2TOOLS_TCTI_NAME:$TPM2TOOLS_DEVICE_FILE"
 
-if [ -z "$TPM2TOOLS_DEVICE_FILE" ]; then
-    echo "A TPM2 device with the in-kernel resource manager is needed!" >&2
-    exit 1
-fi
+    if [ -z "$TPM2TOOLS_DEVICE_FILE" ]; then
+        echo "A TPM2 device with the in-kernel resource manager is needed!" >&2
+        exit 1
+    fi
 
-if ! [[ -r "$TPM2TOOLS_DEVICE_FILE" && -w "$TPM2TOOLS_DEVICE_FILE" ]]; then
-    echo "The $TPM2TOOLS_DEVICE_FILE device must be readable and writable!" >&2
-    exit 1
+    if ! [[ -r "$TPM2TOOLS_DEVICE_FILE" && -w "$TPM2TOOLS_DEVICE_FILE" ]]; then
+        echo "The $TPM2TOOLS_DEVICE_FILE device must be readable and writable!" >&2
+        exit 1
+    fi
 fi
 
 if ! cfg="$(jose fmt -j "$1" -Oo- 2>/dev/null)"; then


### PR DESCRIPTION
This is a way to customize TPM used for clevis binding/unbinding.
For example for tests against a TPM software emulator:

  TPM2TOOLS_TCTI=swtpm clevis encrypt tpm2 '{}' <<< 'hello, world'

Closes #244