### PR TITLE
ci: correct failing logic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,10 @@ jobs:
       - name: Run tests
         run: |
           cd build
-          meson test || cat meson-logs/testlog.txt >&2
+          if ! meson test ; then
+              cat meson-logs/testlog.txt >&2
+              exit -1
+          fi
 
       - name: Show full test logs
         run: cat build/meson-logs/testlog.txt >&2


### PR DESCRIPTION
This fixes the auto test always succeeding due to the `cat` making fail return code being ignored.