### PR TITLE
clevis-luks-bind: Fix error with password of spaces

### DIFF
--- a/src/luks/clevis-luks-bind
+++ b/src/luks/clevis-luks-bind
@@ -98,8 +98,8 @@ fi
 existing_key=
 keyfile=
 case "${KEY}" in
-"") read -r -s -p "Enter existing LUKS password: " existing_key; echo >&2;;
- -) read -r -s -p "" existing_key
+"") IFS= read -r -s -p "Enter existing LUKS password: " existing_key; echo >&2;;
+ -) IFS= read -r -s -p "" existing_key
     if [ "${luks_type}" = "luks1" ] && ! luksmeta test -d "${DEV}" \
                                     && [ -z "${FRC}" ]; then
         echo "Cannot use '-k-' without '-f' or '-y' unless already initialized!" >&2

--- a/src/luks/clevis-luks-common-functions.in
+++ b/src/luks/clevis-luks-common-functions.in
@@ -683,7 +683,7 @@ clevis_luks_get_existing_key() {
     fi
 
     # Let's prompt the user for the password.
-    read -r -s -p "${PROMPT}" pt; echo >&2
+    IFS= read -r -s -p "${PROMPT}" pt; echo >&2
 
     # Check if key is valid.
     clevis_luks_check_valid_key_or_keyfile "${DEV}" "${pt}" || return 1

--- a/src/luks/tests/tests-common-functions.in
+++ b/src/luks/tests/tests-common-functions.in
@@ -224,4 +224,4 @@ compare_luks2_metadata() {
     return 0
 }
 
-export DEFAULT_PASS='just-some-test-password-here'
+export DEFAULT_PASS='   just-some-   test-password-here 1.+?~!@#$%^&*();:'"'"'"[]{}_=/`\   '


### PR DESCRIPTION
This fixes the problem with passwords that contain spaces at beginning or ending. Such a password will make the `existing_key` variable has an incorrect key and result into a "No key available with this passphrase.` or "Nothing to read on input." error.