### PR TITLE
sss pin: unavailable address should be dumped when one of the URLs is not reachable

### DIFF
--- a/src/pins/tang/clevis-decrypt-tang
+++ b/src/pins/tang/clevis-decrypt-tang
@@ -99,10 +99,10 @@ fi
 
 xfr="$(jose jwk exc -i '{"alg":"ECMR"}' -l- -r- <<< "$clt$eph")"
 
-url="$url/rec/$kid"
+rec_url="$url/rec/$kid"
 ct="Content-Type: application/jwk+json"
-if ! rep="$(curl -sfg -X POST -H "$ct" --data-binary @- "$url" <<< "$xfr")"; then
-    echo "Error communicating with the server!" >&2
+if ! rep="$(curl -sfg -X POST -H "$ct" --data-binary @- "$rec_url" <<< "$xfr")"; then
+    echo "Error communicating with server $url" >&2
     exit 1
 fi
 


### PR DESCRIPTION
When clevis can not find a remote server when using sss pin, message _Error communicating with the server!_ is dumped

This change dumps the problematic URL, dumping _Error communicating with server http://10.0.139.4_
