### PR TITLE
Add test option for clevis luks unlock

### DIFF
--- a/src/luks/clevis-luks-unlock
+++ b/src/luks/clevis-luks-unlock
@@ -24,13 +24,16 @@ SUMMARY="Unlocks a LUKS volume"
 function usage() {
     exec >&2
     echo
-    echo "Usage: clevis luks unlock -d DEV [-n NAME]"
+    echo "Usage: clevis luks unlock -d DEV [-n NAME] [-t SLT]"
     echo
     echo "$SUMMARY":
     echo
     echo "  -d DEV  The LUKS device on which to perform unlocking"
     echo
     echo "  -n NAME The name of the unlocked device node"
+    echo
+    echo "  -t SLT Test the passphrase for the given slot without unlocking"
+    echo "         the device"
     echo
     exit 2
 }
@@ -40,10 +43,11 @@ if [ $# -eq 1 ] && [ "$1" == "--summary" ]; then
     exit 0
 fi
 
-while getopts ":d:n:" o; do
+while getopts ":d:n:t:" o; do
     case "$o" in
     d) DEV="$OPTARG";;
     n) NAME="$OPTARG";;
+    t) SLT="$OPTARG";;
     *) usage;;
     esac
 done
@@ -60,9 +64,26 @@ fi
 
 NAME="${NAME:-luks-"$(cryptsetup luksUUID "$DEV")"}"
 
-if ! pt=$(clevis_luks_unlock_device "${DEV}"); then
-    echo "${DEV} could not be opened." >&2
-    exit 1
-fi
+if [ -n "$SLT" ]; then
+    if ! jwe="$(clevis_luks_read_slot "${DEV}" "${SLT}" 2>/dev/null)" \
+                || [ -z "${jwe}" ]; then
+        echo "No Clevis information found in slot $SLT"
+        exit 1
+    fi
+    if ! passphrase="$(printf '%s' "${jwe}" | clevis decrypt 2>/dev/null)" \
+                       || [ -z "${passphrase}" ]; then
+        echo "Could not decrypt the passphrase associated with slot $SLT"
+        exit 1
+    fi
+    if ! clevis_luks_check_valid_key_or_keyfile "${DEV}" "${passphrase}"; then
+        echo "Decrypted passphrase does not appear to unlock device $DEV"
+        exit 1
+    fi
+else
+    if ! pt=$(clevis_luks_unlock_device "${DEV}"); then
+        echo "${DEV} could not be opened." >&2
+        exit 1
+    fi
 
-echo -n "${pt}" | cryptsetup open -d- "${DEV}" "${NAME}"
+    echo -n "${pt}" | cryptsetup open -d- "${DEV}" "${NAME}"
+fi

--- a/src/luks/clevis-luks-unlock
+++ b/src/luks/clevis-luks-unlock
@@ -65,18 +65,8 @@ fi
 NAME="${NAME:-luks-"$(cryptsetup luksUUID "$DEV")"}"
 
 if [ -n "$SLT" ]; then
-    if ! jwe="$(clevis_luks_read_slot "${DEV}" "${SLT}" 2>/dev/null)" \
-                || [ -z "${jwe}" ]; then
-        echo "No Clevis information found in slot ${SLT}" >&2
-        exit 1
-    fi
-    if ! passphrase="$(printf '%s' "${jwe}" | clevis decrypt 2>/dev/null)" \
-                       || [ -z "${passphrase}" ]; then
-        echo "Could not decrypt the passphrase associated with slot ${SLT}" >&2
-        exit 1
-    fi
-    if ! clevis_luks_check_valid_key_or_keyfile "${DEV}" "${passphrase}"; then
-        echo "Decrypted passphrase does not appear to unlock device ${DEV}" >&2
+    if ! clevis_luks_unlock_device_by_slot "${DEV}" "${SLT}" >/dev/null; then
+        echo "Test for token slot ${SLT} on device ${DEV} failed." >&2
         exit 1
     fi
 else

--- a/src/luks/clevis-luks-unlock
+++ b/src/luks/clevis-luks-unlock
@@ -67,16 +67,16 @@ NAME="${NAME:-luks-"$(cryptsetup luksUUID "$DEV")"}"
 if [ -n "$SLT" ]; then
     if ! jwe="$(clevis_luks_read_slot "${DEV}" "${SLT}" 2>/dev/null)" \
                 || [ -z "${jwe}" ]; then
-        echo "No Clevis information found in slot $SLT"
+        echo "No Clevis information found in slot ${SLT}" >&2
         exit 1
     fi
     if ! passphrase="$(printf '%s' "${jwe}" | clevis decrypt 2>/dev/null)" \
                        || [ -z "${passphrase}" ]; then
-        echo "Could not decrypt the passphrase associated with slot $SLT"
+        echo "Could not decrypt the passphrase associated with slot ${SLT}" >&2
         exit 1
     fi
     if ! clevis_luks_check_valid_key_or_keyfile "${DEV}" "${passphrase}"; then
-        echo "Decrypted passphrase does not appear to unlock device $DEV"
+        echo "Decrypted passphrase does not appear to unlock device ${DEV}" >&2
         exit 1
     fi
 else

--- a/src/luks/clevis-luks-unlock.1.adoc
+++ b/src/luks/clevis-luks-unlock.1.adoc
@@ -9,7 +9,7 @@ clevis-luks-unlock - Unlocks a LUKS device bound with a Clevis policy
 
 == SYNOPSIS
 
-*clevis luks unlock* -d DEV [-n NAME]
+*clevis luks unlock* -d DEV [-n NAME] [-t SLT]
 
 == OVERVIEW
 
@@ -25,6 +25,9 @@ provisioned Clevis policy. For example:
 
 * *-n* _NAME_ :
   The name to give the unlocked device node
+
+* *-t* _SLT_:
+  Test the passphrase for the given slot without unlocking the device
 
 == SEE ALSO
 

--- a/src/luks/clevis-luks-unlock.1.adoc
+++ b/src/luks/clevis-luks-unlock.1.adoc
@@ -26,7 +26,7 @@ provisioned Clevis policy. For example:
 * *-n* _NAME_ :
   The name to give the unlocked device node
 
-* *-t* _SLT_:
+* *-t* _SLT_ :
   Test the passphrase for the given slot without unlocking the device
 
 == SEE ALSO


### PR DESCRIPTION
Hello! Currently we're looking for a way to test that a given Clevis token can successfully unlock a crypt device without actually activating the device. Does this seem like something you'd be willing to incorporate upstream?