### PR TITLE
tpm2_flushcontext missing in initramfs

### DIFF
--- a/src/initramfs-tools/hooks/clevis.in
+++ b/src/initramfs-tools/hooks/clevis.in
@@ -67,9 +67,11 @@ if [ -x @bindir@/clevis-decrypt-tpm2 ]; then
     tpm2_creatprimary_bin=$(find_binary "tpm2_createprimary")
     tpm2_unseal_bin=$(find_binary "tpm2_unseal")
     tpm2_load_bin=$(find_binary "tpm2_load")
+    tpm2_flushcontext=$(find_binary "tpm2_flushcontext")
     copy_exec "${tpm2_creatprimary_bin}" || die 1 "Unable to copy ${tpm2_creatprimary_bin}" 
     copy_exec "${tpm2_unseal_bin}" || die 1 "Unable to copy ${tpm2_unseal_bin}"
     copy_exec "${tpm2_load_bin}" || die 1 "Unable to copy ${tpm2_load_bin}"
+    copy_exec "${tpm2_flushcontext}" || die 1 "Unable to copy ${tpm2_flushcontext}"
     for _LIBRARY in @libdir@/libtss2-tcti-device.so*; do
         if [ -e "${_LIBRARY}" ]; then
             copy_exec "${_LIBRARY}" || die 2 "Unable to copy ${_LIBRARY}"


### PR DESCRIPTION
tpm2_flushcontext is not copied over to initramfs but are used in [clevis-decrypt-tpm2 ](https://github.com/latchset/clevis/blob/f5786d3b4b3c282dfea4e29c96601473510886f5/src/pins/tpm2/clevis-decrypt-tpm2#L148)