### PR TITLE
luks: ignore empty & comment lines in crypttab

### DIFF
--- a/src/luks/clevis-luks-common-functions.in
+++ b/src/luks/clevis-luks-common-functions.in
@@ -408,7 +408,12 @@ clevis_devices_to_unlock() {
     clevis_devices=
 
     # Build list of devices to unlock.
-    while read -r _ crypt_device _; do
+    while read -r _volname_ crypt_device _; do
+        # skip empty lines and lines which begin with the '#' char, per
+        # crypttab(5)
+        case $_volname_ in
+            ''|\#*) continue ;;
+        esac
         if ! dev=$(clevis_map_device "${crypt_device}") \
                    || [ -z "${dev}" ]; then
             # Unable to get the device - maybe it's not available, e.g. a


### PR DESCRIPTION
When reading /etc/crypttab in `clevis_devices_to_unlock()`, ignore empty
lines and lines which begin with the '#' char, per crypttab(5).  At
best, it's wasteful to parse these lines.  At worst, we could unlock a
device which was not intended to be unlocked.

Another effect of this is that `clevis-luks-askpass` never exits, it
runs every 500ms, parsing /etc/crypttab in a vain attempt to wait for a
device which may never appear.  The loop in `clevis_devices_to_unlock()`
looks like:

    # Build list of devices to unlock
    while read -r _ crypt_device _; do
        if ! dev=$(clevis_map_device "${crypt_device}") \
                   || [ -z "${dev}" ]; then
            # Unable to get the device - maybe it's not available, e.g. a
            # device on a volume group that has not been activated yet.
            # Add it to the list anyway, since it's a pending device.
            clevis_devices="${clevis_devices} ${dev}"
            continue
        fi
        ...
    done

The resulting `${clevis_devices}` grows an empty space for each of the
commented entries where a device is unable to be found.  The loop in
clevis-luks-askpass then fails this test which would break it out of
it's own while loop and exit:

    if remaining=$(clevis_devices_to_unlock) && [ -z "${remaining}" ]; then
        break;
    fi

It's unclear to me why we should add an empty string to the list "since
it's a pending device" in `clevis_devices_to_unlock()`.  That seems like
a bug as well.  Perhaps the intention is to add `${crypt_device}` and
not the empty `${dev}` to `${clevis_devices}`?