### PR TITLE
initramfs: add support for mkinitcpio initramfs generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,34 @@ sudo update-initramfs -u -k 'all'
 
 Upon reboot it will behave exactly as if using Dracut.
 
+### Unlocker: mkinitcpio
+
+When using Clevis with mkinitcpio, you will need to add the `clevis` hook
+before the `encrypt` hook in `/etc/mkinitcpio.conf`:
+
+```bash
+HOOKS=( ... clevis encrypt ... )
+```
+
+Then run
+
+```bash
+$ sudo mkinitcpio -P
+```
+
+in order to regenerate the initramfs. The device to be unlocked is configured
+on the kernel command line using the `cryptdevice` option in the same way as
+for the default `encrypt` hook:
+
+```bash
+cryptdevice=/dev/sda1:root
+```
+
+In order to use a Tang pin you will need to enable networking in the initramfs
+by adding and configuring the [`net`
+hook](https://wiki.archlinux.org/title/Mkinitcpio#Using_net) *before* the
+`clevis` hook.
+
 #### Unlocker: UDisks2
 
 Our UDisks2 unlocker runs in your desktop session. You should not need to

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,3 @@
 option('user', type: 'string', value: 'clevis', description: 'Unprivileged user for secure clevis operations')
 option('group', type: 'string', value: 'clevis', description: 'Unprivileged group for secure clevis operations')
+option('mkinitcpiodir', type: 'string', description: 'mkinitcpio hooks directory')

--- a/src/meson.build
+++ b/src/meson.build
@@ -2,6 +2,7 @@ subdir('bash')
 subdir('luks')
 subdir('pins')
 subdir('initramfs-tools')
+subdir('mkinitcpio')
 
 bins += join_paths(meson.current_source_dir(), 'clevis-decrypt')
 mans += join_paths(meson.current_source_dir(), 'clevis-decrypt.1')

--- a/src/mkinitcpio/clevis.hooks
+++ b/src/mkinitcpio/clevis.hooks
@@ -1,0 +1,10 @@
+#!/usr/bin/ash
+
+run_hook() {
+    IFS=: read cryptdev cryptname cryptoptions <<EOF
+$cryptdevice
+EOF
+    if resolved=$(resolve_device "${cryptdev}" ${rootdelay}); then
+        clevis luks unlock -d "$resolved" -n "$cryptname"
+    fi
+}

--- a/src/mkinitcpio/clevis.install
+++ b/src/mkinitcpio/clevis.install
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+build() {
+    local mod
+
+    add_module "dm-crypt"
+    add_module "dm-integrity"
+    if [[ $CRYPTO_MODULES ]]; then
+        for mod in $CRYPTO_MODULES; do
+            add_module "$mod"
+        done
+    else
+        add_all_modules "/crypto/"
+    fi
+
+    add_binary "cryptsetup"
+
+    map add_udev_rule \
+        '10-dm.rules' \
+        '13-dm-disk.rules' \
+        '95-dm-notify.rules' \
+        '/usr/lib/initcpio/udev/11-dm-initramfs.rules'
+
+    # cryptsetup calls pthread_create(), which dlopen()s libgcc_s.so.1
+    add_binary "/usr/lib/libgcc_s.so.1"
+
+    add_binary "clevis"
+    add_binary "clevis-decrypt"
+    add_binary "clevis-decrypt-sss"
+    add_binary "clevis-decrypt-tang"
+    add_binary "clevis-decrypt-tpm2"
+    add_binary "clevis-luks-common-functions"
+    add_binary "clevis-luks-unlock"
+
+    add_binary "bash"
+    add_binary "curl"
+    add_binary "grep"
+    add_binary "jose"
+    [ -f "/usr/bin/luksmeta" ] && add_binary "luksmeta"
+
+    if [ -f "/usr/bin/tpm2" ]; then
+        add_checked_modules '/tpm/'
+        add_binary "tpm2_createprimary"
+        add_binary "tpm2_unseal"
+        add_binary "tpm2_load"
+        add_binary "tpm2_flushcontext"
+        add_binary "/usr/lib/libtss2-tcti-device.so.0"
+    fi
+
+    add_runscript
+}
+
+help() {
+    cat <<HELPEOF
+This hook allows to unlock an encrypted root device using Clevis. Users should
+specify the device to be unlocked using 'cryptdevice=device:dmname' on the
+kernel command line, where 'device' is the path to the raw device, and 'dmname'
+is the name given to the device after unlocking, and will be available as
+/dev/mapper/dmname.
+HELPEOF
+}
+
+# vim: set ft=sh ts=4 sw=4 et:

--- a/src/mkinitcpio/meson.build
+++ b/src/mkinitcpio/meson.build
@@ -1,0 +1,11 @@
+mkinitcpio = find_program('mkinitcpio', required: false)
+
+if mkinitcpio.found()
+  install_data(['clevis.install', 'clevis.hooks'],
+               rename: ['install/clevis', 'hooks/clevis'],
+               install_dir: get_option('mkinitcpiodir') != '' ?
+                            get_option('mkinitcpiodir') :
+                            join_paths(get_option('sysconfdir'), 'initcpio'))
+else
+  warning('Will not install mkinitcpio hooks due to missing dependencies!')
+endif


### PR DESCRIPTION
[mkinitcpio](https://wiki.archlinux.org/title/Mkinitcpio) is the default mkinitcpio used by Arch Linux. It can be extended through custom hooks, so provide one that installs all the necessary files for `clevis luks unlock` to function. The device to be unlocked is configured through the [`cryptdevice`](https://wiki.archlinux.org/title/Dm-crypt/System_configuration#cryptdevice) kernel command line option in the same way the built-in `encrypt` mkinitcpio hook works.

Resolves: #334