### PR TITLE
Add cryptsetup as a build dependency in CI for Fedora

### DIFF
--- a/.github/workflows/install-dependencies
+++ b/.github/workflows/install-dependencies
@@ -33,7 +33,7 @@ fedora:*)
     printf 'max_parallel_downloads=10\nfastestmirror=1\n' >> /etc/dnf/dnf.conf
     dnf -y clean all
     dnf -y --setopt=deltarpm=0 update
-    dnf -y install dnf-utils jq socat
+    dnf -y install dnf-utils jq socat cryptsetup
     dnf -y builddep clevis
     ;;
 

--- a/src/luks/tests/meson.build
+++ b/src/luks/tests/meson.build
@@ -1,6 +1,10 @@
 # We use jq for comparing the pin config in the clevis luks list tests.
 jq = find_program('jq', required: false)
 
+# We use cryptsetup for testing LUKS2 binding and saving the token in a
+# given token slot.
+cryptsetup = find_program('cryptsetup', required: true)
+
 common_functions = configure_file(input: 'tests-common-functions.in',
   output: 'tests-common-functions',
   configuration: luksmeta_data,


### PR DESCRIPTION
Additionally, also check for it in `luks/tests/meson.build`, as it is required for running the tests.