### PR TITLE
luks-edit: remove unnecessary 2>/dev/null

### DIFF
--- a/src/luks/clevis-luks-edit
+++ b/src/luks/clevis-luks-edit
@@ -174,7 +174,7 @@ rm -rf "${CLEVIS_EDIT_TMP}"
 
 echo "Updating binding..."
 if ! clevis_luks_do_bind "${DEV}" "${SLT}" "" "${pin}" "${new_cfg}" \
-                         "-y" "overwrite" 2>/dev/null; then
+                         "-y" "overwrite"; then
     echo "Unable to update binding in ${DEV}:${SLT}. Operation cancelled." >&2
     exit 1
 fi


### PR DESCRIPTION
This redirection is unnecessary and hides many interesting errors when rebinding
with clevis