### PR TITLE
luks: replace `seq` with bash's builtin sequence expression

### DIFF
--- a/src/luks/clevis-luks-common-functions.in
+++ b/src/luks/clevis-luks-common-functions.in
@@ -894,7 +894,7 @@ clevis_luks_first_free_slot() {
     elif cryptsetup isLuks --type luks2 "${DEV}"; then
         local used_slots slt
         used_slots="$(clevis_luks_used_slots "${DEV}")"
-        for slt in $(seq 0 31); do
+        for slt in {0..31}; do
             if ! echo "${used_slots}" | grep -q "^${slt}$"; then
                 first_free_slot="${slt}"
                 break


### PR DESCRIPTION
This gives the same result without the added dep.

Hit this in FCOS where we don't currently ship `seq` in the initramfs
(normally, the clevis dracut module should've installed it if it
requires it). We could do that of course, but it's even better if we can
avoid it entirely.