### PR TITLE
Update README.md to include note about networking during boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ Enter existing LUKS password:
 Upon successful completion of this binding process, the disk can be unlocked
 using one of the provided unlockers.
 
+#### Network based unlocking
+If you want to use network based unlocking you will need to specify `rd.neednet=1` as kernel argument or use `--hostonly-cmdline` when creating dracut.
+
 #### Unlocker: Dracut
 
 The Dracut unlocker attempts to automatically unlock volumes during early

--- a/src/luks/clevis-luks-unlockers.7.adoc
+++ b/src/luks/clevis-luks-unlockers.7.adoc
@@ -37,9 +37,16 @@ Once Clevis is integrated into your initramfs, a simple reboot should unlock
 your root volume. Note, however, that early boot integration only works for the
 root volume. Non-root volumes should use the late boot unlocker.
 
-Dracut will bring up your network using DHCP by default. If you need to specify
-additional network parameters, such as static IP configuration, please consult
-the dracut documentation.
+Dracut will not bring up your network by default. You can either have it come
+up via dhcp by using rd.neednet=1 in kernel cmdline or you can specify custom
+network parameters, such as static IP configuration, please consult the dracut
+documentation.
+
+dhcp can be easily added to early boot by setting it in a configuration file
+and rebuilding initramfs afterwards
+
+    $ echo 'kernel_cmdline="rd.neednet=1"' | sudo tee /etc/dracut.conf.d/clevis.conf
+    $ sudo dracut -f
 
 == LATE BOOT UNLOCKING
 


### PR DESCRIPTION
Hi,
with the changes from https://github.com/latchset/clevis/pull/211 and https://github.com/latchset/clevis/pull/252 networking is no longer automatically enabled during early boot. This PR adds a note about how to enable it.

Greetings
Klaas