### PR TITLE
Improve handling of temporary directories

### DIFF
--- a/src/luks/clevis-luks-common-functions.in
+++ b/src/luks/clevis-luks-common-functions.in
@@ -946,7 +946,7 @@ clevis_luks_do_bind() {
     # We can proceed to binding, after backing up the LUKS header and
     # metadata.
     local CLEVIS_TMP_DIR
-
+    mkdir -p "${TMPDIR:-/tmp}"
     if ! CLEVIS_TMP_DIR="$(mktemp -d)" || [ -z "${CLEVIS_TMP_DIR}" ]; then
         echo "Unable to create a a temporary dir for device backup/restore" >&2
         return 1

--- a/src/luks/clevis-luks-edit
+++ b/src/luks/clevis-luks-edit
@@ -119,6 +119,7 @@ if ! pretty_cfg="$(printf '%s' "${cfg}" | jq --monochrome-output .)" \
     exit 1
 fi
 
+mkdir -p "${TMPDIR:-/tmp}"
 if ! CLEVIS_EDIT_TMP="$(mktemp -d)" || [ -z "${CLEVIS_EDIT_TMP}" ]; then
     echo "Creating a temporary dir for editing binding failed" >&2
     exit 1

--- a/src/luks/systemd/dracut/clevis/module-setup.sh.in
+++ b/src/luks/systemd/dracut/clevis/module-setup.sh.in
@@ -46,6 +46,7 @@ install() {
         luksmeta \
         clevis \
         mktemp \
+        mkdir \
         jose
 
     dracut_need_initqueue

--- a/src/pins/tpm2/clevis-decrypt-tpm2
+++ b/src/pins/tpm2/clevis-decrypt-tpm2
@@ -108,6 +108,7 @@ if ! jwk_priv="$(jose fmt -j- -Og clevis -g tpm2 -g jwk_priv -Su- <<< "$jhd")"; 
     exit 1
 fi
 
+mkdir -p "${TMPDIR:-/tmp}"
 if ! TMP="$(mktemp -d)"; then
     echo "Creating a temporary dir for TPM files failed!" >&2
     exit 1

--- a/src/pins/tpm2/clevis-encrypt-tpm2
+++ b/src/pins/tpm2/clevis-encrypt-tpm2
@@ -144,6 +144,7 @@ if ! jwk="$(jose jwk gen -i '{"alg":"A256GCM"}')"; then
     exit 1
 fi
 
+mkdir -p "${TMPDIR:-/tmp}"
 if ! TMP="$(mktemp -d)"; then
     echo "Creating a temporary dir for TPM files failed!" >&2
     exit 1


### PR DESCRIPTION
Sometimes `TMPDIR` may be defined to some non-existing directory, so we
now attempt an `mkdir -p` on it (or `/tmp`, if it's not defined) before
doing an `mktemp` call, in order to minimize the failures when we have
these weird corner cases.