### PR TITLE
ci: make ubuntu:devel and fedora:rawhide not to fail the pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,18 +6,23 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-18.04
+    continue-on-error: ${{ ! matrix.stable }}
     strategy:
       matrix:
         os:
-          - fedora:rawhide
           - fedora:latest
           - centos:7
           - centos:8
           - debian:testing
           - debian:latest
-          - ubuntu:devel
           - ubuntu:rolling
           - ubuntu:bionic
+        stable: [true]
+        include:
+          - os: fedora:rawhide
+            stable: false
+          - os: ubuntu:devel
+            stable: false
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
We will still attempt to build and run these two, but in case they
fail, the CI pipeline will not fail and cancel the other jobs.