### PR TITLE
Fix killing of child process of clevisloop

### DIFF
--- a/src/initramfs-tools/scripts/local-bottom/clevis.in
+++ b/src/initramfs-tools/scripts/local-bottom/clevis.in
@@ -34,8 +34,10 @@ esac
 [ -s /run/clevis.pid ] || exit 0
 
 pid=$(cat /run/clevis.pid)
-ps -l | awk -v pid="$pid" '$4==pid { system("kill " $3) }'
-kill "$pid"
+child_pids=$(ps -o pid,ppid | awk -v pid="$pid" '$2==pid { print $1 }')
+for kill_pid in $pid $child_pids; do
+	kill "$kill_pid"
+done
 
 # Not really worried about downing extra interfaces: they will come up
 # during the actual boot. Might make this configurable later if needed.


### PR DESCRIPTION
The usage of `ps -l` is fragile and does not always return the expected set of columns. It differs even between several BusyBox versions and operating systems. Use `ps -o pid,ppid` to get the expected set of columns instead.

Also kill parent first before its children to prevent spawning another command from clevisloop itself.

Fixes #448