### PR TITLE
systemd: account for unlocking failures in clevis-luks-askpass

### DIFF
--- a/src/luks/systemd/clevis-luks-askpass.in
+++ b/src/luks/systemd/clevis-luks-askpass.in
@@ -67,8 +67,11 @@ while true; do
     done
 
     [ "${loop}" != true ] && break
+
     # Checking for pending devices to be unlocked.
-    if remaining=$(clevis_devices_to_unlock) && [ -z "${remaining}" ]; then
+    remaining_crypttab=$(clevis_devices_to_unlock) ||:
+    remaining_askfiles=$(ls "${path}"/ask.* 2>/dev/null) ||:
+    if [ -z "${remaining_crypttab}" ] && [ -z "${remaining_askfiles}" ]; then
         break;
     fi
 


### PR DESCRIPTION
As unlock may fail for some reason, e.g. the network is not up yet,
one way cause problems would be to add extra `rd.luks.uuid' params
to the cmdline, which would then cause such devices to be unlocked
in early boot. If the unlocking fail, those devices might not be
accounted for in the clevis_devices_to_unlock() check, as it is
based on crypttab.

Let's make sure there are no pending ask.* sockets waiting to be
answered, before exiting.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1878892