### PR TITLE
Fix 2 GitHub Actions issues

### DIFF
--- a/.github/workflows/install-dependencies
+++ b/.github/workflows/install-dependencies
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-COMMON="meson curl git make file bzip2 jose tang cryptsetup keyutils jq socat ${CC}"
+COMMON="meson curl git make file bzip2 jose tang cryptsetup keyutils jq socat lsof ${CC}"
 
 case "${DISTRO}" in
 debian:*|ubuntu:*)
@@ -33,7 +33,7 @@ debian:*|ubuntu:*)
     printf 'max_parallel_downloads=10\nfastestmirror=1\n' >> /etc/dnf/dnf.conf
     dnf -y clean all
     dnf -y --setopt=deltarpm=0 update
-    dnf -y install dnf-utils jq socat cryptsetup keyutils cracklib-dicts
+    dnf -y install dnf-utils jq socat cryptsetup keyutils cracklib-dicts lsof
     dnf -y builddep clevis
     ;;
 

--- a/.github/workflows/install-dependencies
+++ b/.github/workflows/install-dependencies
@@ -33,7 +33,7 @@ debian:*|ubuntu:*)
     printf 'max_parallel_downloads=10\nfastestmirror=1\n' >> /etc/dnf/dnf.conf
     dnf -y clean all
     dnf -y --setopt=deltarpm=0 update
-    dnf -y install dnf-utils jq socat cryptsetup keyutils
+    dnf -y install dnf-utils jq socat cryptsetup keyutils cracklib-dicts
     dnf -y builddep clevis
     ;;
 

--- a/src/luks/tests/assume-yes
+++ b/src/luks/tests/assume-yes
@@ -33,8 +33,8 @@ trap 'on_exit' ERR
 
 TMP="$(mktemp -d)"
 
-port=$(tang_new_random_port)
-tang_run "${TMP}" "${port}"
+tang_run "${TMP}"
+port=$(tang_get_port "${TMP}")
 
 url="http://localhost:${port}"
 cfg=$(printf '{"url":"%s"}' "$url")

--- a/src/luks/tests/assume-yes-luks2
+++ b/src/luks/tests/assume-yes-luks2
@@ -33,8 +33,8 @@ trap 'on_exit' ERR
 
 TMP="$(mktemp -d)"
 
-port=$(tang_new_random_port)
-tang_run "${TMP}" "${port}"
+tang_run "${TMP}"
+port=$(tang_get_port "${TMP}")
 
 url="http://localhost:${port}"
 cfg=$(printf '{"url":"%s"}' "$url")

--- a/src/luks/tests/bind-binary-keyfile-luks1
+++ b/src/luks/tests/bind-binary-keyfile-luks1
@@ -33,8 +33,8 @@ trap 'on_exit' EXIT
 
 TMP="$(mktemp -d)"
 
-port=$(tang_new_random_port)
-tang_run "${TMP}" "${port}"
+tang_run "${TMP}"
+port=$(tang_get_port "${TMP}")
 
 url="http://localhost:${port}"
 ADV="${TMP}/adv.jws"

--- a/src/luks/tests/bind-luks1-avoid-luksmeta-corruption
+++ b/src/luks/tests/bind-luks1-avoid-luksmeta-corruption
@@ -37,8 +37,9 @@ DEV="${TMP}/luks1-device"
 new_device "luks1" "${DEV}"
 
 # TANG server specifics
-port=$(tang_new_random_port)
-tang_run "${TMP}" "${port}"
+tang_run "${TMP}"
+port=$(tang_get_port "${TMP}")
+
 url="http://localhost:${port}"
 
 # Initial binding to ensure luksmeta gets corrupted

--- a/src/luks/tests/edit-tang-luks1
+++ b/src/luks/tests/edit-tang-luks1
@@ -36,8 +36,8 @@ trap 'on_exit' ERR
 
 TMP="$(mktemp -d)"
 
-port=$(tang_new_random_port)
-tang_run "${TMP}" "${port}"
+tang_run "${TMP}"
+port=$(tang_get_port "${TMP}")
 
 url="http://localhost:${port}"
 
@@ -64,9 +64,9 @@ fi
 
 # Now let's have another tang instance running and change the config to use
 # the new one.
-port2=$(tang_new_random_port)
 TMP2="$(mktemp -d)"
-tang_run "${TMP2}" "${port2}"
+tang_run "${TMP2}"
+port2=$(tang_get_port "${TMP2}")
 new_url="http://localhost:${port2}"
 new_cfg=$(printf '{"url":"%s"}' "${new_url}")
 

--- a/src/luks/tests/edit-tang-luks2
+++ b/src/luks/tests/edit-tang-luks2
@@ -36,8 +36,8 @@ trap 'on_exit' ERR
 
 TMP="$(mktemp -d)"
 
-port=$(tang_new_random_port)
-tang_run "${TMP}" "${port}"
+tang_run "${TMP}"
+port=$(tang_get_port "${TMP}")
 
 url="http://localhost:${port}"
 
@@ -64,9 +64,9 @@ fi
 
 # Now let's have another tang instance running and change the config to use
 # the new one.
-port2=$(tang_new_random_port)
 TMP2="$(mktemp -d)"
-tang_run "${TMP2}" "${port2}"
+tang_run "${TMP2}"
+port2=$(tang_get_port "${TMP2}")
 new_url="http://localhost:${port2}"
 new_cfg=$(printf '{"url":"%s"}' "${new_url}")
 

--- a/src/luks/tests/pass-tang-luks1
+++ b/src/luks/tests/pass-tang-luks1
@@ -32,8 +32,8 @@ trap 'on_exit' EXIT
 
 TMP=$(mktemp -d)
 
-port=$(tang_new_random_port)
-tang_run "${TMP}" "${port}"
+tang_run "${TMP}"
+port=$(tang_get_port "${TMP}")
 
 url="http://localhost:${port}"
 adv="${TMP}/adv"

--- a/src/luks/tests/pass-tang-luks2
+++ b/src/luks/tests/pass-tang-luks2
@@ -32,8 +32,8 @@ trap 'on_exit' EXIT
 
 TMP=$(mktemp -d)
 
-port=$(tang_new_random_port)
-tang_run "${TMP}" "${port}"
+tang_run "${TMP}"
+port=$(tang_get_port "${TMP}")
 
 url="http://localhost:${port}"
 adv="${TMP}/adv"

--- a/src/luks/tests/regen-inplace-luks1
+++ b/src/luks/tests/regen-inplace-luks1
@@ -32,8 +32,8 @@ trap 'on_exit' EXIT
 
 TMP=$(mktemp -d)
 
-port=$(tang_new_random_port)
-tang_run "${TMP}" "${port}"
+tang_run "${TMP}"
+port=$(tang_get_port "${TMP}")
 
 url="http://localhost:${port}"
 adv="${TMP}/adv"

--- a/src/luks/tests/regen-inplace-luks2
+++ b/src/luks/tests/regen-inplace-luks2
@@ -32,8 +32,8 @@ trap 'on_exit' EXIT
 
 TMP=$(mktemp -d)
 
-port=$(tang_new_random_port)
-tang_run "${TMP}" "${port}"
+tang_run "${TMP}"
+port=$(tang_get_port "${TMP}")
 
 url="http://localhost:${port}"
 adv="${TMP}/adv"

--- a/src/luks/tests/regen-not-inplace-luks1
+++ b/src/luks/tests/regen-not-inplace-luks1
@@ -32,8 +32,8 @@ trap 'on_exit' EXIT
 
 export TMP=$(mktemp -d)
 
-port=$(tang_new_random_port)
-tang_run "${TMP}" "${port}"
+tang_run "${TMP}"
+port=$(tang_get_port "${TMP}")
 
 url="http://localhost:${port}"
 adv="${TMP}/adv"

--- a/src/luks/tests/regen-not-inplace-luks2
+++ b/src/luks/tests/regen-not-inplace-luks2
@@ -32,8 +32,8 @@ trap 'on_exit' EXIT
 
 export TMP=$(mktemp -d)
 
-port=$(tang_new_random_port)
-tang_run "${TMP}" "${port}"
+tang_run "${TMP}"
+port=$(tang_get_port "${TMP}")
 
 url="http://localhost:${port}"
 adv="${TMP}/adv"

--- a/src/luks/tests/report-sss-luks1
+++ b/src/luks/tests/report-sss-luks1
@@ -32,8 +32,8 @@ trap 'on_exit' EXIT
 
 TMP=$(mktemp -d)
 
-port=$(tang_new_random_port)
-tang_run "${TMP}" "${port}"
+tang_run "${TMP}"
+port=$(tang_get_port "${TMP}")
 
 url="http://localhost:${port}"
 adv="${TMP}/adv"

--- a/src/luks/tests/report-sss-luks2
+++ b/src/luks/tests/report-sss-luks2
@@ -32,8 +32,8 @@ trap 'on_exit' EXIT
 
 TMP=$(mktemp -d)
 
-port=$(tang_new_random_port)
-tang_run "${TMP}" "${port}"
+tang_run "${TMP}"
+port=$(tang_get_port "${TMP}")
 
 url="http://localhost:${port}"
 adv="${TMP}/adv"

--- a/src/luks/tests/report-tang-luks1
+++ b/src/luks/tests/report-tang-luks1
@@ -32,8 +32,8 @@ trap 'on_exit' EXIT
 
 TMP=$(mktemp -d)
 
-port=$(tang_new_random_port)
-tang_run "${TMP}" "${port}"
+tang_run "${TMP}"
+port=$(tang_get_port "${TMP}")
 
 url="http://localhost:${port}"
 adv="${TMP}/adv"

--- a/src/luks/tests/report-tang-luks2
+++ b/src/luks/tests/report-tang-luks2
@@ -32,8 +32,8 @@ trap 'on_exit' EXIT
 
 TMP=$(mktemp -d)
 
-port=$(tang_new_random_port)
-tang_run "${TMP}" "${port}"
+tang_run "${TMP}"
+port=$(tang_get_port "${TMP}")
 
 url="http://localhost:${port}"
 adv="${TMP}/adv"

--- a/src/luks/tests/unlock-arbitrary-parameter
+++ b/src/luks/tests/unlock-arbitrary-parameter
@@ -30,8 +30,8 @@ trap 'on_exit' ERR
 
 TMP="$(mktemp -d)"
 
-port=$(tang_new_random_port)
-tang_run "${TMP}" "${port}"
+tang_run "${TMP}"
+port=$(tang_get_port "${TMP}")
 
 url="http://localhost:${port}"
 adv="${TMP}/adv"

--- a/src/luks/tests/unlock-tang-luks1
+++ b/src/luks/tests/unlock-tang-luks1
@@ -33,8 +33,8 @@ trap 'on_exit' ERR
 
 TMP="$(mktemp -d)"
 
-port=$(tang_new_random_port)
-tang_run "${TMP}" "${port}"
+tang_run "${TMP}"
+port=$(tang_get_port "${TMP}")
 
 url="http://localhost:${port}"
 adv="${TMP}/adv"

--- a/src/luks/tests/unlock-tang-luks2
+++ b/src/luks/tests/unlock-tang-luks2
@@ -33,8 +33,8 @@ trap 'on_exit' ERR
 
 TMP="$(mktemp -d)"
 
-port=$(tang_new_random_port)
-tang_run "${TMP}" "${port}"
+tang_run "${TMP}"
+port=$(tang_get_port "${TMP}")
 
 url="http://localhost:${port}"
 adv="${TMP}/adv"

--- a/src/pins/tang/tests/default-thp-alg
+++ b/src/pins/tang/tests/default-thp-alg
@@ -34,8 +34,8 @@ trap 'on_exit' EXIT
 
 TMP="$(mktemp -d)"
 
-port=$(tang_new_random_port)
-tang_run "${TMP}" "${port}"
+tang_run "${TMP}"
+port=$(tang_get_port "${TMP}")
 
 url="http://localhost:${port}"
 data="just a sample text"

--- a/src/pins/tang/tests/pin-tang
+++ b/src/pins/tang/tests/pin-tang
@@ -31,9 +31,8 @@ trap 'on_exit' EXIT
 
 TMP="$(mktemp -d)"
 
-port=$(tang_new_random_port)
-
-tang_run "${TMP}" "${port}" sig exc
+tang_run "${TMP}" sig exc
+port=$(tang_get_port "${TMP}")
 
 thp="$(jose jwk thp -i "$TMP/db/sig.jwk")"
 adv="${TMP}/adv.jws"

--- a/src/pins/tang/tests/tang-common-test-functions.in
+++ b/src/pins/tang/tests/tang-common-test-functions.in
@@ -56,12 +56,6 @@ tang_create_adv() {
                        --key="${SIG}" --output="${adv}"
 }
 
-# Get a random port to be used with a test tang server.
-tang_new_random_port() {
-    tang_sanity_check
-    shuf -i 1024-65535 -n 1
-}
-
 # Removes tang rotated keys from the test server.
 tang_remove_rotated_keys() {
     tang_sanity_check
@@ -112,19 +106,30 @@ tang_new_keys() {
     return 0
 }
 
+# Find listening port of a process
+tang_find_port() {
+    local pid="${1}"
+
+    [ -z "${pid}" ] && \
+        tang_error "tang_find_port: please specify 'pid'"
+
+    local port
+    port=$(lsof -Pan -p "${pid}" -iTCP -sTCP:LISTEN -Fn | grep '^n.*:' | cut -d: -f2)
+    [ -n "${port}" ] && echo "${port}"
+}
+
 # Wait for the tang server to be operational.
 tang_wait_until_ready() {
     tang_sanity_check
-    local port="${1}"
+    local pid="${1}"
 
-    [ -z "${port}" ] && \
-        tang_error "tang_wait_until_ready: please specify 'port'"
+    [ -z "${pid}" ] && \
+        tang_error "tang_wait_until_ready: please specify 'pid'"
 
     local max_timeout_in_s=5
     local start elapsed
     start="${SECONDS}"
-    while ! curl --output /dev/null --silent --fail \
-                "http://localhost:${port}/adv"; do
+    while ! tang_find_port "${pid}" >/dev/null; do
         elapsed=$((SECONDS - start))
         if [ "${elapsed}" -gt "${max_timeout_in_s}" ]; then
             tang_error "Timeout (${max_timeout_in_s}s) waiting for tang server"
@@ -138,12 +143,10 @@ tang_wait_until_ready() {
 tang_run() {
     tang_sanity_check
     local basedir="${1}"
-    local port="${2}"
-    local sig_name="${3:-}"
-    local exc_name="${4:-}"
+    local sig_name="${2:-}"
+    local exc_name="${3:-}"
 
     [ -z "${basedir}" ] && tang_error "tang_run: please specify 'basedir'"
-    [ -z "${port}" ] && tang_error "tang_run: please specify 'port'"
 
     if ! tang_new_keys "${basedir}" "" "${sig_name}" "${exc_name}"; then
         tang_error "Error creating new keys for tang server"
@@ -152,15 +155,17 @@ tang_run() {
     local KEYS="${basedir}/cache"
     [ -z "${TANGD_UPDATE}" ] && KEYS="${basedir}/db"
 
-    local pid pidfile
+    local pid pidfile portfile
     pidfile="${basedir}/tang.pid"
+    portfile="${basedir}/tang.port"
 
-    "${SOCAT}" -v -v TCP-LISTEN:${port},reuseaddr,fork \
+    "${SOCAT}" -v -v TCP4-LISTEN:0,reuseaddr,fork \
                exec:"${TANGD} ${KEYS}" &
-
     pid=$!
+
     echo "${pid}" > "${pidfile}"
-    tang_wait_until_ready "${port}"
+    tang_wait_until_ready "${pid}"
+    tang_find_port "${pid}" > "${portfile}"
 }
 
 # Stop tang server.
@@ -172,9 +177,23 @@ tang_stop() {
     local pidfile="${basedir}/tang.pid"
     [ -f "${pidfile}" ] || return 0
 
+    local portfile="${basedir}/tang.port"
+
     local pid
     pid=$(<"${pidfile}")
     kill -9 "${pid}" 2>/dev/null || :
+    rm -f "${portfile}"
+    rm -f "${pidfile}"
+}
+
+tang_get_port() {
+    local basedir="${1}"
+    [ -z "${basedir}" ] && tang_error "tang_get_port: please specify 'basedir'"
+
+    local portfile="${basedir}/tang.port"
+    [ -f "${portfile}" ] || tang_error "tang_get_port: tang is not running"
+
+    cat "${portfile}"
 }
 
 # Get tang advertisement.
@@ -188,13 +207,23 @@ tang_get_adv() {
 }
 
 run_test_server() {
+    local basedir="${1}"
     local port="${1}"
     local response="${2}"
 
     [ -z "${SOCAT}" ] && tang_skip "run_test_server: socat is not available"
+    [ -z "${basedir}" ] && tang_error "run_test_server: please specify 'basedir'"
     [ -z "${port}" ] && tang_error "run_test_server: please specify 'port'"
     [ -z "${response}" ] && tang_error "run_test_server: please specify 'response'"
 
-    "${SOCAT}" -v -v TCP-LISTEN:${port},reuseaddr SYSTEM:"cat ${response}" &
-    sleep 1
+    local pid pidfile portfile
+    pidfile="${basedir}/tang.pid"
+    portfile="${basedir}/tang.port"
+
+    "${SOCAT}" -v -v TCP4-LISTEN:0,reuseaddr,bind=localhost SYSTEM:"cat ${response}" &
+    pid=$!
+
+    echo "${pid}" > "${pidfile}"
+    tang_wait_until_ready "${pid}"
+    tang_find_port "${pid}" > "${portfile}"
 }

--- a/src/pins/tang/tests/tang-validate-adv
+++ b/src/pins/tang/tests/tang-validate-adv
@@ -22,17 +22,21 @@
 
 on_exit() {
     local exit_status=$?
-    tang_stop "${TMP}"
-    [ -d "${TMP}" ] && rm -rf "${TMP}"
+    for d in "${TMP}" "${TMP2}"; do
+        [ ! -d "${d}" ] && continue
+        tang_stop "${d}"
+        rm -rf "${d}"
+    done
     exit "${exit_status}"
 }
 
 do_test() {
-    local port="${1}"
-    local response="${2}"
-    local stderr="${3:-/dev/stderr}"
+    local response="${1}"
+    local stderr="${2:-/dev/stderr}"
+    local port
 
-    run_test_server "${port}" "${response}"
+    run_test_server "${TMP2}" "${response}"
+    port=$(tang_get_port "${TMP2}")
     cfg="$(printf '{"url":"localhost:%d"}' "${port}")"
     if ! echo foo | clevis encrypt tang "${cfg}" -y 2>"${stderr}"; then
         echo "Error (do_test) response: ${response}" >&2
@@ -42,11 +46,10 @@ do_test() {
 }
 
 do_test_with_adv() {
-    local port="${1}"
-    local adv="${2}"
-    local stderr="${3:-/dev/stderr}"
+    local adv="${1}"
+    local stderr="${2:-/dev/stderr}"
 
-    cfg="$(printf '{"url":"localhost:%d","adv":"%s"}' "${port}" "${adv}")"
+    cfg="$(printf '{"url":"127.1.2.3:1234","adv":"%s"}' "${adv}")"
     if ! echo foo-adv | clevis encrypt tang "${cfg}" 2>"${stderr}"; then
         echo "Error (do_test_with_adv) adv: ${adv} response: ${response}" >&2
         [ -r "${stderr}" ] && cat "${stderr}" >&2
@@ -64,10 +67,10 @@ validate_output() {
 trap 'on_exit' EXIT
 
 TMP="$(mktemp -d)"
+TMP2="$(mktemp -d)"
+
 CASES="${TMP}/cases"
 mkdir -p "${CASES}"
-
-port=$(tang_new_random_port)
 
 # Let's test server responses.
 # Case 1 - regular advertisement - PASS.
@@ -109,29 +112,28 @@ HTTP/1.0 500 Internal Server Error
 EOF
 
 for c in "${CASES}"/good-*; do
-    port=$(tang_new_random_port)
     STDERR="${c}".stderr
-    do_test "${port}" "${c}" "${STDERR}"
+    do_test "${c}" "${STDERR}"
     validate_output "${STDERR}"
 done
 
 # Tests where bind is expected to fail (validate is still expected to succeed).
 for c in "${CASES}"/bad-*; do
-    port=$(tang_new_random_port)
     STDERR="${c}".stderr
-    ! do_test "${port}" "${c}" "${STDERR}"
+    ! do_test "${c}" "${STDERR}"
     validate_output "${STDERR}"
 done
 
 # Now let's do some tests passing "adv" in the configuration.
 STDERR="${CASES}"/stderr
 for adv in "[]" "]" "" "{}"; do
-    ! do_test_with_adv "${port}" "${adv}" "${STDERR}"
+    ! do_test_with_adv "${adv}" "${STDERR}"
     validate_output "${STDERR}"
 done
 
 # Now let's use existing files as well.
-tang_run "${TMP}" "${port}"
+tang_run "${TMP}"
+port=$(tang_get_port "${TMP}")
 
 touch "${CASES}"/adv-bad-01
 echo '{' > "${CASES}"/adv-bad-02
@@ -141,13 +143,13 @@ tang_get_adv "${port}" "${CASES}"/adv-good-01
 # Tests where bind is expected to pass.
 for adv in "${CASES}"/adv-good-*; do
     STDERR="${adv}".stderr
-    do_test_with_adv "${port}" "${adv}" "${STDERR}"
+    do_test_with_adv "${adv}" "${STDERR}"
     validate_output "${STDERR}"
 done
 
 # Tests where bind is expected to fail. validate still should pass.
 for adv in "${CASES}"/adv-bad-*; do
     STDERR="${adv}".stderr
-    ! do_test_with_adv "${port}" "${adv}" "${STDERR}"
+    ! do_test_with_adv "${adv}" "${STDERR}"
     validate_output "${STDERR}"
 done


### PR DESCRIPTION
There are currently two build [failures](https://github.com/latchset/clevis/actions/runs/8961382072/job/24608935028):

* build on fedora fails, because the `pw_dict.pwd` is missing:

  ```
  {"payload": "eyJrZXlzIjogW3siYWxnIjogIkVDTVIiLCAiY3J2IjogIlAtNTIxIiwgImtleV9vcHMiOiBbImRlcml2ZUtleSJdLCAia3R5IjogIkVDIiwgIngiOiAiQVJJUHhCUEY5TzR1VnZ2d19IWjg3bW51c0xQd2JLYUNQN0tCSW51azA0Wk43X0JnQUVZRUdjcGZiZXdVU29XU0RkQXpKRnVjSFBmNzVaeWY4Rno5anAybiIsICJ5IjogIkFHeHFtYldLNFdZalN2SzBxbXF6VE9NT0RsTkZLV3BnVUxhYjlueDBSRlNTck4tb1JQazFMUUNQdDhQY3ZWb3BxSlNCVWMwc1hIcW4tVGVKLUtZMW43MmIifSwgeyJhbGciOiAiRVM1MTIiLCAiY3J2IjogIlAtNTIxIiwgImtleV9vcHMiOiBbInZlcmlmeSJdLCAia3R5IjogIkVDIiwgIngiOiAiQVdQRkdLVnZ5azVMX2N6SlZXUVA2b1N6LVhGRmpHeEFRY1NnLXRral9Kcjl0am9wUWFsSUZzRGlndHdkeG1kQm5mY1dVM1pxajZPYl9zd0xwZG5hR2o2NSIsICJ5IjogIkFBSllBLVdsSU5xc210MFZjcE8yRDhkSWRkYmtuMjN2dmVPS0RzOUhIZkNFT1ZkVUtZbUN5QlBUc1p5enlKMmFBc3lDQXNXTFdDWm9mWE1ENm1SWHpmRmQifV19", "protected": "***", "signature": "ASnzLij7bI7GUGqlaa3Qn1W5DGSy84sGmz3KHAj__hMhfRJl1ulnm9GZxOiFKjF3WcdUsT3O3W72jaE6t2iPSzOuAZNc2BIimb8CBCc67hRZjW1IVqat4lKovc175swLDWZFowA2l1_zMHpuGClLRuyr2qQsvbiPqMncVD9AQ1q3xKV_"}/usr/share/cracklib/pw_dict.pwd.gz: No such file or directory
  ```

  This can be fixed by installing `cracklib-dicts`.

* sometimes the `tang_new_random_port` function returns already used port:

  ```
  + /usr/bin/socat -v -v TCP-LISTEN:42870,reuseaddr,fork 'exec:/usr/libexec/tangd /tmp/tmp.J2NzGGyhIB/db'
  2024/05/05 21:54:07 socat[13293] E bind(5, {AF=2 0.0.0.0:42870}, 16): Address already in use
  ```

  This can be fixed by letting the system assign the port and then finding it with `lsof`.