### PR TITLE
Use `command -v` instead of `which`

### DIFF
--- a/src/initramfs-tools/hooks/clevis.in
+++ b/src/initramfs-tools/hooks/clevis.in
@@ -42,7 +42,7 @@ die() {
 
 find_binary() {
     bin_name="$1"
-    resolved=$(which ${bin_name})
+    resolved=$(command -v ${bin_name})
     [ -z "$resolved" ] && die 1 "Unable to find ${bin_name}"
     echo "$resolved"
 }


### PR DESCRIPTION
On debian `/usr/bin/which` results in deprecated messages, recommending
`command -v` instead.

They look like:

```
at 10:35:36 ❯ sudo update-initramfs -u -k 'all'
update-initramfs: Generating /boot/initrd.img-5.15.0-2-amd64
I: The initramfs will attempt to resume from /dev/dm-2
I: (/dev/mapper/sys-swap)
I: Set the RESUME variable to override this.
/usr/bin/which: this version of `which' is deprecated; use `command -v' in scripts instead.
/usr/bin/which: this version of `which' is deprecated; use `command -v' in scripts instead.
/usr/bin/which: this version of `which' is deprecated; use `command -v' in scripts instead.
/usr/bin/which: this version of `which' is deprecated; use `command -v' in scripts instead.
/usr/bin/which: this version of `which' is deprecated; use `command -v' in scripts instead.
/usr/bin/which: this version of `which' is deprecated; use `command -v' in scripts instead.
/usr/bin/which: this version of `which' is deprecated; use `command -v' in scripts instead.
/usr/bin/which: this version of `which' is deprecated; use `command -v' in scripts instead.
```