### PR TITLE
passing args to 'cryptsetup open'

### DIFF
--- a/src/luks/clevis-luks-unlock
+++ b/src/luks/clevis-luks-unlock
@@ -35,6 +35,10 @@ function usage() {
     echo "  -t SLT Test the passphrase for the given slot without unlocking"
     echo "         the device"
     echo
+    echo "  -o OPTS Pass options to underlying 'cryptsetup open'; be sure"
+    echo "          to quote the OPTS you pass, if they contain a space,"
+    echo "          etc."
+    echo
     exit 2
 }
 
@@ -43,11 +47,12 @@ if [ $# -eq 1 ] && [ "$1" == "--summary" ]; then
     exit 0
 fi
 
-while getopts ":d:n:t:" o; do
+while getopts ":d:n:t:o:" o; do
     case "$o" in
     d) DEV="$OPTARG";;
     n) NAME="$OPTARG";;
     t) SLT="$OPTARG";;
+    o) OPENARGS="$OPTARG";;
     *) usage;;
     esac
 done
@@ -75,5 +80,5 @@ else
         exit 1
     fi
 
-    echo -n "${pt}" | cryptsetup open -d- "${DEV}" "${NAME}"
+    echo -n "${pt}" | cryptsetup ${OPENARGS} open -d- "${DEV}" "${NAME}"
 fi

--- a/src/luks/clevis-luks-unlock.1.adoc
+++ b/src/luks/clevis-luks-unlock.1.adoc
@@ -29,6 +29,9 @@ provisioned Clevis policy. For example:
 * *-t* _SLT_ :
   Test the passphrase for the given slot without unlocking the device
 
+* *-o* _PARAMS_ :
+  Pass arbitrary parameters to cryptsetup; quote parameters as necessary
+
 == SEE ALSO
 
 link:clevis-luks-bind.1.adoc[*clevis-luks-bind*(1)]

--- a/src/luks/tests/meson.build
+++ b/src/luks/tests/meson.build
@@ -86,3 +86,6 @@ if luksmeta_data.get('OLD_CRYPTSETUP') == '0'
   test('backup-restore-luks2', find_program('backup-restore-luks2'), env: env, timeout: 120)
   test('pass-tang-luks2', find_program('pass-tang-luks2'), env: env, timeout: 60)
 endif
+
+test('unlock-arbitrary-parameter', find_program('unlock-arbitrary-parameter'), env: env)
+

--- a/src/luks/tests/unlock-arbitrary-parameter
+++ b/src/luks/tests/unlock-arbitrary-parameter
@@ -1,0 +1,68 @@
+#!/bin/bash -ex
+# vim: set ts=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+TEST=$(basename "${0}")
+. tests-common-functions
+
+. clevis-luks-common-functions
+
+on_exit() {
+    [ ! -d "${TMP}" ] && return 0
+    tang_stop "${TMP}"
+    rm -rf "${TMP}"
+}
+
+trap 'on_exit' EXIT
+trap 'on_exit' ERR
+
+TMP="$(mktemp -d)"
+
+port=$(tang_new_random_port)
+tang_run "${TMP}" "${port}"
+
+url="http://localhost:${port}"
+adv="${TMP}/adv"
+tang_get_adv "${port}" "${adv}"
+
+cfg=$(printf '{"url":"%s","adv":"%s"}' "$url" "$adv")
+
+DEV="${TMP}/luks1-device"
+new_device "luks1" "${DEV}"
+
+if ! clevis luks bind -f -d "${DEV}" tang "${cfg}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: Bind should have succeeded."
+fi
+
+TESTPARAM="arbitrarytestparameter"
+
+#set up a "cryptsetup" function, to hijack the command
+cryptsetup () { 
+    #need to handle "cryptsetup isLuks" from clevis-luks-unlock, among others   
+    if [[ $1 == "isLuks" ]]; then
+        exit 0;
+    elif [[ $1 == "luksUUID" ]]; then
+        echo "TESTINGLUKSUUID"
+        exit 0;
+    else
+        echo "$*" | grep -q -- "${TESTPARAM}"
+        exit $?
+    fi
+}
+export -f cryptsetup
+
+if ! clevis-luks-unlock -o "$TESTPARAM" -d ${DEV} -n clevis_unlock_test; then
+    error "${TEST}: clevis luks unlock did not match arbitrary test parameter \"$TESTPARAM\"."
+fi


### PR DESCRIPTION
Quick attempt to allow passing of arbitrary args to 'cryptsetup open' when unlocking volume.  Related to the discussion [here](https://github.com/latchset/clevis/issues/316).

