### PR TITLE
tang: fix clevis-encrypt-tang when specifying a SHA-256 thp

### DIFF
--- a/src/pins/tang/clevis-encrypt-tang
+++ b/src/pins/tang/clevis-encrypt-tang
@@ -122,7 +122,7 @@ if [ -z "${trust}" ]; then
 
     elif [ "$thp" != "any" ] && \
         ! jose jwk thp -i- -f "${thp}" -a "${CLEVIS_DEFAULT_THP_ALG}" \
-          <<< "$ver"; then
+          -o /dev/null <<< "$ver"; then
         # Thumbprint of trusted JWK did not match the signature. Let's check
         # alternative thumbprints generated with clevis supported hash
         # algorithms to be sure.

--- a/src/pins/tang/tests/default-thp-alg
+++ b/src/pins/tang/tests/default-thp-alg
@@ -79,14 +79,24 @@ for alg in ${CLEVIS_SUPPORTED_THP_ALGS}; do
 done
 
 # Now let's test encryption providing the thp in the configuration.
+data="just another test"
 for alg in ${CLEVIS_SUPPORTED_THP_ALGS}; do
     thp="$(jose fmt --json="${adv}" -g payload -y -o- \
            | jose jwk use -i- -r -u verify -o- \
            | jose jwk thp -i- -a "${alg}")"
     cfg="$(printf '{"url":"%s", "thp":"%s"}' "${url}" "${thp}")"
-    if ! echo foo | clevis encrypt tang "${cfg}" >/dev/null; then
+    if ! encoded=$(printf '%s' "${data}" | clevis encrypt tang "${cfg}"); then
         tang_error "${TEST}: tang encryption should have succeeded when providing the thp (${thp}) with any supported algorithm (${alg})"
     fi
+
+    if ! decoded="$(printf '%s' "${encoded}" | clevis decrypt)"; then
+        tang_error "${TEST}: decoding is expected to work (thp alg = ${alg})"
+    fi
+
+    if  [ "${decoded}" != "${data}" ]; then
+        tang_error "${TEST}: tang decrypt should have succeeded decoded[${decoded}] data[${data}] (alg = ${alg})"
+    fi
+
 done
 
 # Let's also try some unsupported thp hash algorithms.


### PR DESCRIPTION
After #264, we have started using SHA-256 for the JWK thumbprints,
however an issue was introduced causing clevis to output data to stdout
in certain situations which in turn would render the output of the
encryption malformed.

This commit fixes this issue and updates the tests to catch this
scenario.

Fixes: #304 