### PR TITLE
Fix issue with multiple encrypted devices.

### DIFF
--- a/src/initramfs-tools/scripts/local-top/clevis.in
+++ b/src/initramfs-tools/scripts/local-top/clevis.in
@@ -130,6 +130,8 @@ clevisloop() {
 
     while true; do
 
+        # Re-get the askpass PID in case there are multiple encrypted devices
+        pid=""
         until [ "$pid" ] && [ -p "$PASSFIFO" ]; do
             sleep .1
             pid_fifo=$(get_askpass_pid)


### PR DESCRIPTION
There is a separate askpass process (with its own PID) for each encrypted device. So re-get the askpass PID with each loop iteration.

This seems like a hacky fix, but "if it's stupid, but it works, then it ain't stupid"