### PR TITLE
Do not kill non clevis slots

### DIFF
--- a/src/luks/clevis-luks-unbind.in
+++ b/src/luks/clevis-luks-unbind.in
@@ -106,6 +106,7 @@ elif [ "$luks_type" == "luks2" ]; then
     grep -q "^\s*$SLT: luks2" <<< "$dump" && KILL=true
     TOK="$(grep -E -B1 "^\s+Keyslot:\s+$SLT$" <<< "$dump" \
         | sed -rn 's|^\s+([0-9]+): clevis|\1|p')"
+    test -z "${TOK}" && unset KILL
 fi
 
 if [ -z "${FRC[*]}" ]; then

--- a/src/luks/clevis-luks-unbind.in
+++ b/src/luks/clevis-luks-unbind.in
@@ -107,7 +107,7 @@ elif [ "$luks_type" == "luks2" ]; then
     TOK="$(grep -E -B1 "^\s+Keyslot:\s+$SLT$" <<< "$dump" \
         | sed -rn 's|^\s+([0-9]+): clevis|\1|p')"
     if [ -z "${TOK}" ]; then
-        echo "No clevis slot detected on device $DEV!" >&2
+        echo "No clevis slot detected on device ${DEV}:${SLT}!" >&2
         exit 1
     fi
 fi

--- a/src/luks/clevis-luks-unbind.in
+++ b/src/luks/clevis-luks-unbind.in
@@ -106,7 +106,10 @@ elif [ "$luks_type" == "luks2" ]; then
     grep -q "^\s*$SLT: luks2" <<< "$dump" && KILL=true
     TOK="$(grep -E -B1 "^\s+Keyslot:\s+$SLT$" <<< "$dump" \
         | sed -rn 's|^\s+([0-9]+): clevis|\1|p')"
-    test -z "${TOK}" && unset KILL
+    if [ -z "${TOK}" ]; then
+        echo "No clevis slot detected on device $DEV!" >&2
+        exit 1
+    fi
 fi
 
 if [ -z "${FRC[*]}" ]; then

--- a/src/luks/tests/tests-common-functions.in
+++ b/src/luks/tests/tests-common-functions.in
@@ -70,6 +70,32 @@ new_device() {
     cp -f "${DEV}" "${DEV_CACHED}"
 }
 
+# Creates a new LUKS1 or LUKS2 device to be used.
+new_uncached_sized_device() {
+    local LUKS="${1}"
+    local DEV="${2}"
+    local PASS="${3}"
+    local SIZE="${4}"
+
+    # Some builders fail if the cryptsetup steps are not ran as root, so let's
+    # skip the test now if not running as root.
+    if [ "$(id -u)" != 0 ]; then
+        skip_test "WARNING: You must be root to run this test; test skipped."
+    fi
+
+    # Using a default password, if none has been provided.
+    if [ -z "${PASS}" ]; then
+        PASS="${DEFAULT_PASS}"
+    fi
+
+    # If no size, assign a default size
+    if [ -z "${SIZE}" ]; then
+        SIZE="${DEFAULT_SIZE}"
+    fi
+    fallocate -l"${SIZE}" "${DEV}"
+    cryptsetup luksFormat --type "${LUKS}" --batch-mode --force-password "${DEV}" <<<"${PASS}"
+}
+
 # Creates a new LUKS1 or LUKS2 device to be used, using a keyfile.
 new_device_keyfile() {
     local LUKS="${1}"
@@ -230,3 +256,4 @@ new_passphrase() {
 }
 
 export DEFAULT_PASS='   just-some-   test-password-here 1.+?~!@#$%^&*();:'"'"'"[]{}_=/`\   '
+export DEFAULT_SIZE='64M'

--- a/src/luks/tests/tests-common-functions.in
+++ b/src/luks/tests/tests-common-functions.in
@@ -230,4 +230,3 @@ new_passphrase() {
 }
 
 export DEFAULT_PASS='   just-some-   test-password-here 1.+?~!@#$%^&*();:'"'"'"[]{}_=/`\   '
-export DEFAULT_SIZE='64M'

--- a/src/luks/tests/tests-common-functions.in
+++ b/src/luks/tests/tests-common-functions.in
@@ -70,32 +70,6 @@ new_device() {
     cp -f "${DEV}" "${DEV_CACHED}"
 }
 
-# Creates a new LUKS1 or LUKS2 device to be used.
-new_uncached_sized_device() {
-    local LUKS="${1}"
-    local DEV="${2}"
-    local PASS="${3}"
-    local SIZE="${4}"
-
-    # Some builders fail if the cryptsetup steps are not ran as root, so let's
-    # skip the test now if not running as root.
-    if [ "$(id -u)" != 0 ]; then
-        skip_test "WARNING: You must be root to run this test; test skipped."
-    fi
-
-    # Using a default password, if none has been provided.
-    if [ -z "${PASS}" ]; then
-        PASS="${DEFAULT_PASS}"
-    fi
-
-    # If no size, assign a default size
-    if [ -z "${SIZE}" ]; then
-        SIZE="${DEFAULT_SIZE}"
-    fi
-    fallocate -l"${SIZE}" "${DEV}"
-    cryptsetup luksFormat --type "${LUKS}" --batch-mode --force-password "${DEV}" <<<"${PASS}"
-}
-
 # Creates a new LUKS1 or LUKS2 device to be used, using a keyfile.
 new_device_keyfile() {
     local LUKS="${1}"

--- a/src/luks/tests/unbind-luks2
+++ b/src/luks/tests/unbind-luks2
@@ -49,3 +49,16 @@ SLT=1
 if ! clevis luks unbind -f -d "${DEV}" -s "${SLT}"; then
     error "${TEST}: Unbind is expected to succeed for device ${DEV} and slot ${SLT}" >&2
 fi
+
+DEV_NO_CLEVIS="${TMP}/luks-device-no-clevis"
+new_uncached_sized_device "luks2" "${DEV_NO_CLEVIS}" "${DEFAULT_PASS}" "10m"
+
+SLT=0
+if ! echo "${DEFAULT_PASS}" | cryptsetup open --test-passphrase "${DEV_NO_CLEVIS}" --key-slot "${SLT}"; then
+   error "${TEST}: new_device luks2 not able to be decrypted" >&2
+fi
+
+clevis luks unbind -f -d "${DEV_NO_CLEVIS}" -s "${SLT}" >&2
+if ! echo "${DEFAULT_PASS}" | cryptsetup open --test-passphrase "${DEV_NO_CLEVIS}" --key-slot "${SLT}"; then
+  error "${TEST}: Unbind is expected not to remove non clevis slots" >&2
+fi

--- a/src/luks/tests/unbind-luks2
+++ b/src/luks/tests/unbind-luks2
@@ -50,18 +50,15 @@ if ! clevis luks unbind -f -d "${DEV}" -s "${SLT}"; then
     error "${TEST}: Unbind is expected to succeed for device ${DEV} and slot ${SLT}" >&2
 fi
 
-DEV_NO_CLEVIS="${TMP}/luks-device-no-clevis"
-new_device "luks2" "${DEV_NO_CLEVIS}"
-
 SLT=0
-if ! echo "${DEFAULT_PASS}" | cryptsetup open --test-passphrase "${DEV_NO_CLEVIS}" --key-slot "${SLT}"; then
+if ! echo "${DEFAULT_PASS}" | cryptsetup open --test-passphrase "${DEV}" --key-slot "${SLT}"; then
    error "${TEST}: new_device luks2 not able to be decrypted" >&2
 fi
 
-if clevis luks unbind -f -d "${DEV_NO_CLEVIS}" -s "${SLT}"; then
+if clevis luks unbind -f -d "${DEV}" -s "${SLT}"; then
    error "${TEST}: Unbind is expected to fail for device not bound with clevis" >&2
 fi
 
-if ! echo "${DEFAULT_PASS}" | cryptsetup open --test-passphrase "${DEV_NO_CLEVIS}" --key-slot "${SLT}"; then
+if ! echo "${DEFAULT_PASS}" | cryptsetup open --test-passphrase "${DEV}" --key-slot "${SLT}"; then
   error "${TEST}: Unbind is expected not to remove non clevis slots" >&2
 fi

--- a/src/luks/tests/unbind-luks2
+++ b/src/luks/tests/unbind-luks2
@@ -42,23 +42,23 @@ DEV="${TMP}/luks2-device"
 new_device "luks2" "${DEV}"
 # Binding.
 if ! clevis luks bind -d "${DEV}" tang "${CFG}" <<< "${DEFAULT_PASS}"; then
-    error "${TEST}: Binding is expected to succeed." >&2
+    error "${TEST}: Binding is expected to succeed."
 fi
 
 SLT=1
 if ! clevis luks unbind -f -d "${DEV}" -s "${SLT}"; then
-    error "${TEST}: Unbind is expected to succeed for device ${DEV} and slot ${SLT}" >&2
+    error "${TEST}: Unbind is expected to succeed for device ${DEV} and slot ${SLT}"
 fi
 
 SLT=0
 if ! echo "${DEFAULT_PASS}" | cryptsetup open --test-passphrase "${DEV}" --key-slot "${SLT}"; then
-   error "${TEST}: new_device luks2 not able to be decrypted" >&2
+   error "${TEST}: Unable to open device ${DEV}:${SLT}"
 fi
 
 if clevis luks unbind -f -d "${DEV}" -s "${SLT}"; then
-   error "${TEST}: Unbind is expected to fail for device not bound with clevis" >&2
+   error "${TEST}: Unbind is expected to fail for device ${DEV}:${SLT} that is not bound with clevis"
 fi
 
 if ! echo "${DEFAULT_PASS}" | cryptsetup open --test-passphrase "${DEV}" --key-slot "${SLT}"; then
-  error "${TEST}: Unbind is expected not to remove non clevis slots" >&2
+  error "${TEST}: Unbind is expected not to remove non clevis slots"
 fi

--- a/src/luks/tests/unbind-luks2
+++ b/src/luks/tests/unbind-luks2
@@ -51,14 +51,17 @@ if ! clevis luks unbind -f -d "${DEV}" -s "${SLT}"; then
 fi
 
 DEV_NO_CLEVIS="${TMP}/luks-device-no-clevis"
-new_uncached_sized_device "luks2" "${DEV_NO_CLEVIS}" "${DEFAULT_PASS}" "10m"
+new_device "luks2" "${DEV_NO_CLEVIS}"
 
 SLT=0
 if ! echo "${DEFAULT_PASS}" | cryptsetup open --test-passphrase "${DEV_NO_CLEVIS}" --key-slot "${SLT}"; then
    error "${TEST}: new_device luks2 not able to be decrypted" >&2
 fi
 
-clevis luks unbind -f -d "${DEV_NO_CLEVIS}" -s "${SLT}" >&2
+if clevis luks unbind -f -d "${DEV_NO_CLEVIS}" -s "${SLT}"; then
+   error "${TEST}: Unbind is expected to fail for device not bound with clevis" >&2
+fi
+
 if ! echo "${DEFAULT_PASS}" | cryptsetup open --test-passphrase "${DEV_NO_CLEVIS}" --key-slot "${SLT}"; then
   error "${TEST}: Unbind is expected not to remove non clevis slots" >&2
 fi


### PR DESCRIPTION
When using clevis-luks-unbind against a slot
that has no clevis token assigned, removing the slot
must be avoided.  Fixes #183

Signed-off-by: Sergio Arroutbi Braojos <sarroutb@redhat.com>