### PR TITLE
Added language and misspell check for markdown files

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -2,6 +2,7 @@ name: Spellcheck
 on: 
   push:
     # branches: [main]
+  pull_request:  
 jobs: 
   spell-check:
     name: Language tool & Misspell check

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -16,15 +16,14 @@ jobs:
           # Change reviewdog reporter if you need [github-pr-check,github-check,github-pr-review].
           reporter: github-check
           # Change reporter level if you need.
-          level: info
+          level: warning
           language: en-US
           disabled_categories: 'TYPOS,TYPOGRAPHY,CASING'
           disabled_rules: 'WHITESPACE_RULE,EN_QUOTES,DASH_RULE,WORD_CONTAINS_UNDERSCORE,UPPERCASE_SENTENCE_START,ARROWS,COMMA_PARENTHESIS_WHITESPACE,UNLIKELY_OPENING_PUNCTUATION,SENTENCE_WHITESPACE,CURRENCY,EN_UNPAIRED_BRACKETS,PHRASE_REPETITION,PUNCTUATION_PARAGRAPH_END,METRIC_UNITS_EN_US,ENGLISH_WORD_REPEAT_BEGINNING_RULE,DOUBLE_PUNCTUATION,'
           enabled_only: 'false'
           enabled_rules: ''
           enabled_categories: ''
-          patterns: |
-            "**.md"
+          patterns: "**.md"
             
     
     

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,0 +1,43 @@
+name: Spellcheck
+on: 
+  push:
+    # branches: [main]
+jobs: 
+  spell-check:
+    name: Language tool & Misspell check
+    runs-on: ubuntu-latest
+    steps:
+      - name: check out code
+        uses: actions/checkout@v3
+      - name: running language tool 
+        uses: reviewdog/action-languagetool@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          # Change reviewdog reporter if you need [github-pr-check,github-check,github-pr-review].
+          reporter: github-check
+          # Change reporter level if you need.
+          level: info
+          language: en-US
+          disabled_categories: 'TYPOS,TYPOGRAPHY,CASING'
+          disabled_rules: 'WHITESPACE_RULE,EN_QUOTES,DASH_RULE,WORD_CONTAINS_UNDERSCORE,UPPERCASE_SENTENCE_START,ARROWS,COMMA_PARENTHESIS_WHITESPACE,UNLIKELY_OPENING_PUNCTUATION,SENTENCE_WHITESPACE,CURRENCY,EN_UNPAIRED_BRACKETS,PHRASE_REPETITION,PUNCTUATION_PARAGRAPH_END,METRIC_UNITS_EN_US,ENGLISH_WORD_REPEAT_BEGINNING_RULE,DOUBLE_PUNCTUATION,'
+          enabled_only: 'false'
+          enabled_rules: ''
+          enabled_categories: ''
+          patterns: |
+            "**.md"
+            
+    
+    
+      - name: running misspell
+        # To perform misspell check even after the language tool test fails 
+        if: success() || failure()  
+        uses: reviewdog/action-misspell@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          locale: "US"
+          reporter: github-check
+          level: info
+          pattern: "**.md"
+          exclude: |
+            ./.git/*
+            ./.cache/*

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -57,7 +57,7 @@ $ sudo ninja -C build install
 
 This will install Clevis to a location determined at configure time.
 
-See the output of `meson --help` for the available options. Typically
+See the output of `meson --help` for the available options. Typically,
 much won't be needed besides providing an alternative --prefix option at
 configure time, and maybe DESTDIR at install time if you're packaging for
 a distro.

--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@ advertisement is trusted.
 
 Clevis provides support to encrypt a key in a Trusted Platform Module 2.0 (TPM2)
 chip. The cryptographically-strong, random key used for encryption is encrypted
-using the TPM2 chip, and then at decryption time is decrypted using the TPM2 to
-allow clevis to decrypt the secret stored in the JWE.
+using the TPM2 chip, and is decrypted using TPM2 at the time of decryption to allow clevis to decrypt the secret stored in the JWE.
 
 For example:
 
@@ -164,7 +163,7 @@ initramfs you will need to run:
 sudo update-initramfs -u -k 'all'
 ```
 
-Upon reboot it will behave exactly as if using Dracut.
+Upon reboot, it will behave exactly as if using Dracut.
 
 #### Unlocker: UDisks2
 


### PR DESCRIPTION
## Resolves #407

### Description

Changes proposed in this pull request:

- Added Language Tool
- Added Misspell check

Files Added

    spellcheck.yaml @.github\workflows\

### results
![image](https://github.com/latchset/clevis/assets/100558220/cd46047a-020b-4884-842b-593492e9a7d7)

![image](https://github.com/latchset/clevis/assets/100558220/15c4c62a-33a0-4f09-aa7a-3ae357863a76)

![image](https://github.com/latchset/clevis/assets/100558220/b57e98f8-3966-4737-ad94-86dfcc80a557)

currently level is set to `warning` so that it doesnt stops the PR and CI will succeed with info shown as warning . Can be changed to `error` if required 

