### PR TITLE
test: define the key size for our tests

### DIFF
--- a/src/luks/tests/tests-common-functions.in
+++ b/src/luks/tests/tests-common-functions.in
@@ -64,7 +64,7 @@ new_device() {
 
     fallocate -l64M "${DEV}"
     cryptsetup luksFormat --type "${LUKS}" --pbkdf pbkdf2 \
-        --pbkdf-force-iterations 1000 --batch-mode \
+        --pbkdf-force-iterations 1000 --key-size 512 --batch-mode \
         --force-password "${DEV}" <<< "${PASS}"
     # Caching the just-formatted device for possible reuse.
     cp -f "${DEV}" "${DEV_CACHED}"
@@ -88,7 +88,7 @@ new_device_keyfile() {
 
     fallocate -l64M "${DEV}"
     cryptsetup luksFormat --type "${LUKS}" --pbkdf pbkdf2 \
-        --pbkdf-force-iterations 1000 --batch-mode \
+        --pbkdf-force-iterations 1000 --key-size 512 --batch-mode \
         "${DEV}" "${KEYFILE}"
 }
 


### PR DESCRIPTION
Older cryptsetup had a different default value for the key size,
e.g. 256, whereas newer ones have changed it to 512.

Let's specify the key size when creating our LUKS devices for the
tests, to make the devices more similar even when running in older
versions of cryptsetup.

We now use 512 as the key size for our test devices.