### PR TITLE
sss.h: Added include so pid_t type is correctly defined.

### DIFF
--- a/src/pins/sss/sss.h
+++ b/src/pins/sss/sss.h
@@ -20,6 +20,7 @@
 #pragma once
 #include <jansson.h>
 #include <stdint.h>
+#include <sys/types.h>
 
 json_t *
 sss_generate(size_t key_bytes, size_t threshold);


### PR DESCRIPTION
Closes: #345