### PR TITLE
Work around /dev/fd/X removal in systemd

### DIFF
--- a/src/clevis-decrypt
+++ b/src/clevis-decrypt
@@ -46,7 +46,8 @@ if ! [ -t 0 ]; then
         exit 1
     fi
 
-    exec "$cmd" < <(echo -n "$hdr."; /bin/cat)
+    (echo -n "$hdr."; /bin/cat) | "$cmd"
+    exit $?
 fi
 
 exec >&2

--- a/src/luks/clevis-luks-unlock
+++ b/src/luks/clevis-luks-unlock
@@ -65,4 +65,4 @@ if ! pt=$(clevis_luks_unlock_device "${DEV}"); then
     exit 1
 fi
 
-cryptsetup open -d- "${DEV}" "${NAME}" < <(echo -n "${pt}")
+echo -n "${pt}" | cryptsetup open -d- "${DEV}" "${NAME}"

--- a/src/pins/tang/clevis-decrypt-tang
+++ b/src/pins/tang/clevis-decrypt-tang
@@ -88,4 +88,5 @@ fi
 tmp="$(jose jwk exc -i '{"alg":"ECMR"}' -l- -r- <<< "$eph$srv")"
 rep="$(jose jwk pub -i- <<< "$rep")"
 jwk="$(jose jwk exc -l- -r- <<< "$rep$tmp")"
-exec jose jwe dec -k- -i- < <(echo -n "$jwk$hdr."; /bin/cat)
+(echo -n "$jwk$hdr."; /bin/cat) | jose jwe dec -k- -i-
+exit $?

--- a/src/pins/tpm2/clevis-decrypt-tpm2
+++ b/src/pins/tpm2/clevis-decrypt-tpm2
@@ -165,8 +165,5 @@ if [ -n "$fail" ]; then
     exit 1
 fi
 
-# The on_exit() trap will not be fired after exec, so let's clean up the temp
-# directory at this point.
-[ -d "${TMP}" ] && rm -rf "${TMP}"
-
-exec jose jwe dec -k- -i- < <(echo -n "$jwk$hdr."; /bin/cat)
+(echo -n "$jwk$hdr."; /bin/cat) | jose jwe dec -k- -i-
+exit $?


### PR DESCRIPTION
The <(command) notation in bash relies on the existence of /dev/fd/X,
these device nodes however are no longer created by udev/systemd and
therefore are not available in early userland, breaking unlocking.

Work around by re-writing the code using pipe.

systemd commit:
    https://github.com/systemd/systemd/commit/6b2229c6c60d0486

Debian bug report:
    https://bugs.debian.org/968518

Closes: #262