### PR TITLE
luks-list: show tang key thumbprints

### DIFF
--- a/src/luks/clevis-luks-common-functions.in
+++ b/src/luks/clevis-luks-common-functions.in
@@ -163,6 +163,7 @@ clevis_luks_decode_jwe() {
 clevis_luks_print_pin_config() {
     local P="${1}"
     local decoded="${2}"
+    local THP="${3}"
 
     local content
     if ! content="$(jose fmt -j- -g clevis -g "${P}" -o- <<< "${decoded}")" \
@@ -173,9 +174,15 @@ clevis_luks_print_pin_config() {
     local pin=
     case "${P}" in
     tang)
-        local url
+        local url adv thp
         url="$(jose fmt -j- -g url -u- <<< "${content}")"
-        pin=$(printf '{"url":"%s"}' "${url}")
+        if [ -z "${THP}" ]; then
+            pin=$(printf '{"url":"%s"}' "${url}")
+        else
+            adv="$(jose fmt -j- -g adv -o- <<< "${content}")"
+            thp="$(jose jwk thp -i- <<< "${adv}" | tail -n1)"
+            pin=$(printf '{"url":"%s","thp":"%s"}' "${url}" "${thp}")
+        fi
         printf "tang '%s'" "${pin}"
         ;;
     tpm2)
@@ -195,7 +202,7 @@ clevis_luks_print_pin_config() {
     sss)
         local threshold
         threshold=$(jose fmt -j- -Og t -o- <<< "${content}")
-        clevis_luks_process_sss_pin "${content}" "${threshold}"
+        clevis_luks_process_sss_pin "${content}" "${threshold}" "${THP}"
         ;;
     *)
         printf "unknown pin '%s'" "${P}"
@@ -207,6 +214,7 @@ clevis_luks_print_pin_config() {
 # from it.
 clevis_luks_decode_pin_config() {
     local jwe="${1}"
+    local THP="${2}"
 
     local decoded
     if ! decoded=$(clevis_luks_decode_jwe "${jwe}"); then
@@ -218,7 +226,7 @@ clevis_luks_decode_pin_config() {
         return 1
     fi
 
-    clevis_luks_print_pin_config "${P}" "${decoded}"
+    clevis_luks_print_pin_config "${P}" "${decoded}" "${THP}"
 }
 
 # clevis_luks_join_sss_cfg() will receive a list of configurations for a given
@@ -235,6 +243,7 @@ clevis_luks_join_sss_cfg() {
 clevis_luks_process_sss_pin() {
     local jwe="${1}"
     local threshold="${2}"
+    local THP="${3}"
 
     local sss_tang
     local sss_tpm2
@@ -245,7 +254,7 @@ clevis_luks_process_sss_pin() {
 
     local coded
     for coded in $(jose fmt -j- -Og jwe -Af- <<< "${jwe}"| tr -d '"'); do
-        if ! pin_cfg="$(clevis_luks_decode_pin_config "${coded}")"; then
+        if ! pin_cfg="$(clevis_luks_decode_pin_config "${coded}" "${THP}")"; then
             continue
         fi
         read -r pin cfg <<< "${pin_cfg}"
@@ -286,6 +295,7 @@ clevis_luks_process_sss_pin() {
 clevis_luks_read_pins_from_slot() {
     local DEV="${1}"
     local SLOT="${2}"
+    local THP="${3}"
 
     local jwe
     if ! jwe=$(clevis_luks_read_slot "${DEV}" "${SLOT}" 2>/dev/null); then
@@ -293,7 +303,7 @@ clevis_luks_read_pins_from_slot() {
     fi
 
     local cfg
-    if ! cfg="$(clevis_luks_decode_pin_config "${jwe}")"; then
+    if ! cfg="$(clevis_luks_decode_pin_config "${jwe}" "${THP}")"; then
         return 1
     fi
     printf "%s: %s\n" "${SLOT}" "${cfg}"

--- a/src/luks/clevis-luks-list
+++ b/src/luks/clevis-luks-list
@@ -25,13 +25,15 @@ SUMMARY="Lists pins bound to a LUKSv1 or LUKSv2 device"
 
 function usage() {
     echo >&2
-    echo "Usage: clevis luks list -d DEV [-s SLT]" >&2
+    echo "Usage: clevis luks list -d DEV [-s SLT] [-t]" >&2
     echo >&2
     echo "$SUMMARY": >&2
     echo >&2
     echo "  -d DEV  The LUKS device to list bound pins" >&2
     echo >&2
     echo "  -s SLOT The slot number to list" >&2
+    echo >&2
+    echo "  -t show thumbprints in the output" >&2
     echo >&2
     exit 1
 }
@@ -41,10 +43,11 @@ if [ ${#} -eq 1 ] && [ "${1}" = "--summary" ]; then
     exit 0
 fi
 
-while getopts ":d:s:" o; do
+while getopts ":d:s:t" o; do
     case "$o" in
     d) DEV=${OPTARG};;
     s) SLT=${OPTARG};;
+    t) THP="true";;
     *) usage;;
     esac
 done
@@ -62,7 +65,7 @@ if cryptsetup isLuks --type luks1 "${DEV}"; then
 fi
 
 if [ -n "${SLT}" ]; then
-    clevis_luks_read_pins_from_slot "${DEV}" "${SLT}"
+    clevis_luks_read_pins_from_slot "${DEV}" "${SLT}" "${THP}"
 else
     if ! used_slots=$(clevis_luks_used_slots "${DEV}"); then
         echo "No used slots detected for device ${DEV}!" >&2
@@ -70,7 +73,7 @@ else
     fi
 
     for s in ${used_slots}; do
-        if ! clevis_luks_read_pins_from_slot "${DEV}" "${s}"; then
+        if ! clevis_luks_read_pins_from_slot "${DEV}" "${s}" "${THP}"; then
             continue
         fi
     done


### PR DESCRIPTION
Implements #351, adding the thp to the list output. The displayed thp can be used to fetch the specific stored key from the tang server at `GET /adv/<thp>`.