### PR TITLE
Upgrade checkout version (v3->v4)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           - debian:testing
           - debian:latest
           - ubuntu:rolling
-          - ubuntu:bionic
+          - ubuntu:latest
         stable: [true]
         include:
           - os: quay.io/fedora/fedora:rawhide
@@ -30,7 +30,7 @@ jobs:
           - os: ubuntu:devel
             stable: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Show OS information
         run: cat /etc/os-release 2>/dev/null || echo /etc/os-release not available

--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: running language tool 
         uses: reviewdog/action-languagetool@v1
         with:


### PR DESCRIPTION
Upgrade version of checkout Github action
from v3 to v4, as v4 is based on Node20

Resolves: #451