### PR TITLE
luks: define max entropy bits for pwmake

### DIFF
--- a/src/clevis.1.adoc
+++ b/src/clevis.1.adoc
@@ -101,7 +101,7 @@ This is accomplished with a simple command:
 
 This command performs four steps:
 
-1. Creates a new key with the same entropy as the LUKS master key.
+1. Creates a new key with the same entropy as the LUKS master key -- maximum entropy bits is 256.
 2. Encrypts the new key with Clevis.
 3. Stores the Clevis JWE in the LUKS header.
 4. Enables the new key for use with LUKS.

--- a/src/luks/clevis-luks-bind.1.adoc
+++ b/src/luks/clevis-luks-bind.1.adoc
@@ -20,7 +20,7 @@ policy. This is accomplished with a simple command:
 
 This command performs four steps:
 
-1. Creates a new key with the same entropy as the LUKS master key.
+1. Creates a new key with the same entropy as the LUKS master key -- maximum entropy bits is 256.
 2. Encrypts the new key with Clevis.
 3. Stores the Clevis JWE in the LUKS header.
 4. Enables the new key for use with LUKS.

--- a/src/luks/clevis-luks-common-functions.in
+++ b/src/luks/clevis-luks-common-functions.in
@@ -841,6 +841,7 @@ clevis_luks_generate_key() {
     [ -z "${DEV}" ] && return 1
 
     local dump filter bits
+    local MAX_ENTROPY_BITS=256  # Maximum allowed by pwmake.
     dump=$(cryptsetup luksDump "${DEV}")
     if cryptsetup isLuks --type luks1 "${DEV}"; then
         filter="$(echo "${dump}" | sed -rn 's|MK bits:[ \t]*([0-9]+)|\1|p')"
@@ -852,6 +853,9 @@ clevis_luks_generate_key() {
     fi
 
     bits="$(echo -n "${filter}" | sort -n | tail -n 1)"
+    if [ "${bits}" -gt "${MAX_ENTROPY_BITS}" ]; then
+        bits="${MAX_ENTROPY_BITS}"
+    fi
     pwmake "${bits}"
 }
 


### PR DESCRIPTION
So that we don't get a warning about using a value outside the allowed
entropy range, when generating a new passphrase.

Fixes: #321 