### PR TITLE
luks: explicitly specify pbkdf iterations to cryptsetup

### DIFF
--- a/src/luks/clevis-luks-common-functions.in
+++ b/src/luks/clevis-luks-common-functions.in
@@ -751,10 +751,12 @@ clevis_luks_add_key() {
         extra_args="$(printf -- '--key-file %s' "${KEYFILE}")"
         input="$(printf '%s' "${NEWKEY}")"
     fi
+    local pbkdf_args="--pbkdf pbkdf2 --pbkdf-force-iterations 1000"
 
     printf '%s' "${input}" | cryptsetup luksAddKey --batch-mode \
                                          --key-slot "${SLT}" \
                                          "${DEV}" \
+                                         ${pbkdf_args} \
                                          ${extra_args}
 }
 
@@ -783,11 +785,14 @@ clevis_luks_update_key() {
         extra_args="$(printf -- '--key-file %s' "${KEYFILE}")"
         input="$(printf '%s' "${NEWKEY}")"
     fi
+    local pbkdf_args="--pbkdf pbkdf2 --pbkdf-force-iterations 1000"
 
     if [ -n "${in_place}" ]; then
         printf '%s' "${input}" | cryptsetup luksChangeKey "${DEV}" \
                                             --key-slot "${SLT}" \
-                                            --batch-mode ${extra_args}
+                                            --batch-mode \
+                                            ${pbkdf_args} \
+                                            ${extra_args}
         return
     fi
 


### PR DESCRIPTION
This fixes an Out of memory error when the system has not much memory, such as a VM configured with 2GB currently being installed through the network (hence having ~1GB free memory only).
See [RHBZ #1979256](https://bugzilla.redhat.com/show_bug.cgi?id=1979256).