### PR TITLE
Fix DNS resolution in initramfs

### DIFF
--- a/src/initramfs-tools/hooks/clevis.in
+++ b/src/initramfs-tools/hooks/clevis.in
@@ -93,3 +93,11 @@ bash_bin=$(find_binary "bash")
 copy_exec "${curl_bin}" || die 2 "Unable to copy ${curl_bin} to initrd image"
 copy_exec "${awk_bin}" || die 2 "Unable to copy ${awk_bin} to initrd image"
 copy_exec "${bash_bin}" || die 2 "Unable to copy ${bash_bin} to initrd image"
+
+# Copy latest versions of shared objects needed for DNS resolution
+for so in $(ldconfig -p | sed -nr 's/^\s*libnss_files\.so\.[0-9]+\s.*=>\s*//p'); do
+  copy_exec "${so}"
+done
+for so in $(ldconfig -p | sed -nr 's/^\s*libnss_dns\.so\.[0-9]+\s.*=>\s*//p'); do
+  copy_exec "${so}"
+done

--- a/src/initramfs-tools/scripts/local-top/clevis.in
+++ b/src/initramfs-tools/scripts/local-top/clevis.in
@@ -267,13 +267,18 @@ do_configure_networking() {
         # Add DNS servers from configure_networking to /etc/resolv.conf
         if [ ! -e /etc/resolv.conf ]; then
             touch /etc/resolv.conf
-            if [ ! -z "${IPV4DNS0}" ]; then
-                echo nameserver "${IPV4DNS0}" >> /etc/resolv.conf
-                echo nameserver "${IPV4DNS1}" >> /etc/resolv.conf
-            fi
-            if [ ! -z "${IPV6DNS0}" ]; then
-                echo nameserver "${IPV6DNS0}" >> /etc/resolv.conf
-            fi
+            for intf in /run/net-*.conf; do
+                . "${intf}"
+                if [ ! -z "${IPV4DNS0}" ] && [ "${IPV4DNS0}" != "0.0.0.0" ]; then
+                    echo nameserver "${IPV4DNS0}" >> /etc/resolv.conf
+                fi
+                if [ ! -z "${IPV4DNS1}" ] && [ "${IPV4DNS1}" != "0.0.0.0" ]; then
+                    echo nameserver "${IPV4DNS1}" >> /etc/resolv.conf
+                fi
+                if [ ! -z "${IPV6DNS0}" ]; then
+                    echo nameserver "${IPV6DNS0}" >> /etc/resolv.conf
+                fi
+            done
         fi
     fi
 }

--- a/src/initramfs-tools/scripts/local-top/clevis.in
+++ b/src/initramfs-tools/scripts/local-top/clevis.in
@@ -263,6 +263,18 @@ do_configure_networking() {
             echo "clevis: Warning: multiple network interfaces available but no ip= parameter provided."
         fi
         configure_networking
+
+        # Add DNS servers from configure_networking to /etc/resolv.conf
+        if [ ! -e /etc/resolv.conf ]; then
+            touch /etc/resolv.conf
+            if [ ! -z "${IPV4DNS0}" ]; then
+                echo nameserver "${IPV4DNS0}" >> /etc/resolv.conf
+                echo nameserver "${IPV4DNS1}" >> /etc/resolv.conf
+            fi
+            if [ ! -z "${IPV6DNS0}" ]; then
+                echo nameserver "${IPV6DNS0}" >> /etc/resolv.conf
+            fi
+        fi
     fi
 }
 


### PR DESCRIPTION
As mentioned in  #148 there seems to be a problem with the name resolution when using tang pin. If the URL to the server is not a plain IP, clevis is unable to contact tang. I could recreate this issue on Ubuntu 11. The changes in initramfs-tool hooks and scripts fixed it.

In my test setup i could only verify the changes with a DHCP server that hands out a single DNS server via IPv4 on a single interface. So the second IPv4 DNS, IPv6 DNS and multiple interfaces section in the code is only proofread and not tested.