### PR TITLE
Add support for ZFS encryption

### DIFF
--- a/dracut/60clevis-zfs/clevis-zfs-hook.sh
+++ b/dracut/60clevis-zfs/clevis-zfs-hook.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+
+# import the libs now that we know the pool imported
+[ -f /lib/dracut-lib.sh ] && dracutlib=/lib/dracut-lib.sh
+[ -f /usr/lib/dracut/modules.d/99base/dracut-lib.sh ] && dracutlib=/usr/lib/dracut/modules.d/99base/dracut-lib.sh
+# shellcheck source=./lib-zfs.sh.in
+. "$dracutlib"
+
+# load the kernel command line vars
+[ -z "$root" ] && root="$(getarg root=)"
+# If root is not ZFS= or zfs: or rootfstype is not zfs then we are not supposed to handle it.
+[ "${root##zfs:}" = "${root}" ] && [ "${root##ZFS=}" = "${root}" ] && [ "$rootfstype" != "zfs" ] && exit 0
+
+# There is a race between the zpool import and the pre-mount hooks, so we wait for a pool to be imported
+while true; do
+    zpool list -H | grep -q -v '^$' && break
+    [ "$(systemctl is-failed zfs-import-cache.service)" = 'failed' ] && exit 1
+    [ "$(systemctl is-failed zfs-import-scan.service)" = 'failed' ] && exit 1
+    sleep 0.1s
+done
+
+# run this after import as zfs-import-cache/scan service is confirmed good
+# we do not overwrite the ${root} variable, but create a new one, BOOTFS, to hold the dataset
+if [ "${root}" = "zfs:AUTO" ] ; then
+    BOOTFS="$(zpool list -H -o bootfs | awk '$1 != "-" {print; exit}')"
+else
+    BOOTFS="${root##zfs:}"
+    BOOTFS="${BOOTFS##ZFS=}"
+fi
+
+# if pool encryption is active and the zfs command understands '-o encryption'
+if [ "$(zpool list -H -o feature@encryption $(echo "${BOOTFS}" | awk -F\/ '{print $1}'))" = 'active' ]; then
+    # if the root dataset has encryption enabled
+    ENCRYPTIONROOT=$(zfs get -H -o value encryptionroot "${BOOTFS}")
+    # where the key is stored (in a file or loaded via prompt)
+    KEYLOCATION=$(zfs get -H -o value keylocation "${ENCRYPTIONROOT}")
+    if ! [ "${ENCRYPTIONROOT}" = "-" ]; then
+        KEYSTATUS="$(zfs get -H -o value keystatus "${ENCRYPTIONROOT}")"
+        # continue only if the key needs to be loaded
+        [ "$KEYSTATUS" = "unavailable" ] || exit 0
+        # decrypt them
+        TRY_COUNT=5
+        while [ $TRY_COUNT -gt 0 ]; do
+	    echo >&2 "Attempting to unlock with clevis-zfs-unlock; ${TRY_COUNT} attempts left..."
+	    clevis-zfs-unlock -d "${ENCRYPTIONROOT}" && break
+            TRY_COUNT=$((TRY_COUNT - 1))
+        done
+    fi
+fi
+
+
+

--- a/dracut/60clevis-zfs/module-setup.sh
+++ b/dracut/60clevis-zfs/module-setup.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# vim: set tabstop=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
+#
+# Copyright (c) 2016 Red Hat, Inc.
+# Author: Nathaniel McCallum <npmccallum@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+depends() {
+    # do we have a hard dependency on systemd?
+    echo zfs systemd
+    return 255
+}
+
+install() {
+    inst_multiple \
+        /etc/services \
+        grep sed cut \
+        clevis-decrypt \
+        clevis-zfs-common \
+        clevis-zfs-unlock \
+        clevis-zfs-list \
+        clevis \
+        mktemp \
+        jose
+
+    inst_hook pre-mount 90 "${moddir}/clevis-zfs-hook.sh"
+
+    dracut_need_initqueue
+}

--- a/src/initramfs-tools/hooks/clevis-zfs.in
+++ b/src/initramfs-tools/hooks/clevis-zfs.in
@@ -53,7 +53,7 @@ copy_exec @bindir@/clevis-decrypt-tang || die 1 "@bindir@/clevis-decrypt-tang no
 copy_exec @bindir@/clevis-decrypt-sss || die 1 "@bindir@/clevis-decrypt-sss not found"
 copy_exec @bindir@/clevis-decrypt-null || die 1 "@bindir@/clevis-decrypt-null not found"
 copy_exec @bindir@/clevis-decrypt || die 1 "@bindir@/clevis-decrypt not found"
-copy_exec @bindir@/clevis-zfs-common || die 1 "@bindir@/clevis-zfs-common not found"
+copy_exec @libexecdir@/clevis-zfs-common || die 1 "@libexecdir@/clevis-zfs-common not found"
 copy_exec @bindir@/clevis-zfs-unlock || die 1 "@bindir@/clevis-zfs-unlock not found"
 if [ -x @bindir@/clevis-decrypt-tpm2 ]; then
     copy_exec @bindir@/clevis-decrypt-tpm2 || die 1 "@bindir@/clevis-decrypt-tpm2 not found"

--- a/src/initramfs-tools/hooks/clevis-zfs.in
+++ b/src/initramfs-tools/hooks/clevis-zfs.in
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
 # Copyright (c) 2017 Shawn Rose
+# Copyright (c) 2024 Joel Low
 # Author: Shawn Rose <shawnandrewrose@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
@@ -18,7 +19,7 @@
 #
 
 
-PREREQ="cryptroot"
+PREREQ=""
 prereqs()
 {
      echo "$PREREQ"
@@ -47,21 +48,13 @@ find_binary() {
     echo "$resolved"
 }
 
-if [ -n "${FORCE_CLEVIS}" ] && [ "${FORCE_CLEVIS}" != "n" ]; then
-    for f in /sbin/cryptsetup /sbin/dmsetup /lib/cryptsetup/askpass; do
-        if [ ! -e "${DESTDIR}${f}" ]; then
-            die 2 "cryptsetup utility '$f' wasn't found in the generated ramdisk image. "
-        fi
-    done
-fi    
-
 
 copy_exec @bindir@/clevis-decrypt-tang || die 1 "@bindir@/clevis-decrypt-tang not found"
 copy_exec @bindir@/clevis-decrypt-sss || die 1 "@bindir@/clevis-decrypt-sss not found"
 copy_exec @bindir@/clevis-decrypt-null || die 1 "@bindir@/clevis-decrypt-null not found"
 copy_exec @bindir@/clevis-decrypt || die 1 "@bindir@/clevis-decrypt not found"
-copy_exec @bindir@/clevis-luks-common-functions || die 1 "@bindir@/clevis-luks-common-functions not found"
-copy_exec @bindir@/clevis-luks-list || die 1 "@bindir@/clevis-luks-list not found"
+copy_exec @bindir@/clevis-zfs-common || die 1 "@bindir@/clevis-zfs-common not found"
+copy_exec @bindir@/clevis-zfs-unlock || die 1 "@bindir@/clevis-zfs-unlock not found"
 if [ -x @bindir@/clevis-decrypt-tpm2 ]; then
     copy_exec @bindir@/clevis-decrypt-tpm2 || die 1 "@bindir@/clevis-decrypt-tpm2 not found"
     tpm2_creatprimary_bin=$(find_binary "tpm2_createprimary")
@@ -82,9 +75,7 @@ if [ -x @bindir@/clevis-decrypt-tpm2 ]; then
 fi
 
 
-luksmeta_bin=$(find_binary "luksmeta")
 jose_bin=$(find_binary "jose")
-copy_exec "${luksmeta_bin}" || die 2 "Unable to copy ${luksmeta_bin}"
 copy_exec "${jose_bin}" || die 2 "Unable to copy ${jose_bin}"
 
 

--- a/src/initramfs-tools/hooks/clevis.in
+++ b/src/initramfs-tools/hooks/clevis.in
@@ -61,6 +61,7 @@ copy_exec @bindir@/clevis-decrypt-sss || die 1 "@bindir@/clevis-decrypt-sss not 
 copy_exec @bindir@/clevis-decrypt-null || die 1 "@bindir@/clevis-decrypt-null not found"
 copy_exec @bindir@/clevis-decrypt || die 1 "@bindir@/clevis-decrypt not found"
 copy_exec @bindir@/clevis-luks-common-functions || die 1 "@bindir@/clevis-luks-common-functions not found"
+copy_exec @bindir@/clevis-zfs-common || die 1 "@bindir@/clevis-zfs-common not found"
 copy_exec @bindir@/clevis-luks-list || die 1 "@bindir@/clevis-luks-list not found"
 if [ -x @bindir@/clevis-decrypt-tpm2 ]; then
     copy_exec @bindir@/clevis-decrypt-tpm2 || die 1 "@bindir@/clevis-decrypt-tpm2 not found"

--- a/src/initramfs-tools/hooks/clevis.in
+++ b/src/initramfs-tools/hooks/clevis.in
@@ -62,6 +62,7 @@ copy_exec @bindir@/clevis-decrypt-null || die 1 "@bindir@/clevis-decrypt-null no
 copy_exec @bindir@/clevis-decrypt || die 1 "@bindir@/clevis-decrypt not found"
 copy_exec @bindir@/clevis-luks-common-functions || die 1 "@bindir@/clevis-luks-common-functions not found"
 copy_exec @bindir@/clevis-zfs-common || die 1 "@bindir@/clevis-zfs-common not found"
+copy_exec @bindir@/clevis-zfs-unlock || die 1 "@bindir@/clevis-zfs-unlock not found"
 copy_exec @bindir@/clevis-luks-list || die 1 "@bindir@/clevis-luks-list not found"
 if [ -x @bindir@/clevis-decrypt-tpm2 ]; then
     copy_exec @bindir@/clevis-decrypt-tpm2 || die 1 "@bindir@/clevis-decrypt-tpm2 not found"

--- a/src/initramfs-tools/hooks/meson.build
+++ b/src/initramfs-tools/hooks/meson.build
@@ -1,6 +1,12 @@
 configure_file(
   input: 'clevis.in',
-  output: 'clevis',
+  output: 'clevis-luks',
+  install_dir: initramfs_hooks_dir,
+  configuration: initramfs_data,
+)
+configure_file(
+  input: 'clevis-zfs.in',
+  output: 'clevis-zfs',
   install_dir: initramfs_hooks_dir,
   configuration: initramfs_data,
 )

--- a/src/initramfs-tools/meson.build
+++ b/src/initramfs-tools/meson.build
@@ -4,6 +4,7 @@ if initramfs_tools.found()
   initramfstools_dir = '/usr/share/initramfs-tools'
   initramfs_hooks_dir =  '/usr/share/initramfs-tools/hooks'
   initramfs_scripts_dir = '/usr/share/initramfs-tools/scripts'
+  zfs_initramfs_load_key_scripts_dir = '/etc/zfs/initramfs-tools-load-key.d'
   initramfs_data = configuration_data()
   initramfs_data.merge_from(data)
   initramfs_data.set('initramfstoolsdir', initramfstools_dir)

--- a/src/initramfs-tools/scripts/local-bottom/meson.build
+++ b/src/initramfs-tools/scripts/local-bottom/meson.build
@@ -4,3 +4,9 @@ configure_file(
   install_dir: join_paths(initramfs_scripts_dir, 'local-bottom'),
   configuration: initramfs_data,
 )
+configure_file(
+  input: 'clevis-zfs.in',
+  output: 'clevis-zfs',
+  install_dir: join_paths(initramfs_scripts_dir, 'local-bottom'),
+  configuration: initramfs_data,
+)

--- a/src/initramfs-tools/scripts/local-bottom/meson.build
+++ b/src/initramfs-tools/scripts/local-bottom/meson.build
@@ -4,9 +4,3 @@ configure_file(
   install_dir: join_paths(initramfs_scripts_dir, 'local-bottom'),
   configuration: initramfs_data,
 )
-configure_file(
-  input: 'clevis-zfs.in',
-  output: 'clevis-zfs',
-  install_dir: join_paths(initramfs_scripts_dir, 'local-bottom'),
-  configuration: initramfs_data,
-)

--- a/src/initramfs-tools/scripts/local-top/meson.build
+++ b/src/initramfs-tools/scripts/local-top/meson.build
@@ -4,9 +4,3 @@ configure_file(
   install_dir: join_paths(initramfs_scripts_dir, 'local-top'),
   configuration: initramfs_data,
 )
-configure_file(
-  input: 'clevis-zfs.in',
-  output: 'clevis-zfs',
-  install_dir: join_paths(initramfs_scripts_dir, 'local-top'),
-  configuration: initramfs_data,
-)

--- a/src/initramfs-tools/scripts/local-top/meson.build
+++ b/src/initramfs-tools/scripts/local-top/meson.build
@@ -4,3 +4,9 @@ configure_file(
   install_dir: join_paths(initramfs_scripts_dir, 'local-top'),
   configuration: initramfs_data,
 )
+configure_file(
+  input: 'clevis-zfs.in',
+  output: 'clevis-zfs',
+  install_dir: join_paths(initramfs_scripts_dir, 'local-top'),
+  configuration: initramfs_data,
+)

--- a/src/initramfs-tools/scripts/meson.build
+++ b/src/initramfs-tools/scripts/meson.build
@@ -1,2 +1,3 @@
 subdir('local-top')
 subdir('local-bottom')
+subdir('zfs-load-key')

--- a/src/initramfs-tools/scripts/zfs-load-key/clevis-zfs.in
+++ b/src/initramfs-tools/scripts/zfs-load-key/clevis-zfs.in
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Copyright (c) 2024 Joel Low
+#
+# Author: Joel Low <lowjoel@users.sourceforge.net>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+set -eu
+
+clevis zfs unlock -d "${ENCRYPTIONROOT}"

--- a/src/initramfs-tools/scripts/zfs-load-key/meson.build
+++ b/src/initramfs-tools/scripts/zfs-load-key/meson.build
@@ -1,0 +1,6 @@
+configure_file(
+  input: 'clevis-zfs.in',
+  output: 'clevis-zfs',
+  install_dir: zfs_initramfs_load_key_scripts_dir,
+  configuration: initramfs_data,
+)

--- a/src/meson.build
+++ b/src/meson.build
@@ -2,6 +2,7 @@ subdir('bash')
 subdir('luks')
 subdir('pins')
 subdir('initramfs-tools')
+subdir('zfs')
 
 bins += join_paths(meson.current_source_dir(), 'clevis-decrypt')
 mans += join_paths(meson.current_source_dir(), 'clevis-decrypt.1')

--- a/src/zfs/clevis-zfs-bind
+++ b/src/zfs/clevis-zfs-bind
@@ -91,17 +91,18 @@ main() {
 
 	check_valid_dataset "${dataset}"
 
-	if ! pin=${@:$((OPTIND++)):1} || [ -z "$PIN" ]; then
+	if ! pin=${@:$((OPTIND++)):1} || [ -z "$pin" ]; then
 		error "Did not specify a pin!"
-	elif ! findexe clevis-encrypt-"${PIN}" &>/dev/null; then
-		error "'$PIN' is not a valid pin!"
+	elif ! findexe clevis-encrypt-"${pin}" &>/dev/null; then
+		error "'$pin' is not a valid pin!"
 	fi
 
-	if ! cfg=${@:$((OPTIND++)):1} || [ -z "$CFG" ]; then
+	if ! cfg=${@:$((OPTIND++)):1} || [ -z "$cfg" ]; then
 		error "Did not specify a pin config!"
 	fi
 
 	bind_zfs_dataset "${dataset}" "${pin}" "${cfg}" "${key}" "${overwrite}"
+	echo >&2 "dataset ${dataset} is succesfully bound"
 }
 
 main "${@}"

--- a/src/zfs/clevis-zfs-bind
+++ b/src/zfs/clevis-zfs-bind
@@ -1,0 +1,107 @@
+#!/bin/bash
+set -euo pipefail
+
+. clevis-zfs-common
+
+SUMMARY="Binds a ZFS dataset using the specified policy"
+
+
+
+function usage() {
+	cat >&2 <<-USAGE_END
+		Usage: clevis zfs bind [-f] [-k KEY] -d DATASET PIN CFG
+
+		$SUMMARY:
+
+		  -f          Do not prompt when overwriting configuration
+
+		  -d DATASET  The zfs dataset on which to perform binding
+
+		  -k KEY      Non-interactively read zfs password from KEY file
+		  -k -        Non-interactively read zfs password from standard input
+
+	USAGE_END
+}
+
+
+function bind_zfs_dataset() {
+    local dataset="${1}"
+    local pin="${2}"
+    local cfg="${3}"
+    local key="${4}"
+    local overwrite="${5:-}"
+
+	local existing_key clevis_data
+
+	if [[ -z "${overwrite}" ]] && zfs_is_bound "${dataset}"; then
+		error "given dataset already has a clevis binding, not overwriting: ${dataset}."
+	fi
+
+	existing_key="$(load_key "${dataset}" "${key}")"
+
+	if ! zfs_test_key "${dataset}" <<<"${existing_key}"; then
+		error "given key does not unlock ${dataset}"
+	fi
+
+	echo >&2 -n 'creating new clevis data... '
+	clevis_data="$(clevis encrypt "${pin}" "${cfg}" <<<"${existing_key}" )"
+	echo >&2 'ok'
+
+	[[ -n "${overwrite}" ]] && zfs_wipe_clevis_data "${dataset}" && echo >&2 'wiped old clevis data'
+
+	zfs_bind_clevis_data "${dataset}" "${clevis_data}"
+}
+
+function check_valid_dataset() {
+	local dataset="${1}"
+
+	if ! zfs_get_prop "${dataset}" 'name' -snone &>/dev/null; then
+		error "${dataset} is not a zfs dataset!"
+	fi
+
+	if ! zfs_is_encryptionroot "${dataset}"; then
+		error "given dataset is not an encryptionroot: ${dataset}"
+	fi
+}
+
+main() {
+
+	if [ $# -eq 1 -a "${1:-}" == "--summary" ]; then
+		echo "$SUMMARY"
+		exit 0
+	fi
+
+	local dataset=
+	local pin=
+	local cfg=
+	local key=
+	local overwrite=
+	while getopts ":hfd:k:" o; do
+		case "$o" in
+		f) overwrite='yes' ;;
+		d) dataset="$OPTARG";;
+		k) key="$OPTARG";;
+		*) error "unrecognized argument: -${OPTARG}";;
+		esac
+	done
+
+	if [ -z "${dataset:-""}" ]; then
+		error "did not specify a device!"
+	fi
+
+	check_valid_dataset "${dataset}"
+
+	if ! pin=${@:$((OPTIND++)):1} || [ -z "$PIN" ]; then
+		error "Did not specify a pin!"
+	elif ! findexe clevis-encrypt-"${PIN}" &>/dev/null; then
+		error "'$PIN' is not a valid pin!"
+	fi
+
+	if ! cfg=${@:$((OPTIND++)):1} || [ -z "$CFG" ]; then
+		error "Did not specify a pin config!"
+	fi
+
+	bind_zfs_dataset "${dataset}" "${pin}" "${cfg}" "${key}" "${overwrite}"
+}
+
+main "${@}"

--- a/src/zfs/clevis-zfs-bind
+++ b/src/zfs/clevis-zfs-bind
@@ -21,6 +21,14 @@ function usage() {
 	USAGE_END
 }
 
+findexe() {
+    while read -r -d: path; do
+        [ -f "${path}/${1}" ] && [ -x "${path}/${1}" ] && \
+          echo "${path}/${1}" && return 0
+    done <<< "${PATH}:"
+    return 1
+}
+
 
 function bind_zfs_dataset() {
     local dataset="${1}"
@@ -33,10 +41,10 @@ function bind_zfs_dataset() {
 	local existing_key clevis_data
 
 	if [[ -z "${overwrite}" ]] && zfs_is_bound "${dataset}" "${label}"; then
-		error "given label ${label} in dataset ${dataset} already has a clevis binding, not overwritin."
+		error "given label ${label} in dataset ${dataset} already has a clevis binding, not overwriting."
 	fi
 
-	existing_key="$(read_key "${dataset}" "${key}")"
+	existing_key="$(read_passphrase "${dataset}" "${key}")"
 
 	if ! zfs_test_key "${dataset}" <<<"${existing_key}"; then
 		error "given key does not unlock ${dataset}"
@@ -46,21 +54,9 @@ function bind_zfs_dataset() {
 	clevis_data="$(clevis encrypt "${pin}" "${cfg}" <<<"${existing_key}" )"
 	echo >&2 'ok'
 
-	[[ -n "${overwrite}" ]] && zfs_wipe_clevis_label "${dataset}" "${label}" && echo >&2 'wiped old clevis data'
+	[[ -n "${overwrite}" ]] && zfs_unbind_clevis_label "${dataset}" "${label}" && echo >&2 'unbound old clevis data'
 
-	zfs_bind_clevis_data "${dataset}" "${label}" "${clevis_data}"
-}
-
-function check_valid_dataset() {
-	local dataset="${1}"
-
-	if ! zfs_get_prop "${dataset}" 'name' -snone &>/dev/null; then
-		error "${dataset} is not a zfs dataset!"
-	fi
-
-	if ! zfs_is_encryptionroot "${dataset}"; then
-		error "given dataset is not an encryptionroot: ${dataset}"
-	fi
+	zfs_bind_clevis_label "${dataset}" "${label}" "${clevis_data}"
 }
 
 function main() {

--- a/src/zfs/clevis-zfs-bind
+++ b/src/zfs/clevis-zfs-bind
@@ -106,6 +106,6 @@ function main() {
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-	. clevis-zfs-common
+	. @libexecdir@/clevis-zfs-common
 	main "${@}"
 fi

--- a/src/zfs/clevis-zfs-bind
+++ b/src/zfs/clevis-zfs-bind
@@ -1,11 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-. clevis-zfs-common
 
 SUMMARY="Binds a ZFS dataset using the specified policy"
-
-
 
 function usage() {
 	cat >&2 <<-USAGE_END
@@ -16,6 +13,7 @@ function usage() {
 		  -f          Do not prompt when overwriting configuration
 
 		  -d DATASET  The zfs dataset on which to perform binding
+		  -l LABEL    The label to use for this binding, can use letters, numbers and underscores
 
 		  -k KEY      Non-interactively read zfs password from KEY file
 		  -k -        Non-interactively read zfs password from standard input
@@ -26,18 +24,19 @@ function usage() {
 
 function bind_zfs_dataset() {
     local dataset="${1}"
-    local pin="${2}"
-    local cfg="${3}"
-    local key="${4}"
-    local overwrite="${5:-}"
+	local label="${2}"
+    local pin="${3}"
+    local cfg="${4}"
+    local key="${5}"
+    local overwrite="${6:-}"
 
 	local existing_key clevis_data
 
-	if [[ -z "${overwrite}" ]] && zfs_is_bound "${dataset}"; then
-		error "given dataset already has a clevis binding, not overwriting: ${dataset}."
+	if [[ -z "${overwrite}" ]] && zfs_is_bound "${dataset}" "${label}"; then
+		error "given label ${label} in dataset ${dataset} already has a clevis binding, not overwritin."
 	fi
 
-	existing_key="$(load_key "${dataset}" "${key}")"
+	existing_key="$(read_key "${dataset}" "${key}")"
 
 	if ! zfs_test_key "${dataset}" <<<"${existing_key}"; then
 		error "given key does not unlock ${dataset}"
@@ -47,9 +46,9 @@ function bind_zfs_dataset() {
 	clevis_data="$(clevis encrypt "${pin}" "${cfg}" <<<"${existing_key}" )"
 	echo >&2 'ok'
 
-	[[ -n "${overwrite}" ]] && zfs_wipe_clevis_data "${dataset}" && echo >&2 'wiped old clevis data'
+	[[ -n "${overwrite}" ]] && zfs_wipe_clevis_label "${dataset}" "${label}" && echo >&2 'wiped old clevis data'
 
-	zfs_bind_clevis_data "${dataset}" "${clevis_data}"
+	zfs_bind_clevis_data "${dataset}" "${label}" "${clevis_data}"
 }
 
 function check_valid_dataset() {
@@ -64,22 +63,24 @@ function check_valid_dataset() {
 	fi
 }
 
-main() {
+function main() {
 
-	if [ $# -eq 1 -a "${1:-}" == "--summary" ]; then
+	if [ $# -eq 1 ] && [ "${1:-}" == "--summary" ]; then
 		echo "$SUMMARY"
 		exit 0
 	fi
 
-	local dataset=
-	local pin=
-	local cfg=
-	local key=
-	local overwrite=
-	while getopts ":hfd:k:" o; do
+	local dataset
+	local pin
+	local cfg
+	local label
+	local key
+	local overwrite=''
+	while getopts ":hfd:l:k:" o; do
 		case "$o" in
 		f) overwrite='yes' ;;
 		d) dataset="$OPTARG";;
+		l) label="$OPTARG";;
 		k) key="$OPTARG";;
 		*) error "unrecognized argument: -${OPTARG}";;
 		esac
@@ -91,6 +92,11 @@ main() {
 
 	check_valid_dataset "${dataset}"
 
+	if [ -z "${label:-}" ]; then
+		error "Did not specify a label!"
+	fi
+
+
 	if ! pin=${@:$((OPTIND++)):1} || [ -z "$pin" ]; then
 		error "Did not specify a pin!"
 	elif ! findexe clevis-encrypt-"${pin}" &>/dev/null; then
@@ -101,8 +107,11 @@ main() {
 		error "Did not specify a pin config!"
 	fi
 
-	bind_zfs_dataset "${dataset}" "${pin}" "${cfg}" "${key}" "${overwrite}"
-	echo >&2 "dataset ${dataset} is succesfully bound"
+	bind_zfs_dataset "${dataset}" "${label}" "${pin}" "${cfg}" "${key}" "${overwrite}"
+	echo >&2 "label ${label} on dataset ${dataset} is succesfully bound"
 }
 
-main "${@}"
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	. clevis-zfs-common
+	main "${@}"
+fi

--- a/src/zfs/clevis-zfs-bind
+++ b/src/zfs/clevis-zfs-bind
@@ -70,7 +70,7 @@ function main() {
 	local pin
 	local cfg
 	local label
-	local key
+	local key=''
 	local overwrite=''
 	while getopts ":hfd:l:k:" o; do
 		case "$o" in

--- a/src/zfs/clevis-zfs-bind
+++ b/src/zfs/clevis-zfs-bind
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-
 SUMMARY="Binds a ZFS dataset using the specified policy"
 
 function usage() {
@@ -11,17 +10,16 @@ function usage() {
 		$SUMMARY:
 
 		  -f          Do not prompt when overwriting configuration
+		  -d DATASET  The ZFS dataset on which to perform binding
+		  -l LABEL    The label to use for this binding. Valid characters: letters, numbers and underscores
 
-		  -d DATASET  The zfs dataset on which to perform binding
-		  -l LABEL    The label to use for this binding, can use letters, numbers and underscores
-
-		  -k KEY      Non-interactively read zfs password from KEY file
-		  -k -        Non-interactively read zfs password from standard input
+		  -k KEY      Non-interactively read ZFS password from KEY file
+		  -k -        Non-interactively read ZFS password from standard input
 
 	USAGE_END
 }
 
-findexe() {
+function findexe() {
     while read -r -d: path; do
         [ -f "${path}/${1}" ] && [ -x "${path}/${1}" ] && \
           echo "${path}/${1}" && return 0
@@ -29,19 +27,18 @@ findexe() {
     return 1
 }
 
-
 function bind_zfs_dataset() {
-    local dataset="${1}"
+	local dataset="${1}"
 	local label="${2}"
-    local pin="${3}"
-    local cfg="${4}"
-    local key="${5}"
-    local overwrite="${6:-}"
+	local pin="${3}"
+	local cfg="${4}"
+	local key="${5}"
+	local overwrite="${6:-}"
 
 	local existing_key clevis_data
 
 	if [[ -z "${overwrite}" ]] && zfs_is_bound "${dataset}" "${label}"; then
-		error "given label ${label} in dataset ${dataset} already has a clevis binding, not overwriting."
+		error "given label ${label} in dataset ${dataset} already has a Clevis binding, not overwriting."
 	fi
 
 	existing_key="$(read_passphrase "${dataset}" "${key}")"
@@ -50,8 +47,8 @@ function bind_zfs_dataset() {
 		error "given key does not unlock ${dataset}"
 	fi
 
-	echo >&2 -n 'creating new clevis data... '
-	clevis_data="$(clevis encrypt "${pin}" "${cfg}" <<<"${existing_key}" )"
+	echo >&2 -n 'creating new Clevis data... '
+	clevis_data="$(clevis encrypt "${pin}" "${cfg}" <<<"${existing_key}")"
 	echo >&2 'ok'
 
 	[[ -n "${overwrite}" ]] && zfs_unbind_clevis_label "${dataset}" "${label}" && echo >&2 'unbound old clevis data'
@@ -60,7 +57,6 @@ function bind_zfs_dataset() {
 }
 
 function main() {
-
 	if [ $# -eq 1 ] && [ "${1:-}" == "--summary" ]; then
 		echo "$SUMMARY"
 		exit 0
@@ -74,7 +70,8 @@ function main() {
 	local overwrite=''
 	while getopts ":hfd:l:k:" o; do
 		case "$o" in
-		f) overwrite='yes' ;;
+		h) usage; exit 0;;
+		f) overwrite='yes';;
 		d) dataset="$OPTARG";;
 		l) label="$OPTARG";;
 		k) key="$OPTARG";;
@@ -83,24 +80,25 @@ function main() {
 	done
 
 	if [ -z "${dataset:-""}" ]; then
-		error "did not specify a device!"
+		error "did not specify a dataset!"
 	fi
 
 	check_valid_dataset "${dataset}"
 
 	if [ -z "${label:-}" ]; then
-		error "Did not specify a label!"
+		error "did not specify a label!"
 	fi
 
-
-	if ! pin=${@:$((OPTIND++)):1} || [ -z "$pin" ]; then
-		error "Did not specify a pin!"
+	pin="${*:$((OPTIND++)):1}"
+	if [ -z "$pin" ]; then
+		error "did not specify a pin!"
 	elif ! findexe clevis-encrypt-"${pin}" &>/dev/null; then
 		error "'$pin' is not a valid pin!"
 	fi
 
-	if ! cfg=${@:$((OPTIND++)):1} || [ -z "$cfg" ]; then
-		error "Did not specify a pin config!"
+	cfg="${*:$((OPTIND++)):1}"
+	if [ -z "$cfg" ]; then
+		error "did not specify a pin config!"
 	fi
 
 	bind_zfs_dataset "${dataset}" "${label}" "${pin}" "${cfg}" "${key}" "${overwrite}"

--- a/src/zfs/clevis-zfs-bind
+++ b/src/zfs/clevis-zfs-bind
@@ -20,11 +20,11 @@ function usage() {
 }
 
 function findexe() {
-    while read -r -d: path; do
-        [ -f "${path}/${1}" ] && [ -x "${path}/${1}" ] && \
-          echo "${path}/${1}" && return 0
-    done <<< "${PATH}:"
-    return 1
+	[ $# -eq 1 ] || return 1
+	while read -r -d: path; do
+		[ -f "$path/$1" ] && [ -x "$path/$1" ] && echo "$path/$1" && return 0
+	done <<< "$PATH:"
+	return 1
 }
 
 function bind_zfs_dataset() {
@@ -92,7 +92,7 @@ function main() {
 	pin="${*:$((OPTIND++)):1}"
 	if [ -z "$pin" ]; then
 		error "did not specify a pin!"
-	elif ! findexe clevis-encrypt-"${pin}" &>/dev/null; then
+	elif ! eval "findexe clevis-encrypt-${pin}" &>/dev/null; then
 		error "'$pin' is not a valid pin!"
 	fi
 

--- a/src/zfs/clevis-zfs-common
+++ b/src/zfs/clevis-zfs-common
@@ -132,7 +132,11 @@ function zfs_remove_label() {
 	local labels
 	read -ra labels <<< "$(zfs_get_labels "${dataset}")"
 	local new_labels=( "${labels[@]/${old_label}}" )
-	zfs_set_labels "${dataset}" "${new_labels[*]}"
+	if [[ "${#new_labels}" -eq 0 ]]; then
+		zfs_remove_property "${dataset}" "${zfs_labels_prop}"
+	else
+		zfs_set_labels "${dataset}" "${new_labels[*]}"
+	fi
 }
 
 # functions for checking zfs datasets

--- a/src/zfs/clevis-zfs-common
+++ b/src/zfs/clevis-zfs-common
@@ -1,14 +1,82 @@
 #!/bin/bash
+set -euo pipefail
 
 # zfs user properties are limited to 8192 bytes
 zfs_userprop_max_size=8000
 zfs_userprop_max_size=800 # set smaller to test splitting/combining chunks
 
+# all clevis userprops will be prefixed with "latchset.clevis:" as suggested by
+# the User Properties section in zfsprops(8)
 zfs_userprop_prefix='latchset.clevis'
-zfs_data_prop="${zfs_userprop_prefix}:data"
-zfs_status_prop="${zfs_userprop_prefix}:status"
 
-function load_key() {
+# This contains the space-separated list of labels that have been bound with clevis
+zfs_labels_prop="${zfs_userprop_prefix}:labels"
+
+# The data for each label is saved into one or more zfs properties.
+# E.g. the label 'mybinding' with data of 20k bytes and label 'other' with 4k bytes
+# we suffix the label in the :labels property so we can easily find all numbered parts
+# - latchset.clevis:labels = "mybinding:2 other"
+# - latchset.clevis.label:mybinding-0 = "[clevis data first 8k]"
+# - latchset.clevis.label:mybinding-1 = "[clevis data second 8k]"
+# - latchset.clevis.label:mybinding-2 = "[clevis data final 4k]"
+# - latchset.clevis.label:other = [clevis data 4k]
+zfs_label_prefix="${zfs_userprop_prefix}.label"
+
+
+function zfs_get_labels() {
+	local dataset="${1}"
+	zfs_get_prop "${dataset}" "${zfs_labels_prop}"
+}
+
+function zfs_set_labels() {
+	local dataset="${1}";
+	local new_labels="${2}"
+	echo >&2 "setting new labels: ${new_labels}"
+	zfs set "${zfs_labels_prop}=${new_labels}" "${dataset}"
+}
+
+function zfs_add_label() {
+	local dataset="${1}"
+	local new_label="${2}"
+	local labels=( $(zfs_get_labels "${dataset}") )
+	local labels+=( "${new_label}" )
+	zfs_set_labels "${dataset}" "${labels[*]}"
+}
+
+function zfs_remove_label() {
+	local dataset="${1}"
+	local old_label="${2}"
+	local labels=( $(zfs_get_labels "${dataset}") )
+	local new_labels=( "${labels[@]/${old_label}}" )
+	zfs_set_labels "${dataset}" "${new_labels[*]}"
+}
+
+# valid characters of userprops are: [0-9a-z:._-]
+# valid characters of clevis-zfs labels are: [0-9a-z_]
+function is_valid_label() {
+	local label="${1}"
+	# The length limit is quite arbitrary; but we have to draw the line
+	# somewhere and zfs-user-property names can be at most 256 characters long.
+	# We can't use all 256 characters because we need some space in the
+	# property name for the zfs_label_prefix and the chunk_counter suffix.
+	local limit=100
+	local regex='^[0-9a-z_]+$'
+
+	if [[ "${#label}" -gt "${limit}" ]]; then
+		echo >&2 "label is longer than ${limit}: ${label}"
+		return 1
+	fi
+
+	if [[ "${label}" =~ ${regex} ]]; then
+		return 0
+	else
+		echo >&2 "label is invalid: '${label}'. Expecting an alphanumeric string "
+		return 1
+	fi
+}
+
+
+function read_key() {
 	local dataset="${1}"
 	local key="${2?need keyinput argument}"
 
@@ -50,7 +118,7 @@ zfs_get_prop() {
 	local dataset="${1}"
 	local prop="${2}"
 	shift 2
-	zfs get -H -o value -slocal "${prop}" "${dataset}" "${@}"
+	zfs get "${prop}" "${dataset}" -H -o value -slocal "${@}"
 }
 
 function cut_into_chunks() {
@@ -59,12 +127,21 @@ function cut_into_chunks() {
 
 function zfs_is_bound() {
 	local dataset="${1}"
-	[[ "$(zfs_get_prop "${dataset}" "${zfs_status_prop}" )" == 'bound' ]]
+	local label_to_check="${2:-}"
+	local label="${label_to_check%:*}"
+
+	local labels="$(zfs_get_labels "${dataset}")"
+	if [[ -n "${label}" ]]; then
+		[[ " ${labels} " == *" ${label} "* ]] && return 0
+	else
+		# we don't check for a specific label, just that at least one label is set
+		[[ "${#current_labels[@]}" -gt 0 ]] && return 0
+	fi
+	return 1
 }
 
 function zfs_is_encryptionroot() {
 	local dataset="${1}"
-	zfs_get_prop "${dataset}" 'encryptionroot'
 	[[ "$(zfs_get_prop "${dataset}" 'encryptionroot' -snone )" == "${dataset}" ]]
 }
 
@@ -87,34 +164,43 @@ function zero_pad() {
 
 function zfs_bind_clevis_data() {
 	local dataset="${1}"
-	local clevis_data="${2}"
+	local label="${2}"
+	local clevis_data="${3}"
+
+	local zfs_label_prop="${zfs_label_prefix}:${label}"
 
 	echo >&2 -n 'binding new clevis data... '
-	clevis_chunks=( $(cut_into_chunks <<<"${clevis_data}") )
-	last_index="$(( "${#clevis_chunks[@]}" - 1 ))"
-	width="${#last_index}"
+	# use a single prop without number suffix if it will fit in one prop
+	if [[ "${#clevis_data}" -lt "${zfs_userprop_max_size}" ]]; then
+		zfs set "${zfs_label_prop}=${clevis_data}" "${dataset}"
+	else
+		clevis_chunks=( $(cut_into_chunks <<<"${clevis_data}") )
+		last_index="$(( "${#clevis_chunks[@]}" - 1 ))"
+		width="${#last_index}"
 
-	local chunk chunk_num
-	for i in $(seq 0 "${last_index}" ); do
-		chunk="${clevis_chunks[${i}]}"
-		# we add zero-padding so the props sort nicely when we want to combine
-		# them when we unlock
-		chunk_num="$(zero_pad "${i}" "${width}" )"
+		local chunk chunk_num
+		for i in $(seq 0 "${last_index}" ); do
+			chunk="${clevis_chunks[${i}]}"
+			# we add zero-padding so the props sort nicely when we want to combine
+			# them when we unlock
+			chunk_num="$(zero_pad "${i}" "${width}" )"
 
-		# e.g. latchset.clevis:pin-01=chunk_data
-		zfs set "${zfs_data_prop}-${chunk_num}=${chunk}" "${dataset}"
-	done
+			# e.g. latchset.clevis.label:${label}-01=chunk_data
+			zfs set "${zfs_label_prop}-${chunk_num}=${chunk}" "${dataset}"
+		done
+
+		label="${label}:${last_index}"
+	fi
 	echo >&2 'ok'
 
 	# check if unlocking works
 	echo >&2 -n 'testing new clevis data... '
-	if ! (zfs_get_clevis_data "${dataset}" | clevis decrypt | zfs_test_key "${dataset}"); then
-		zfs_wipe_clevis_data "${dataset}"
+	if ! (zfs_get_clevis_label "${dataset}" "${label}" | clevis decrypt | zfs_test_key "${dataset}"); then
+		zfs_wipe_clevis_label "${dataset}" "${label}"
 		error "could not unlock dataset with clevis configuration: ${dataset}"
 	fi
 	echo >&2 'ok'
-
-	zfs set "${zfs_status_prop}=bound" "${dataset}"
+	zfs_add_label "${dataset}" "${label}"
 }
 
 function zfs_get_data_props() {
@@ -123,18 +209,37 @@ function zfs_get_data_props() {
 	#property HAS to be set, otherwise the grep doesn't work
 	local outputs="${2:-property}"
 
-	zfs_get_prop "${dataset}" 'all' -o "${outputs}" | grep -F "${zfs_data_prop}" | sort
+	zfs_get_prop "${dataset}" 'all' -o "${outputs}" | grep -F "${zfs_label_prefix}" | sort
 }
 
-function zfs_wipe_clevis_data() {
+function zfs_wipe_clevis_label() {
 	local dataset="${1}"
+	local label="${2}"
 
-	for prop in $(zfs_get_prop "${dataset}" 'all' -o property | grep -F "${zfs_userprop_prefix}" ); do
+	local zfs_label_prop="${zfs_label_prefix}:${label}"
+
+	for prop in $(zfs_get_prop "${dataset}" 'all' -o property | grep -F "${zfs_label_prop}" ); do
 		zfs inherit "${prop}" "${dataset}"
 	done
 }
 
-function zfs_get_clevis_data() {
-	local dataset="${1:?}"
-	zfs_get_data_props "${dataset}" 'property,value' | sort | awk '{print $2}' | tr -d '\n'
+function zfs_get_clevis_label() {
+	local dataset="${1}"
+	local label="${2%:*}"
+	local last_index="${2#*:}"
+
+	if [[ -z "${last_index}" ]]; then
+		zfs_label_prop="${zfs_label_prefix}:${label}"
+		zfs_get_prop "${dataset}" "${zfs_label_prop}"
+	else
+		for num in $(seq -w 0 "${last_index}"); do
+			zfs_get_prop "${dataset}" "${zfs_label_prop}-${num}" | tr -d '\n'
+		done
+	fi
 }
+
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	. clevis-zfs-test
+    _test "$@"
+fi

--- a/src/zfs/clevis-zfs-common
+++ b/src/zfs/clevis-zfs-common
@@ -202,7 +202,7 @@ function read_passphrase() {
 function error() {
 	usage
 	echo >&2 -e "ERROR: ${*}"
-    exit 1
+	exit 1
 }
 
 

--- a/src/zfs/clevis-zfs-common
+++ b/src/zfs/clevis-zfs-common
@@ -31,7 +31,6 @@ function zfs_get_labels() {
 function zfs_set_labels() {
 	local dataset="${1}";
 	local new_labels="${2}"
-	echo >&2 "setting new labels: ${new_labels}"
 	zfs set "${zfs_labels_prop}=${new_labels}" "${dataset}"
 }
 
@@ -135,7 +134,7 @@ function zfs_is_bound() {
 		[[ " ${labels} " == *" ${label} "* ]] && return 0
 	else
 		# we don't check for a specific label, just that at least one label is set
-		[[ "${#current_labels[@]}" -gt 0 ]] && return 0
+		[[ "${#labels}" -gt 0 ]] && return 0
 	fi
 	return 1
 }
@@ -146,13 +145,13 @@ function zfs_is_encryptionroot() {
 }
 
 function zfs_test_key() {
-	local dataset="${1}"
-	zfs load-key -n -L prompt "${dataset}" &>/dev/null
+	zfs_load_key "${1}" 'dry_run'
 }
 
 function zfs_load_key() {
 	local dataset="${1}"
-	zfs load-key -L prompt "${dataset}" &>/dev/null
+	local dry_run="${2:+-n}"
+	zfs load-key ${dry_run} -L prompt "${dataset}" >/dev/null
 }
 
 function zero_pad() {
@@ -203,24 +202,21 @@ function zfs_bind_clevis_data() {
 	zfs_add_label "${dataset}" "${label}"
 }
 
-function zfs_get_data_props() {
-	local dataset="${1}"
-
-	#property HAS to be set, otherwise the grep doesn't work
-	local outputs="${2:-property}"
-
-	zfs_get_prop "${dataset}" 'all' -o "${outputs}" | grep -F "${zfs_label_prefix}" | sort
-}
-
 function zfs_wipe_clevis_label() {
 	local dataset="${1}"
-	local label="${2}"
+	local label="${2%:*}"
+	local last_index="${2#*:}"
 
 	local zfs_label_prop="${zfs_label_prefix}:${label}"
 
-	for prop in $(zfs_get_prop "${dataset}" 'all' -o property | grep -F "${zfs_label_prop}" ); do
-		zfs inherit "${prop}" "${dataset}"
-	done
+	if [[ "${label}" == "${last_index}" ]]; then
+		zfs inherit "${zfs_label_prop}" "${dataset}"
+	else
+		for num in $(seq -w 0 "${last_index}"); do
+			zfs inherit "${zfs_label_prop}-${num}" "${dataset}"
+		done
+	fi
+	zfs_remove_label "${dataset}" "${label}"
 }
 
 function zfs_get_clevis_label() {
@@ -228,8 +224,8 @@ function zfs_get_clevis_label() {
 	local label="${2%:*}"
 	local last_index="${2#*:}"
 
-	if [[ -z "${last_index}" ]]; then
-		zfs_label_prop="${zfs_label_prefix}:${label}"
+	local zfs_label_prop="${zfs_label_prefix}:${label}"
+	if [[ "${label}" == "${last_index}" ]]; then
 		zfs_get_prop "${dataset}" "${zfs_label_prop}"
 	else
 		for num in $(seq -w 0 "${last_index}"); do

--- a/src/zfs/clevis-zfs-common
+++ b/src/zfs/clevis-zfs-common
@@ -51,8 +51,11 @@ function zfs_get_property() {
 
 function zfs_load_key() {
 	local dataset="${1}"
-	local dry_run="${2:+-n}"
-	zfs load-key "${dry_run}" -L prompt "${dataset}" >/dev/null
+	local args=( "-L" "prompt" )
+	if [[ -n "${2:-}" ]]; then
+		args+=( "-n" )
+	fi
+	zfs load-key "${args[@]}" "${dataset}" >/dev/null
 }
 
 function zfs_test_key() {

--- a/src/zfs/clevis-zfs-common
+++ b/src/zfs/clevis-zfs-common
@@ -1,0 +1,140 @@
+#!/bin/bash
+
+# zfs user properties are limited to 8192 bytes
+zfs_userprop_max_size=8000
+zfs_userprop_max_size=800 # set smaller to test splitting/combining chunks
+
+zfs_userprop_prefix='latchset.clevis'
+zfs_data_prop="${zfs_userprop_prefix}:data"
+zfs_status_prop="${zfs_userprop_prefix}:status"
+
+function load_key() {
+	local dataset="${1}"
+	local key="${2?need keyinput argument}"
+
+	# Get the existing passphrase/keyfile.
+	local existing_key
+	local keyfile
+
+	case "${key}" in
+	"") IFS= read -r -s -p "Enter existing ZFS password for ${dataset}: " existing_key;
+		echo >&2
+		;;
+	 -) IFS= read -r -s -p "" existing_key ;;
+	 *) keyfile="${key}"
+		if [ -r "${keyfile}" ]; then
+			existing_key="$(< "${keyfile}")"
+		else
+			error "cannot read key file '${keyfile}'"
+		fi
+		;;
+	esac
+	echo "${existing_key}"
+}
+
+function error() {
+	usage
+	echo >&2 -e "ERROR: ${*}"
+    exit 1
+}
+
+findexe() {
+    while read -r -d: path; do
+        [ -f "${path}/${1}" ] && [ -x "${path}/${1}" ] && \
+          echo "${path}/${1}" && return 0
+    done <<< "${PATH}:"
+    return 1
+}
+
+zfs_get_prop() {
+	local dataset="${1}"
+	local prop="${2}"
+	shift 2
+	zfs get -H -o value -slocal "${prop}" "${dataset}" "${@}"
+}
+
+function cut_into_chunks() {
+	fold -w "${zfs_userprop_max_size}"
+}
+
+function zfs_is_bound() {
+	local dataset="${1}"
+	[[ "$(zfs_get_prop "${dataset}" "${zfs_status_prop}" )" == 'bound' ]]
+}
+
+function zfs_is_encryptionroot() {
+	local dataset="${1}"
+	zfs_get_prop "${dataset}" 'encryptionroot'
+	[[ "$(zfs_get_prop "${dataset}" 'encryptionroot' -snone )" == "${dataset}" ]]
+}
+
+function zfs_test_key() {
+	local dataset="${1}"
+	zfs load-key -n -L prompt "${dataset}" &>/dev/null
+}
+
+function zfs_load_key() {
+	local dataset="${1}"
+	zfs load-key -L prompt "${dataset}" &>/dev/null
+}
+
+function zero_pad() {
+	local num="${1}"
+	local width="${2}"
+	printf "%0${width}d" "${num}"
+}
+
+
+function zfs_bind_clevis_data() {
+	local dataset="${1}"
+	local clevis_data="${2}"
+
+	echo >&2 -n 'binding new clevis data... '
+	clevis_chunks=( $(cut_into_chunks <<<"${clevis_data}") )
+	last_index="$(( "${#clevis_chunks[@]}" - 1 ))"
+	width="${#last_index}"
+
+	local chunk chunk_num
+	for i in $(seq 0 "${last_index}" ); do
+		chunk="${clevis_chunks[${i}]}"
+		# we add zero-padding so the props sort nicely when we want to combine
+		# them when we unlock
+		chunk_num="$(zero_pad "${i}" "${width}" )"
+
+		# e.g. latchset.clevis:pin-01=chunk_data
+		zfs set "${zfs_data_prop}-${chunk_num}=${chunk}" "${dataset}"
+	done
+	echo >&2 'ok'
+
+	# check if unlocking works
+	echo >&2 -n 'testing new clevis data... '
+	if ! (zfs_get_clevis_data "${dataset}" | clevis decrypt | zfs_test_key "${dataset}"); then
+		zfs_wipe_clevis_data "${dataset}"
+		error "could not unlock dataset with clevis configuration: ${dataset}"
+	fi
+	echo >&2 'ok'
+
+	zfs set "${zfs_status_prop}=bound" "${dataset}"
+}
+
+function zfs_get_data_props() {
+	local dataset="${1}"
+
+	#property HAS to be set, otherwise the grep doesn't work
+	local outputs="${2:-property}"
+
+	zfs_get_prop "${dataset}" 'all' -o "${outputs}" | grep -F "${zfs_data_prop}" | sort
+}
+
+function zfs_wipe_clevis_data() {
+	local dataset="${1}"
+
+	for prop in $(zfs_get_prop "${dataset}" 'all' -o property | grep -F "${zfs_userprop_prefix}" ); do
+		zfs inherit "${prop}" "${dataset}"
+	done
+}
+
+function zfs_get_clevis_data() {
+	local dataset="${1:?}"
+	zfs_get_data_props "${dataset}" 'property,value' | sort | awk '{print $2}' | tr -d '\n'
+}

--- a/src/zfs/clevis-zfs-common
+++ b/src/zfs/clevis-zfs-common
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 # zfs user properties are limited to 8192 bytes
-zfs_userprop_max_size=8000
-zfs_userprop_max_size=800 # set smaller to test splitting/combining chunks
+zfs_userprop_value_limit=8000
+zfs_userprop_name_limit=256
 
 # all clevis userprops will be prefixed with "latchset.clevis:" as suggested by
 # the User Properties section in zfsprops(8)
@@ -23,17 +23,97 @@ zfs_labels_prop="${zfs_userprop_prefix}:labels"
 zfs_label_prefix="${zfs_userprop_prefix}.label"
 
 
-function zfs_get_labels() {
+# Interfacing functions with ZFS
+################################
+function zfs_remove_property() {
 	local dataset="${1}"
-	zfs_get_prop "${dataset}" "${zfs_labels_prop}"
+	local property="${2}"
+	zfs inherit "${property}" "${dataset}"
 }
 
+# valid characters of zfs user property names are: [0-9a-z:._-] (see zfsprops(7) )
+function zfs_set_property() {
+	local dataset="${1}"
+	local property="${2}"
+	local value="${3}"
+	[[ "${#property}" -le "${zfs_userprop_name_limit}"  ]] || error "property name longer than ${zfs_userprop_name_limit} characters '${property}'"
+	[[ "${#value}"    -le "${zfs_userprop_value_limit}" ]] || error "property value longer than ${zfs_userprop_value_limit} characters '${value}'"
+	zfs set "${property}=${value}" "${dataset}"
+}
+
+# defaults to getting just the value of the given property and only when it is set directly on the dataset ("local")
+zfs_get_property() {
+	local dataset="${1}"
+	local property="${2}"
+	shift 2
+	zfs get "${property}" "${dataset}" -H -o value -slocal "${@}"
+}
+
+function zfs_load_key() {
+	local dataset="${1}"
+	local dry_run="${2:+-n}"
+	zfs load-key ${dry_run} -L prompt "${dataset}" >/dev/null
+}
+
+function zfs_test_key() {
+	zfs_load_key "${1}" 'dry_run'
+}
+
+function zfs_unload_key() {
+	local dataset="${1}"
+	zfs unload-key "${dataset}" >/dev/null
+}
+
+# ZFS properties functions to deal with clevis labels
+##############################################
+
+# valid characters of clevis-zfs labels are: [0-9a-z_]
+function is_valid_label() {
+	local label="${1}"
+	# This length limit is quite arbitrary; (as is the removal of [:.-] )
+	# but we have to draw the line somewhere and zfs-user-property names
+	# can be at most 256 characters long.  We can't use all 256 characters
+	# because we need some space in the property name for the
+	# zfs_label_prefix and the chunk_counter suffix.
+	local limit=100
+	local regex='^[0-9a-z_]+$'
+
+	if [[ "${#label}" -gt "${limit}" ]]; then
+		echo >&2 "label is longer than ${limit} characters: ${label}"
+		return 1
+	fi
+
+	if [[ "${label}" =~ ${regex} ]]; then
+		return 0
+	else
+		echo >&2 "label is invalid: '${label}'. Valid characters: a-z, 0-9, _ (underscore)"
+		return 1
+	fi
+}
+
+# get a list of all labels, including possible number suffixes
+function zfs_get_labels() {
+	local dataset="${1}"
+	zfs_get_property "${dataset}" "${zfs_labels_prop}"
+}
+
+# get a single label from the list of all labels,
+# including possible number suffix
+function zfs_get_label() {
+	local dataset="${1}"
+	local label="${2%%:*}"
+	zfs_get_labels "${dataset}" >&2
+	zfs_get_labels "${dataset}" | tr ' ' '\n' | grep -E "^${label}(:|$)"
+}
+
+# set the list of labels to the given value
 function zfs_set_labels() {
 	local dataset="${1}";
 	local new_labels="${2}"
-	zfs set "${zfs_labels_prop}=${new_labels}" "${dataset}"
+	zfs_set_property "${dataset}" "${zfs_labels_prop}" "${new_labels}"
 }
 
+# add a single label to the existing list of labels
 function zfs_add_label() {
 	local dataset="${1}"
 	local new_label="${2}"
@@ -42,6 +122,7 @@ function zfs_add_label() {
 	zfs_set_labels "${dataset}" "${labels[*]}"
 }
 
+# remove a single label to the existing list of labels
 function zfs_remove_label() {
 	local dataset="${1}"
 	local old_label="${2}"
@@ -50,32 +131,51 @@ function zfs_remove_label() {
 	zfs_set_labels "${dataset}" "${new_labels[*]}"
 }
 
-# valid characters of userprops are: [0-9a-z:._-]
-# valid characters of clevis-zfs labels are: [0-9a-z_]
-function is_valid_label() {
-	local label="${1}"
-	# The length limit is quite arbitrary; but we have to draw the line
-	# somewhere and zfs-user-property names can be at most 256 characters long.
-	# We can't use all 256 characters because we need some space in the
-	# property name for the zfs_label_prefix and the chunk_counter suffix.
-	local limit=100
-	local regex='^[0-9a-z_]+$'
+# functions for checking zfs datasets
+#####################################
 
-	if [[ "${#label}" -gt "${limit}" ]]; then
-		echo >&2 "label is longer than ${limit}: ${label}"
-		return 1
-	fi
+# check if a dataset is bound to a specific label (or any label)
+function zfs_is_bound() {
+	local dataset="${1}"
+	local label="${2:-}"
 
-	if [[ "${label}" =~ ${regex} ]]; then
+	if [[ -z "${label}" ]] && [[ -n "$(zfs_get_labels "${dataset}")" ]]; then
+		return 0
+	elif [[ -n "$(zfs_get_label "${dataset}" "${label}")" ]]; then
 		return 0
 	else
-		echo >&2 "label is invalid: '${label}'. Expecting an alphanumeric string "
 		return 1
 	fi
 }
 
+# we can only load keys on encryptionroots
+# it does not make sense to add a binding elsewhere
+function zfs_is_encryptionroot() {
+	local dataset="${1}"
+	[[ "$(zfs_get_property "${dataset}" 'encryptionroot' -snone )" == "${dataset}" ]]
+}
 
-function read_key() {
+# does it even exist?
+function zfs_is_dataset() {
+	zfs_get_property "${dataset}" 'name' -snone &>/dev/null
+}
+
+
+function check_valid_dataset() {
+	local dataset="${1}"
+
+	if ! zfs_is_dataset; then
+		error "${dataset} is not a zfs dataset!"
+	fi
+
+	if ! zfs_is_encryptionroot "${dataset}"; then
+		error "given dataset is not an encryptionroot: ${dataset}"
+	fi
+}
+
+
+# functions to deal with I/O to the user
+function read_passphrase() {
 	local dataset="${1}"
 	local key="${2?need keyinput argument}"
 
@@ -105,63 +205,29 @@ function error() {
     exit 1
 }
 
-findexe() {
-    while read -r -d: path; do
-        [ -f "${path}/${1}" ] && [ -x "${path}/${1}" ] && \
-          echo "${path}/${1}" && return 0
-    done <<< "${PATH}:"
-    return 1
-}
 
-zfs_get_prop() {
-	local dataset="${1}"
-	local prop="${2}"
-	shift 2
-	zfs get "${prop}" "${dataset}" -H -o value -slocal "${@}"
-}
+# functions to deal with too large clevis data for a single ZFS property
+########################################################################
 
 function cut_into_chunks() {
-	fold -w "${zfs_userprop_max_size}"
-}
-
-function zfs_is_bound() {
-	local dataset="${1}"
-	local label_to_check="${2:-}"
-	local label="${label_to_check%:*}"
-
-	local labels="$(zfs_get_labels "${dataset}")"
-	if [[ -n "${label}" ]]; then
-		[[ " ${labels} " == *" ${label} "* ]] && return 0
-	else
-		# we don't check for a specific label, just that at least one label is set
-		[[ "${#labels}" -gt 0 ]] && return 0
-	fi
-	return 1
-}
-
-function zfs_is_encryptionroot() {
-	local dataset="${1}"
-	[[ "$(zfs_get_prop "${dataset}" 'encryptionroot' -snone )" == "${dataset}" ]]
-}
-
-function zfs_test_key() {
-	zfs_load_key "${1}" 'dry_run'
-}
-
-function zfs_load_key() {
-	local dataset="${1}"
-	local dry_run="${2:+-n}"
-	zfs load-key ${dry_run} -L prompt "${dataset}" >/dev/null
+	fold -w "${zfs_userprop_value_limit}"
 }
 
 function zero_pad() {
-	local num="${1}"
-	local width="${2}"
-	printf "%0${width}d" "${num}"
+	local width="${1}"; shift
+	printf "%0${width}d " "${@}"
+}
+
+function num_list() {
+	local last_index="${1}"
+	zero_pad "${#last_index}" $(eval "echo {0..${last_index}}")
 }
 
 
-function zfs_bind_clevis_data() {
+
+# functions to add/remove a clevis binding
+#########################################
+function zfs_bind_clevis_label() {
 	local dataset="${1}"
 	local label="${2}"
 	local clevis_data="${3}"
@@ -170,22 +236,22 @@ function zfs_bind_clevis_data() {
 
 	echo >&2 -n 'binding new clevis data... '
 	# use a single prop without number suffix if it will fit in one prop
-	if [[ "${#clevis_data}" -lt "${zfs_userprop_max_size}" ]]; then
-		zfs set "${zfs_label_prop}=${clevis_data}" "${dataset}"
+	if [[ "${#clevis_data}" -lt "${zfs_userprop_value_limit}" ]]; then
+		zfs_set_property "${dataset}" "${zfs_label_prop}" "${clevis_data}"
 	else
 		clevis_chunks=( $(cut_into_chunks <<<"${clevis_data}") )
 		last_index="$(( "${#clevis_chunks[@]}" - 1 ))"
 		width="${#last_index}"
 
 		local chunk chunk_num
-		for i in $(seq 0 "${last_index}" ); do
+		for chunk_num in $(num_list "${last_index}"); do
+			# bash assumes numbers are octal when prefixed with a 0, so we
+			# remove it
+			i="${chunk_num##0}"
+			i="${i:-0}" # if we removed all zeroes, we are at the start
 			chunk="${clevis_chunks[${i}]}"
-			# we add zero-padding so the props sort nicely when we want to combine
-			# them when we unlock
-			chunk_num="$(zero_pad "${i}" "${width}" )"
-
 			# e.g. latchset.clevis.label:${label}-01=chunk_data
-			zfs set "${zfs_label_prop}-${chunk_num}=${chunk}" "${dataset}"
+			zfs_set_property "${dataset}" "${zfs_label_prop}-${chunk_num}" "${chunk}"
 		done
 
 		label="${label}:${last_index}"
@@ -194,30 +260,40 @@ function zfs_bind_clevis_data() {
 
 	# check if unlocking works
 	echo >&2 -n 'testing new clevis data... '
-	if ! (zfs_get_clevis_label "${dataset}" "${label}" | clevis decrypt | zfs_test_key "${dataset}"); then
-		zfs_wipe_clevis_label "${dataset}" "${label}"
+
+	# somehow clevis-decrypt exits with a non-zero code, but still outputs the
+	# correct data, so we ignore the exit code. zfs_test_key will fail anyway
+	# if something goes wrong
+	if ! unlock_with_label "${dataset}" "${label}" 'dry_run'; then
+		zfs_unbind_clevis_label "${dataset}" "${label}"
 		error "could not unlock dataset with clevis configuration: ${dataset}"
 	fi
+
 	echo >&2 'ok'
 	zfs_add_label "${dataset}" "${label}"
 }
 
-function zfs_wipe_clevis_label() {
+function zfs_unbind_clevis_label() {
 	local dataset="${1}"
 	local label="${2%:*}"
-	local last_index="${2#*:}"
+	local last_index
+
+	label="$(zfs_get_label "${dataset}" "${label}")"
+	last_index="${label#*:}"
+	label="${label%:*}"
 
 	local zfs_label_prop="${zfs_label_prefix}:${label}"
 
 	if [[ "${label}" == "${last_index}" ]]; then
-		zfs inherit "${zfs_label_prop}" "${dataset}"
+		zfs_remove_property "${dataset}" "${zfs_label_prop}"
 	else
-		for num in $(seq -w 0 "${last_index}"); do
-			zfs inherit "${zfs_label_prop}-${num}" "${dataset}"
+		for num in $(num_list "${last_index}"); do
+			zfs_remove_property "${dataset}" "${zfs_label_prop}-${num}"
 		done
 	fi
 	zfs_remove_label "${dataset}" "${label}"
 }
+
 
 function zfs_get_clevis_label() {
 	local dataset="${1}"
@@ -226,12 +302,29 @@ function zfs_get_clevis_label() {
 
 	local zfs_label_prop="${zfs_label_prefix}:${label}"
 	if [[ "${label}" == "${last_index}" ]]; then
-		zfs_get_prop "${dataset}" "${zfs_label_prop}"
+		zfs_get_property "${dataset}" "${zfs_label_prop}"
 	else
-		for num in $(seq -w 0 "${last_index}"); do
-			zfs_get_prop "${dataset}" "${zfs_label_prop}-${num}" | tr -d '\n'
+		clevis_data=()
+		for num in $(num_list "${last_index}"); do
+			clevis_data+=( $(zfs_get_property "${dataset}" "${zfs_label_prop}-${num}") )
 		done
+		local IFS=''
+		echo "${clevis_data[*]}"
 	fi
+}
+
+
+function unlock_with_label(){
+	local dataset="${1}"
+	local label="${2}"
+	local test_only="${3:-}"
+
+	# somehow clevis-decrypt exits with a non-zero code, but still outputs the
+	# correct data, so we ignore the exit code. zfs_load_key will fail anyway
+	# if something goes wrong
+	zfs_get_clevis_label "${dataset}" "${label}" \
+	| (clevis decrypt || true) \
+	| zfs_load_key "${dataset}" "${test_only}"
 }
 
 

--- a/src/zfs/clevis-zfs-common
+++ b/src/zfs/clevis-zfs-common
@@ -42,7 +42,7 @@ function zfs_set_property() {
 }
 
 # defaults to getting just the value of the given property and only when it is set directly on the dataset ("local")
-zfs_get_property() {
+function zfs_get_property() {
 	local dataset="${1}"
 	local property="${2}"
 	shift 2
@@ -52,7 +52,7 @@ zfs_get_property() {
 function zfs_load_key() {
 	local dataset="${1}"
 	local dry_run="${2:+-n}"
-	zfs load-key ${dry_run} -L prompt "${dataset}" >/dev/null
+	zfs load-key "${dry_run}" -L prompt "${dataset}" >/dev/null
 }
 
 function zfs_test_key() {
@@ -64,7 +64,7 @@ function zfs_unload_key() {
 	zfs unload-key "${dataset}" >/dev/null
 }
 
-# ZFS properties functions to deal with clevis labels
+# ZFS properties functions to deal with Clevis labels
 ##############################################
 
 # valid characters of clevis-zfs labels are: [0-9a-z_]
@@ -102,7 +102,6 @@ function zfs_get_labels() {
 function zfs_get_label() {
 	local dataset="${1}"
 	local label="${2%%:*}"
-	zfs_get_labels "${dataset}" >&2
 	zfs_get_labels "${dataset}" | tr ' ' '\n' | grep -E "^${label}(:|$)"
 }
 
@@ -117,8 +116,9 @@ function zfs_set_labels() {
 function zfs_add_label() {
 	local dataset="${1}"
 	local new_label="${2}"
-	local labels=( $(zfs_get_labels "${dataset}") )
-	local labels+=( "${new_label}" )
+	local labels
+	read -ra labels <<< "$(zfs_get_labels "${dataset}")"
+	labels+=( "${new_label}" )
 	zfs_set_labels "${dataset}" "${labels[*]}"
 }
 
@@ -126,7 +126,8 @@ function zfs_add_label() {
 function zfs_remove_label() {
 	local dataset="${1}"
 	local old_label="${2}"
-	local labels=( $(zfs_get_labels "${dataset}") )
+	local labels
+	read -ra labels <<< "$(zfs_get_labels "${dataset}")"
 	local new_labels=( "${labels[@]/${old_label}}" )
 	zfs_set_labels "${dataset}" "${new_labels[*]}"
 }
@@ -157,6 +158,7 @@ function zfs_is_encryptionroot() {
 
 # does it even exist?
 function zfs_is_dataset() {
+	local dataset="${1}"
 	zfs_get_property "${dataset}" 'name' -snone &>/dev/null
 }
 
@@ -164,7 +166,7 @@ function zfs_is_dataset() {
 function check_valid_dataset() {
 	local dataset="${1}"
 
-	if ! zfs_is_dataset; then
+	if ! zfs_is_dataset "${dataset}"; then
 		error "${dataset} is not a zfs dataset!"
 	fi
 
@@ -187,7 +189,7 @@ function read_passphrase() {
 	"") IFS= read -r -s -p "Enter existing ZFS password for ${dataset}: " existing_key;
 		echo >&2
 		;;
-	 -) IFS= read -r -s -p "" existing_key ;;
+	 -) IFS= read -r -s -p "" existing_key;;
 	 *) keyfile="${key}"
 		if [ -r "${keyfile}" ]; then
 			existing_key="$(< "${keyfile}")"
@@ -206,7 +208,7 @@ function error() {
 }
 
 
-# functions to deal with too large clevis data for a single ZFS property
+# functions to deal with too large Clevis data for a single ZFS property
 ########################################################################
 
 function cut_into_chunks() {
@@ -220,12 +222,14 @@ function zero_pad() {
 
 function num_list() {
 	local last_index="${1}"
-	zero_pad "${#last_index}" $(eval "echo {0..${last_index}}")
+	local indices=()
+	read -ra indices <<< "$(eval "echo {0..${last_index}}")"
+	zero_pad "${#last_index}" "${indices[@]}"
 }
 
 
 
-# functions to add/remove a clevis binding
+# functions to add/remove a Clevis binding
 #########################################
 function zfs_bind_clevis_label() {
 	local dataset="${1}"
@@ -234,12 +238,13 @@ function zfs_bind_clevis_label() {
 
 	local zfs_label_prop="${zfs_label_prefix}:${label}"
 
-	echo >&2 -n 'binding new clevis data... '
+	echo >&2 -n 'binding new Clevis data... '
 	# use a single prop without number suffix if it will fit in one prop
 	if [[ "${#clevis_data}" -lt "${zfs_userprop_value_limit}" ]]; then
 		zfs_set_property "${dataset}" "${zfs_label_prop}" "${clevis_data}"
 	else
-		clevis_chunks=( $(cut_into_chunks <<<"${clevis_data}") )
+		local clevis_chunks=()
+		read -ra clevis_chunks <<< "$(cut_into_chunks <<<"${clevis_data}")"
 		last_index="$(( "${#clevis_chunks[@]}" - 1 ))"
 		width="${#last_index}"
 
@@ -259,7 +264,7 @@ function zfs_bind_clevis_label() {
 	echo >&2 'ok'
 
 	# check if unlocking works
-	echo >&2 -n 'testing new clevis data... '
+	echo >&2 -n 'testing new Clevis data... '
 
 	# somehow clevis-decrypt exits with a non-zero code, but still outputs the
 	# correct data, so we ignore the exit code. zfs_test_key will fail anyway
@@ -304,9 +309,9 @@ function zfs_get_clevis_label() {
 	if [[ "${label}" == "${last_index}" ]]; then
 		zfs_get_property "${dataset}" "${zfs_label_prop}"
 	else
-		clevis_data=()
+		local clevis_data=()
 		for num in $(num_list "${last_index}"); do
-			clevis_data+=( $(zfs_get_property "${dataset}" "${zfs_label_prop}-${num}") )
+			clevis_data+=( "$(zfs_get_property "${dataset}" "${zfs_label_prop}-${num}")" )
 		done
 		local IFS=''
 		echo "${clevis_data[*]}"
@@ -314,7 +319,7 @@ function zfs_get_clevis_label() {
 }
 
 
-function unlock_with_label(){
+function unlock_with_label() {
 	local dataset="${1}"
 	local label="${2}"
 	local test_only="${3:-}"
@@ -330,5 +335,5 @@ function unlock_with_label(){
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 	. clevis-zfs-test
-    _test "$@"
+	_test "$@"
 fi

--- a/src/zfs/clevis-zfs-common
+++ b/src/zfs/clevis-zfs-common
@@ -205,8 +205,8 @@ function read_passphrase() {
 }
 
 function error() {
-	usage
 	echo >&2 -e "ERROR: ${*}"
+	usage
 	exit 1
 }
 

--- a/src/zfs/clevis-zfs-list
+++ b/src/zfs/clevis-zfs-list
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+
+. clevis-zfs-common
+
+SUMMARY="List zfs datasets that are bound with clevis"
+
+
+
+function usage() {
+	cat >&2 <<-USAGE_END
+		Usage: clevis zfs list [pool]
+
+		$SUMMARY:
+
+		  -f      Do not prompt when overwriting configuration
+
+		  -d DEV  The zfs dataset on which to perform binding
+
+		  -k KEY  Non-interactively read zfs password from KEY file
+		  -k -    Non-interactively read zfs password from standard input
+
+	USAGE_END
+}
+
+
+main() {
+	local poolname="${1:-}"
+	echo "The following ZFS datasets have been bound with clevis:"
+	zfs list -o "name,${zfs_status_prop}" -r ${poolname} | awk '{ if ($2=="bound") {print $1}}' | sort | sed 's/^/  /'
+}
+
+main "${@}"

--- a/src/zfs/clevis-zfs-list
+++ b/src/zfs/clevis-zfs-list
@@ -41,6 +41,6 @@ main() {
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-	. clevis-zfs-common
+	. @libexecdir@/clevis-zfs-common
 	main "${@}"
 fi

--- a/src/zfs/clevis-zfs-list
+++ b/src/zfs/clevis-zfs-list
@@ -16,7 +16,7 @@ function usage() {
 
 
 main() {
-	if [ $# -eq 1 -a "${1:-}" == "--summary" ]; then
+	if [ $# -eq 1 ] && [ "${1:-}" == "--summary" ]; then
 		echo "$SUMMARY"
 		exit 0
 	fi
@@ -30,7 +30,9 @@ main() {
 	done
 
 	echo >&2 "The following ZFS datasets have been bound with clevis:"
-	zfs get -r -H -o name,value -slocal "${zfs_labels_prop}" ${dataset}
+	# we should not quote this in case it is empty
+	# shellcheck disable=SC2086
+	zfs get -r -H -o name,value -slocal "${zfs_labels_prop}" ${dataset:-}
 }
 
 main "${@}"

--- a/src/zfs/clevis-zfs-list
+++ b/src/zfs/clevis-zfs-list
@@ -3,31 +3,34 @@ set -euo pipefail
 
 . clevis-zfs-common
 
-SUMMARY="List zfs datasets that are bound with clevis"
-
-
+SUMMARY="List zfs datasets that are bound with clevis [in dataset]"
 
 function usage() {
 	cat >&2 <<-USAGE_END
-		Usage: clevis zfs list [pool]
+		Usage: clevis zfs list -d DATASET
 
 		$SUMMARY:
-
-		  -f      Do not prompt when overwriting configuration
-
-		  -d DEV  The zfs dataset on which to perform binding
-
-		  -k KEY  Non-interactively read zfs password from KEY file
-		  -k -    Non-interactively read zfs password from standard input
 
 	USAGE_END
 }
 
 
 main() {
-	local poolname="${1:-}"
-	echo "The following ZFS datasets have been bound with clevis:"
-	zfs list -o "name,${zfs_status_prop}" -r ${poolname} | awk '{ if ($2=="bound") {print $1}}' | sort | sed 's/^/  /'
+	if [ $# -eq 1 -a "${1:-}" == "--summary" ]; then
+		echo "$SUMMARY"
+		exit 0
+	fi
+
+	local dataset
+	while getopts "d:" o; do
+		case "$o" in
+		d) dataset="$OPTARG" ;;
+		*) error "unrecognized argument: -${OPTARG}" ;;
+		esac
+	done
+
+	echo >&2 "The following ZFS datasets have been bound with clevis:"
+	zfs get -r -H -o name,value -slocal "${zfs_labels_prop}" ${dataset}
 }
 
 main "${@}"

--- a/src/zfs/clevis-zfs-list
+++ b/src/zfs/clevis-zfs-list
@@ -1,9 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-. clevis-zfs-common
-
-SUMMARY="List zfs datasets that are bound with clevis [in dataset]"
+SUMMARY="List ZFS datasets that are bound with Clevis [in dataset]"
 
 function usage() {
 	cat >&2 <<-USAGE_END
@@ -11,9 +9,10 @@ function usage() {
 
 		$SUMMARY:
 
+		  -d DATASET  The ZFS dataset on which to perform unbinding
+
 	USAGE_END
 }
-
 
 main() {
 	if [ $# -eq 1 ] && [ "${1:-}" == "--summary" ]; then
@@ -22,23 +21,26 @@ main() {
 	fi
 
 	local dataset
-	while getopts "d:" o; do
+	while getopts "hd:" o; do
 		case "$o" in
-		d) dataset="$OPTARG" ;;
-		*) error "unrecognized argument: -${OPTARG}" ;;
+		h) usage; exit 0;;
+		d) dataset="$OPTARG";;
+		*) error "unrecognized argument: -${OPTARG}";;
 		esac
 	done
 
-	if [ -n "${dataset}" ]; then
+	local output='name,value'
+	if [ -n "${dataset:-}" ]; then
 		output='value'
-	else
-		output='name,value'
 	fi
 
-	echo >&2 "The following ZFS datasets have been bound with clevis:"
+	echo >&2 "The following ZFS datasets have been bound with Clevis:"
 	# we should not quote ${dataset:-} in case it is empty
 	# shellcheck disable=SC2086
 	zfs get -H -o "${output}" -slocal "${zfs_labels_prop}" ${dataset:-}
 }
 
-main "${@}"
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	. clevis-zfs-common
+	main "${@}"
+fi

--- a/src/zfs/clevis-zfs-list
+++ b/src/zfs/clevis-zfs-list
@@ -29,10 +29,16 @@ main() {
 		esac
 	done
 
+	if [ -n "${dataset}" ]; then
+		output='value'
+	else
+		output='name,value'
+	fi
+
 	echo >&2 "The following ZFS datasets have been bound with clevis:"
-	# we should not quote this in case it is empty
+	# we should not quote ${dataset:-} in case it is empty
 	# shellcheck disable=SC2086
-	zfs get -r -H -o name,value -slocal "${zfs_labels_prop}" ${dataset:-}
+	zfs get -H -o "${output}" -slocal "${zfs_labels_prop}" ${dataset:-}
 }
 
 main "${@}"

--- a/src/zfs/clevis-zfs-test
+++ b/src/zfs/clevis-zfs-test
@@ -4,11 +4,10 @@ set -euo pipefail
 zpool='clevis-zfs-pool'
 root_dataset="${zpool}/clevis"
 test_dataset="${root_dataset}/test"
-tang_host='TANG_HOST'
-tang_thp='TANG_THP'
 
-tang_host='192.168.178.26:8565'
-tang_thp='NHt3FdBvUX0AiHZycp2emEzfYIc'
+tang_host='127.0.0.1'
+tang_thp='TANG_THP'
+tang_config='{"url": "http://'${tang_host}'", "thp": "'${tang_thp}'"}'
 
 function zfs_usage() {
 	local permissions='create,destroy,mount,load-key,change-key,userprop,encryption,keyformat,keylocation'
@@ -30,6 +29,8 @@ function zfs_usage() {
 
 		4) give the user running the test script permissions to make changes to this pool:
 		    zfs allow ${USER} ${permissions} ${root_dataset}
+
+		5) set tang_host and tang_thp to an existing tang server in ${BASH_SOURCE[0]}
 	EOF
 }
 
@@ -167,8 +168,8 @@ function _test_zfs_functions() {
 	_zfs_create_encrypted_dataset "${test_dataset}"
 
 	testing 'binding zfs dataset twice'
-	echo "${testing_password}" | ./clevis-zfs-bind -d "${test_dataset}" -k - -l 'testlabel' tang '{"url": "http://'${tang_host}'", "thp": "'${tang_thp}'"}' &>/dev/null
-	echo "${testing_password}" | ./clevis-zfs-bind -d "${test_dataset}" -k - -l 'another_testlabel' tang '{"url": "http://'${tang_host}'", "thp": "'${tang_thp}'"}' &>/dev/null
+	echo "${testing_password}" | ./clevis-zfs-bind -d "${test_dataset}" -k - -l 'testlabel' tang "${tang_config}" &>/dev/null
+	echo "${testing_password}" | ./clevis-zfs-bind -d "${test_dataset}" -k - -l 'another_testlabel' tang "${tang_config}" &>/dev/null
 	success
 
 	testing 'listing labels'

--- a/src/zfs/clevis-zfs-test
+++ b/src/zfs/clevis-zfs-test
@@ -15,7 +15,7 @@ shutup='/dev/null'
 
 # simple tang config
 tang_config='{"url": "http://'${tang_host}'", "thp": "'${tang_thp}'"}'
-# config that will go over the 8k limit
+# config that will go over the 8k limit twice (i.e. >16k)
 sss_config='{
 	"t": 4,
 	"pins": {
@@ -186,12 +186,12 @@ function _zfs_test_teardown() {
 
 function _zfs_create_encrypted_dataset() {
 	local dataset="${1}"
-	testing "creating encrypted test dataset: ${1}"
+	testing "creating encrypted test dataset: ${dataset}"
 	# zfs create will work with the permissions as described, but will exit
 	# with an error code because mounting failed
-	zfs create "${1}" -o encryption=on -o keyformat=passphrase <<<"${testing_password}" &>${shutup} || true
+	zfs create "${dataset}" -o encryption=on -o keyformat=passphrase <<<"${testing_password}" &>${shutup} || true
 	# we need to make sure the dataset is created because of the error-code shenanigans
-	zfs list "${1}" &>${shutup} && success || return 1
+	zfs list "${dataset}" &>${shutup} && success || return 1
 }
 
 function _test_zfs_functions() {
@@ -200,10 +200,10 @@ function _test_zfs_functions() {
 	trap _zfs_test_teardown EXIT
 	_zfs_create_encrypted_dataset "${test_dataset}"
 
-	testing 'binding zfs dataset twice'
-	echo "${testing_password}" | ./clevis-zfs-bind -d "${test_dataset}" -k - -l 'tang_testlabel' tang "${tang_config}" &>/dev/null
-	echo "${testing_password}" | ./clevis-zfs-bind -d "${test_dataset}" -k - -l 'sss_testlabel'  sss  "${sss_config}" &>/dev/null
-	success
+	testing 'binding zfs dataset tang'
+	echo "${testing_password}" | ./clevis-zfs-bind -d "${test_dataset}" -k - -l 'tang_testlabel' tang "${tang_config}" &>${shutup} && success || failed
+	testing 'binding zfs dataset sss'
+	echo "${testing_password}" | ./clevis-zfs-bind -d "${test_dataset}" -k - -l 'sss_testlabel'  sss  "${sss_config}"  &>${shutup} && success || failed
 
 	testing 'listing labels'
 	# the tang_testlabel should be way under the 8k limit
@@ -214,23 +214,25 @@ function _test_zfs_functions() {
 
 	expected='unlock test success'
 	result='unlock test failure'
-	#shutup='/dev/stderr'
 	testing 'testing unlocking with bindings tang'
 	./clevis-zfs-unlock -t -d "${test_dataset}" -l 'tang_testlabel' &>${shutup} && success || failed
-	return
+
 	testing 'testing unlocking with bindings sss'
 	./clevis-zfs-unlock -t -d "${test_dataset}" -l 'sss_testlabel' &>${shutup} && success || failed
 	testing 'testing unlocking with bindings either'
 	./clevis-zfs-unlock -t -d "${test_dataset}" &>${shutup} && success || failed
 
 	testing 'unlocking with binding'
-	zfs unload-key "${test_dataset}"
-	[[ "$(zfs_get_property "${test_dataset}" 'keystatus' -snone)" == 'unavailable' ]] || return 1
-	./clevis-zfs-unlock -d "${test_dataset}" &>${shutup}
+	expected='unlock success'
+	zfs unload-key "${test_dataset}" || result='unload key failed' failed
+	[[ "$(zfs_get_property "${test_dataset}" 'keystatus' -snone)" == 'unavailable' ]] || result='unload key failed' failed
+	./clevis-zfs-unlock -d "${test_dataset}" &>${shutup} || result='unlocking failed' failed
 	success
 
-	testing 'unbinding dataset twice'
-	echo "${testing_password}" | ./clevis-zfs-unbind -d "${test_dataset}" -l 'another_testlabel' -k -
-	echo "${testing_password}" | ./clevis-zfs-unbind -d "${test_dataset}" -l 'testlabel' -k -
-	success
+	expected='unbinding success'
+	result='unbinding failed'
+	testing 'unbinding dataset tang'
+	echo "${testing_password}" | ./clevis-zfs-unbind -d "${test_dataset}" -l 'tang_testlabel' -k - &>${shutup} && success || failed
+	testing 'unbinding dataset sss'
+	echo "${testing_password}" | ./clevis-zfs-unbind -d "${test_dataset}" -l 'sss_testlabel' -k - &>${shutup} && success || failed
 }

--- a/src/zfs/clevis-zfs-test
+++ b/src/zfs/clevis-zfs-test
@@ -187,11 +187,17 @@ function _zfs_test_teardown() {
 function _zfs_create_encrypted_dataset() {
 	local dataset="${1}"
 	testing "creating encrypted test dataset: ${dataset}"
-	# zfs create will work with the permissions as described, but will exit
-	# with an error code because mounting failed
+	# zfs create will work, assuming we have the permissions as described in
+	# zfs_usage, but will exit with an error code because only the root user
+	# can mount the dataset
 	zfs create "${dataset}" -o encryption=on -o keyformat=passphrase <<<"${testing_password}" &>${shutup} || true
 	# we need to make sure the dataset is created because of the error-code shenanigans
-	zfs list "${dataset}" &>${shutup} && success || return 1
+	if zfs list "${dataset}" &>${shutup}; then
+		success
+		return 0
+	else
+		return 1
+	fi
 }
 
 function _test_zfs_functions() {

--- a/src/zfs/clevis-zfs-test
+++ b/src/zfs/clevis-zfs-test
@@ -1,0 +1,192 @@
+#!/bin/bash
+set -euo pipefail
+
+zpool='clevis-zfs-pool'
+root_dataset="${zpool}/clevis"
+test_dataset="${root_dataset}/test"
+tang_host='TANG_HOST'
+tang_thp='TANG_THP'
+
+tang_host='192.168.178.26:8565'
+tang_thp='NHt3FdBvUX0AiHZycp2emEzfYIc'
+
+function zfs_usage() {
+	local permissions='create,destroy,mount,load-key,change-key,userprop,encryption,keyformat,keylocation'
+	cat >&2 <<-EOF
+
+		To test the zfs functions you will need to do the following as root:
+
+		1) make sure the zfs kernel module is loaded:
+		    modprobe zfs
+
+		2) create a new backing file:
+		    dd if=/dev/zero bs=10M count=20 conv=fdatasync of=/tmp/clevis-zfs-pool
+
+		3) create an unencrypted zfs pool using the backing file:
+		    zpool create ${zpool} /tmp/clevis-zfs-pool
+
+		4) create an unencrypted child dataset so we can grant access to a non-root user:
+			zpool create ${root_dataset}
+
+		4) give the user running the test script permissions to make changes to this pool:
+		    zfs allow ${USER} ${permissions} ${root_dataset}
+	EOF
+}
+
+exit_code=0
+testing_password="paaaassssswoooooorrrrddd"
+
+function testing() {
+	echo >&2 -en "${FUNCNAME[1]}: ${*}... "
+}
+function success() {
+	echo >&2 'ok'
+}
+function failed() {
+	echo >&2 "failed!"
+	echo >&2 "${BASH_SOURCE[0]}:${BASH_LINENO[0]}  EXPECTED: '${expected}'  GOT: '${result}' ${*}"
+	declare -g exit_code=1
+}
+
+function _test() {
+	_test_is_valid_label
+	_test_read_key
+	_test_zero_pad
+	_test_zfs_functions
+	[[ "${exit_code}" -gt 0 ]] && echo >&2 "SOME TESTS HAVE FAILED"
+	exit "${exit_code}"
+}
+
+
+
+function _test_is_valid_label() {
+	local expected
+	local result
+	valid_labels=(
+		2  # single digit
+		0  # single 0
+		a  # single letter
+		3a # double
+		a4 # double
+		1024 # all digits
+		abcd # all letters
+		0a0ab # alphanum
+		a_bc # with underscore
+	)
+
+	invalid_labels=(
+		a-bc  # with dash
+		a.bc # with dot
+		a:bc # with colon
+		a.1_c-2:e # with all
+		'' # empty string
+		'.' # just a dot
+		'-' # just a dash
+		AteA_ # capitals
+		aa@a  # @-symbol
+		aa/a  # /-symbol
+		aa/a  # /-symbol
+		aa?a  # ?-symbol
+		aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # 101-chars long
+	)
+
+	testing 'testing valid labels'
+	expected=0
+	result=1
+	for l in "${valid_labels[@]}"; do
+		if ! is_valid_label "${l}" &>/dev/null; then
+			failed "for is_valid_label '${l}'"
+		fi
+	done
+	success
+
+	testing 'testing invalid labels'
+	expected=1
+	result=0
+	for l in "${invalid_labels[@]}"; do
+		if is_valid_label "${l}" &>/dev/null; then
+			failed "for \`is_valid_label '${l}'\`"
+		fi
+	done
+	success
+}
+
+
+function _test_read_key() {
+	# test with reading from stdin
+	local expected
+	local result
+
+	testing 'key test: no key argument (stdin)'
+	expected='no-argument-password'
+	result="$(read_key "mydataset" '' <<<"${expected}" 2>/dev/null)"
+	[[ "${expected}" == "${result}" ]] && success || failed
+
+	testing 'key test: dash argument (stdin)'
+	expected='dash-argument-password'
+	result="$(read_key "mydataset" '-' <<<"${expected}" 2>/dev/null)"
+	[[ "${expected}" == "${result}" ]] && success || failed
+
+
+	testing 'key arg: filename'
+	expected='filename-argument-password'
+	result="$(read_key "mydataset" <(echo "${expected}") 2>/dev/null)"
+	[[ "${expected}" == "${result}" ]] && success || failed
+}
+
+
+function _test_zero_pad() {
+	testing 'pad with 4 zeroes'
+	local expected='000051'
+	local result="$(zero_pad 51 6)"
+	[[ "${expected}" == "${result}" ]] && success || failed
+}
+
+
+function _zfs_test_teardown() {
+	testing "removing zfs testing dataset: ${test_dataset}"
+	! zfs list "${test_dataset}" &>/dev/null && success && return 0
+	zfs destroy -f -r "${test_dataset}"
+	success
+}
+
+function _zfs_create_encrypted_dataset() {
+	local dataset="${1}"
+	testing "creating encrypted test dataset: ${1}"
+	# zfs create will work with the permissions as described, but will exit
+	# with an error code because mounting failed
+	zfs create "${1}" -o encryption=on -o keyformat=passphrase <<<"${testing_password}" &>/dev/null || true
+	# we need to make sure the dataset is created because of the error-code shenanigans
+	zfs list "${1}" &>/dev/null && success || return 1
+}
+
+function _test_zfs_functions() {
+	testing "checking if zfs testing dataset exists: ${root_dataset}"
+	zfs list "${root_dataset}" &>/dev/null && success || (zfs_usage; return 1)
+	trap _zfs_test_teardown EXIT
+	_zfs_create_encrypted_dataset "${test_dataset}"
+
+	testing 'binding zfs dataset twice'
+	echo "${testing_password}" | ./clevis-zfs-bind -d "${test_dataset}" -k - -l 'testlabel' tang '{"url": "http://'${tang_host}'", "thp": "'${tang_thp}'"}' &>/dev/null
+	echo "${testing_password}" | ./clevis-zfs-bind -d "${test_dataset}" -k - -l 'another_testlabel' tang '{"url": "http://'${tang_host}'", "thp": "'${tang_thp}'"}' &>/dev/null
+	success
+
+	testing 'listing labels'
+	expected="${test_dataset}"$'\ttestlabel:1 another_testlabel:1'
+	result="$(./clevis-zfs-list -d "${test_dataset}" 2>/dev/null)"
+	[[ "${expected}" == "${result}" ]] && success || failed
+
+	testing 'testing unlocking with bindings'
+	./clevis-zfs-unlock -t -d "${test_dataset}" && success
+
+	testing 'unlocking with binding'
+	zfs unload-key "${test_dataset}"
+	[[ "$(zfs_get_prop "${test_dataset}" 'keystatus' -snone)" == 'unavailable' ]] || return 1
+	./clevis-zfs-unlock -d "${test_dataset}"
+	success
+
+	testing 'unbinding dataset twice'
+	echo "${testing_password}" | ./clevis-zfs-unbind -d "${test_dataset}" -l 'another_testlabel' -k -
+	echo "${testing_password}" | ./clevis-zfs-unbind -d "${test_dataset}" -l 'testlabel' -k -
+	success
+}

--- a/src/zfs/clevis-zfs-test
+++ b/src/zfs/clevis-zfs-test
@@ -7,7 +7,33 @@ test_dataset="${root_dataset}/test"
 
 tang_host='127.0.0.1'
 tang_thp='TANG_THP'
+
+tang_host="192.168.178.26:8565"
+tang_thp="NHt3FdBvUX0AiHZycp2emEzfYIc"
+
+shutup='/dev/null'
+
+# simple tang config
 tang_config='{"url": "http://'${tang_host}'", "thp": "'${tang_thp}'"}'
+# config that will go over the 8k limit
+sss_config='{
+	"t": 4,
+	"pins": {
+		"tang": ['"${tang_config}","${tang_config}","${tang_config}"'],
+		"sss": {
+			"t": 4,
+			"pins": {
+				"tang": ['"${tang_config}","${tang_config}","${tang_config}"'],
+				"sss": {
+					"t": 3,
+					"pins": {
+						"tang": ['"${tang_config}","${tang_config}","${tang_config}"']
+					}
+				}
+			}
+		}
+	}
+}'
 
 function zfs_usage() {
 	local permissions='create,destroy,mount,load-key,change-key,userprop,encryption,keyformat,keylocation'
@@ -51,8 +77,9 @@ function failed() {
 
 function _test() {
 	_test_is_valid_label
-	_test_read_key
+	_test_read_passphrase
 	_test_zero_pad
+	_test_num_list
 	_test_zfs_functions
 	[[ "${exit_code}" -gt 0 ]] && echo >&2 "SOME TESTS HAVE FAILED"
 	exit "${exit_code}"
@@ -95,7 +122,7 @@ function _test_is_valid_label() {
 	expected=0
 	result=1
 	for l in "${valid_labels[@]}"; do
-		if ! is_valid_label "${l}" &>/dev/null; then
+		if ! is_valid_label "${l}" &>${shutup}; then
 			failed "for is_valid_label '${l}'"
 		fi
 	done
@@ -105,7 +132,7 @@ function _test_is_valid_label() {
 	expected=1
 	result=0
 	for l in "${invalid_labels[@]}"; do
-		if is_valid_label "${l}" &>/dev/null; then
+		if is_valid_label "${l}" &>${shutup}; then
 			failed "for \`is_valid_label '${l}'\`"
 		fi
 	done
@@ -113,40 +140,46 @@ function _test_is_valid_label() {
 }
 
 
-function _test_read_key() {
+function _test_read_passphrase() {
 	# test with reading from stdin
 	local expected
 	local result
 
 	testing 'key test: no key argument (stdin)'
 	expected='no-argument-password'
-	result="$(read_key "mydataset" '' <<<"${expected}" 2>/dev/null)"
+	result="$(read_passphrase "mydataset" '' <<<"${expected}" 2>/dev/null)"
 	[[ "${expected}" == "${result}" ]] && success || failed
 
 	testing 'key test: dash argument (stdin)'
 	expected='dash-argument-password'
-	result="$(read_key "mydataset" '-' <<<"${expected}" 2>/dev/null)"
+	result="$(read_passphrase "mydataset" '-' <<<"${expected}" 2>/dev/null)"
 	[[ "${expected}" == "${result}" ]] && success || failed
 
 
 	testing 'key arg: filename'
 	expected='filename-argument-password'
-	result="$(read_key "mydataset" <(echo "${expected}") 2>/dev/null)"
+	result="$(read_passphrase "mydataset" <(echo "${expected}") 2>/dev/null)"
 	[[ "${expected}" == "${result}" ]] && success || failed
 }
 
 
 function _test_zero_pad() {
 	testing 'pad with 4 zeroes'
-	local expected='000051'
-	local result="$(zero_pad 51 6)"
+	local expected='000051 '
+	local result="$(zero_pad 6 51)"
 	[[ "${expected}" == "${result}" ]] && success || failed
 }
 
+function _test_num_list() {
+	testing 'list with zero padding'
+	local expected='00 01 02 03 04 05 06 07 08 09 10 '
+	local result="$(num_list 10)"
+	[[ "${expected}" == "${result}" ]] && success || failed
+}
 
 function _zfs_test_teardown() {
 	testing "removing zfs testing dataset: ${test_dataset}"
-	! zfs list "${test_dataset}" &>/dev/null && success && return 0
+	! zfs list "${test_dataset}" &>${shutup} && success && return 0
 	zfs destroy -f -r "${test_dataset}"
 	success
 }
@@ -156,34 +189,44 @@ function _zfs_create_encrypted_dataset() {
 	testing "creating encrypted test dataset: ${1}"
 	# zfs create will work with the permissions as described, but will exit
 	# with an error code because mounting failed
-	zfs create "${1}" -o encryption=on -o keyformat=passphrase <<<"${testing_password}" &>/dev/null || true
+	zfs create "${1}" -o encryption=on -o keyformat=passphrase <<<"${testing_password}" &>${shutup} || true
 	# we need to make sure the dataset is created because of the error-code shenanigans
-	zfs list "${1}" &>/dev/null && success || return 1
+	zfs list "${1}" &>${shutup} && success || return 1
 }
 
 function _test_zfs_functions() {
 	testing "checking if zfs testing dataset exists: ${root_dataset}"
-	zfs list "${root_dataset}" &>/dev/null && success || (zfs_usage; return 1)
+	zfs list "${root_dataset}" &>${shutup} && success || (zfs_usage; return 1)
 	trap _zfs_test_teardown EXIT
 	_zfs_create_encrypted_dataset "${test_dataset}"
 
 	testing 'binding zfs dataset twice'
-	echo "${testing_password}" | ./clevis-zfs-bind -d "${test_dataset}" -k - -l 'testlabel' tang "${tang_config}" &>/dev/null
-	echo "${testing_password}" | ./clevis-zfs-bind -d "${test_dataset}" -k - -l 'another_testlabel' tang "${tang_config}" &>/dev/null
+	echo "${testing_password}" | ./clevis-zfs-bind -d "${test_dataset}" -k - -l 'tang_testlabel' tang "${tang_config}" &>/dev/null
+	echo "${testing_password}" | ./clevis-zfs-bind -d "${test_dataset}" -k - -l 'sss_testlabel'  sss  "${sss_config}" &>/dev/null
 	success
 
 	testing 'listing labels'
-	expected="${test_dataset}"$'\ttestlabel:1 another_testlabel:1'
+	# the tang_testlabel should be way under the 8k limit
+	# the sss_testlabel should be over 16k
+	expected="${test_dataset}"$'\ttang_testlabel sss_testlabel:2'
 	result="$(./clevis-zfs-list -d "${test_dataset}" 2>/dev/null)"
 	[[ "${expected}" == "${result}" ]] && success || failed
 
-	testing 'testing unlocking with bindings'
-	./clevis-zfs-unlock -t -d "${test_dataset}" && success
+	expected='unlock test success'
+	result='unlock test failure'
+	#shutup='/dev/stderr'
+	testing 'testing unlocking with bindings tang'
+	./clevis-zfs-unlock -t -d "${test_dataset}" -l 'tang_testlabel' &>${shutup} && success || failed
+	return
+	testing 'testing unlocking with bindings sss'
+	./clevis-zfs-unlock -t -d "${test_dataset}" -l 'sss_testlabel' &>${shutup} && success || failed
+	testing 'testing unlocking with bindings either'
+	./clevis-zfs-unlock -t -d "${test_dataset}" &>${shutup} && success || failed
 
 	testing 'unlocking with binding'
 	zfs unload-key "${test_dataset}"
-	[[ "$(zfs_get_prop "${test_dataset}" 'keystatus' -snone)" == 'unavailable' ]] || return 1
-	./clevis-zfs-unlock -d "${test_dataset}"
+	[[ "$(zfs_get_property "${test_dataset}" 'keystatus' -snone)" == 'unavailable' ]] || return 1
+	./clevis-zfs-unlock -d "${test_dataset}" &>${shutup}
 	success
 
 	testing 'unbinding dataset twice'

--- a/src/zfs/clevis-zfs-test
+++ b/src/zfs/clevis-zfs-test
@@ -85,8 +85,6 @@ function _test() {
 	exit "${exit_code}"
 }
 
-
-
 function _test_is_valid_label() {
 	local expected
 	local result
@@ -139,7 +137,6 @@ function _test_is_valid_label() {
 	success
 }
 
-
 function _test_read_passphrase() {
 	# test with reading from stdin
 	local expected
@@ -162,18 +159,19 @@ function _test_read_passphrase() {
 	[[ "${expected}" == "${result}" ]] && success || failed
 }
 
-
 function _test_zero_pad() {
 	testing 'pad with 4 zeroes'
 	local expected='000051 '
-	local result="$(zero_pad 6 51)"
+	local result
+	result="$(zero_pad 6 51)"
 	[[ "${expected}" == "${result}" ]] && success || failed
 }
 
 function _test_num_list() {
 	testing 'list with zero padding'
 	local expected='00 01 02 03 04 05 06 07 08 09 10 '
-	local result="$(num_list 10)"
+	local result
+	result="$(num_list 10)"
 	[[ "${expected}" == "${result}" ]] && success || failed
 }
 

--- a/src/zfs/clevis-zfs-unbind
+++ b/src/zfs/clevis-zfs-unbind
@@ -57,7 +57,7 @@ function main() {
 	fi
 
 	echo >&2 -n 'wiping clevis data... '
-	zfs_wipe_clevis_label "${dataset}" "${label}"
+	zfs_unbind_clevis_label "${dataset}" "${label}"
 	echo >&2 'ok'
 }
 

--- a/src/zfs/clevis-zfs-unbind
+++ b/src/zfs/clevis-zfs-unbind
@@ -31,12 +31,17 @@ function main() {
 	local dataset=
 	local key=
 	local label=
-	while getopts ":hfd:k:l:" o; do
+	local force_unbind='false'
+	local unbind_all='false'
+	while getopts "hafd:k:l:" o; do
 		case "$o" in
+		h) usage; exit 0;;
+		a) unbind_all='true';;
 		d) dataset="$OPTARG";;
+		f) force_unbind='true';;
 		k) key="$OPTARG";;
 		l) label="$OPTARG";;
-		*) error "unrecognized argument: -${OPTARG}";;
+		*) error "unrecognized argument: -${o}";;
 		esac
 	done
 
@@ -44,21 +49,34 @@ function main() {
 		error "did not specify a device!"
 	fi
 
-	if ! zfs_is_bound "${dataset}"; then
-		error "dataset is not bound with clevis: ${dataset}"
+	if [[ "${force_unbind}" != 'true' ]]; then
+
+		if ! zfs_is_bound "${dataset}"; then
+			error "dataset is not bound with clevis: ${dataset}"
+		fi
+
+		local existing_key
+		echo >&2 "Loading existing key... "
+		existing_key="$(read_passphrase "${dataset}" "${key}")"
+
+		if ! zfs_test_key "${dataset}" <<<"${existing_key}"; then
+			error "given key does not unlock ${dataset}"
+		fi
 	fi
 
-	local existing_key
-	echo >&2 "Loading existing key... "
-	existing_key="$(read_passphrase "${dataset}" "${key}")"
 
-	if ! zfs_test_key "${dataset}" <<<"${existing_key}"; then
-		error "given key does not unlock ${dataset}"
-	fi
 
 	echo >&2 -n 'wiping clevis data... '
-	zfs_unbind_clevis_label "${dataset}" "${label}"
+	if [[ "${unbind_all}" == 'true' ]]; then
+		labels="$(zfs_get_labels "${dataset}")"
+		for label in ${labels}; do
+			zfs_unbind_clevis_label "${dataset}" "${label}"
+		done
+	else
+		zfs_unbind_clevis_label "${dataset}" "${label}"
+	fi
 	echo >&2 'ok'
+
 }
 
 main "${@}"

--- a/src/zfs/clevis-zfs-unbind
+++ b/src/zfs/clevis-zfs-unbind
@@ -28,9 +28,9 @@ function main() {
 		exit 0
 	fi
 
-	local dataset
-	local key
-	local label
+	local dataset=
+	local key=
+	local label=
 	while getopts ":hfd:k:l:" o; do
 		case "$o" in
 		d) dataset="$OPTARG";;

--- a/src/zfs/clevis-zfs-unbind
+++ b/src/zfs/clevis-zfs-unbind
@@ -1,10 +1,9 @@
 #!/bin/bash
-set -eu
+set -euo pipefail
 
 . clevis-zfs-common
 
 SUMMARY="Unbinds a label from a ZFS dataset"
-
 
 
 function usage() {
@@ -58,7 +57,8 @@ function main() {
 	fi
 
 	echo >&2 -n 'wiping clevis data... '
-	zfs_wipe_clevis_data "${dataset}" "${label}"
+	zfs_wipe_clevis_label "${dataset}" "${label}"
 	echo >&2 'ok'
 }
+
 main "${@}"

--- a/src/zfs/clevis-zfs-unbind
+++ b/src/zfs/clevis-zfs-unbind
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -euo pipefail
+
+. clevis-zfs-common
+
+SUMMARY="Unbinds a ZFS dataset (remove clevis)"
+
+
+
+function usage() {
+	cat >&2 <<-USAGE_END
+		Usage: clevis zfs unbind [-k KEY] -d DEV
+
+		$SUMMARY:
+
+		  -d DEV  The zfs dataset on which to perform binding
+
+		  -k KEY  Non-interactively read zfs password from KEY file
+		  -k -    Non-interactively read zfs password from standard input
+
+	USAGE_END
+}
+
+
+function main() {
+	if [ $# -eq 1 -a "${1:-}" == "--summary" ]; then
+		echo "$SUMMARY"
+		exit 0
+	fi
+
+	local dataset=
+	local key=
+	while getopts ":hfd:k:" o; do
+		case "$o" in
+		d) dataset="$OPTARG";;
+		k) key="$OPTARG";;
+		*) error "unrecognized argument: -${OPTARG}";;
+		esac
+	done
+
+	if [ -z "${dataset:-""}" ]; then
+		error "did not specify a device!"
+	fi
+
+	if ! zfs_is_bound "${dataset}"; then
+		error "dataset is not bound with clevis: ${dataset}"
+	fi
+
+	echo >&2 "Loading existing key... "
+	local existing_key="$(load_key "${dataset}" "${key}")"
+
+	if ! zfs_test_key "${dataset}" <<<"${existing_key}"; then
+		error "given key does not unlock ${dataset}"
+	fi
+
+	echo >&2 -n 'wiping clevis data... '
+	zfs_wipe_clevis_data "${dataset}"
+	echo >&2 'ok'
+}
+main "${@}"

--- a/src/zfs/clevis-zfs-unbind
+++ b/src/zfs/clevis-zfs-unbind
@@ -1,22 +1,21 @@
 #!/bin/bash
 set -euo pipefail
 
-. clevis-zfs-common
-
 SUMMARY="Unbinds a label from a ZFS dataset"
-
 
 function usage() {
 	cat >&2 <<-USAGE_END
-		Usage: clevis zfs unbind [-k KEY] -d DATASET -l LABEL
+		Usage: clevis zfs unbind [-f] [-k KEY] -d DATASET [-a] -l LABEL
 
 		$SUMMARY:
 
-		  -d DATASET  The zfs dataset on which to perform unbinding
+		  -f          Force unbinding dataset
+		  -d DATASET  The ZFS dataset on which to perform unbinding
+		  -a          Unbind all labels
 		  -l LABEL    The label to unbind
 
-		  -k KEY      Non-interactively read zfs password from KEY file
-		  -k -        Non-interactively read zfs password from standard input
+		  -k KEY      Non-interactively read ZFS password from KEY file
+		  -k -        Non-interactively read ZFS password from standard input
 
 	USAGE_END
 }
@@ -46,13 +45,12 @@ function main() {
 	done
 
 	if [ -z "${dataset:-""}" ]; then
-		error "did not specify a device!"
+		error "did not specify a dataset!"
 	fi
 
 	if [[ "${force_unbind}" != 'true' ]]; then
-
 		if ! zfs_is_bound "${dataset}"; then
-			error "dataset is not bound with clevis: ${dataset}"
+			error "dataset is not bound with Clevis: ${dataset}"
 		fi
 
 		local existing_key
@@ -64,19 +62,21 @@ function main() {
 		fi
 	fi
 
-
-
-	echo >&2 -n 'wiping clevis data... '
+	echo >&2 -n 'Wiping Clevis data... '
 	if [[ "${unbind_all}" == 'true' ]]; then
-		labels="$(zfs_get_labels "${dataset}")"
-		for label in ${labels}; do
+		local labels=()
+		read -ra labels <<< "$(zfs_get_labels "${dataset}")"
+		for label in "${labels[@]}"; do
 			zfs_unbind_clevis_label "${dataset}" "${label}"
 		done
 	else
 		zfs_unbind_clevis_label "${dataset}" "${label}"
 	fi
-	echo >&2 'ok'
 
+	echo >&2 'ok'
 }
 
-main "${@}"
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	. clevis-zfs-common
+	main "${@}"
+fi

--- a/src/zfs/clevis-zfs-unbind
+++ b/src/zfs/clevis-zfs-unbind
@@ -81,6 +81,6 @@ function main() {
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-	. clevis-zfs-common
+	. @libexecdir@/clevis-zfs-common
 	main "${@}"
 fi

--- a/src/zfs/clevis-zfs-unbind
+++ b/src/zfs/clevis-zfs-unbind
@@ -48,6 +48,10 @@ function main() {
 		error "did not specify a dataset!"
 	fi
 
+	if [ -z "${label}" ] && [ "${unbind_all}" == 'false' ]; then
+		error "did not specify a label!"
+	fi
+
 	if [[ "${force_unbind}" != 'true' ]]; then
 		if ! zfs_is_bound "${dataset}"; then
 			error "dataset is not bound with Clevis: ${dataset}"

--- a/src/zfs/clevis-zfs-unbind
+++ b/src/zfs/clevis-zfs-unbind
@@ -50,7 +50,7 @@ function main() {
 
 	local existing_key
 	echo >&2 "Loading existing key... "
-	existing_key="$(read_key "${dataset}" "${key}")"
+	existing_key="$(read_passphrase "${dataset}" "${key}")"
 
 	if ! zfs_test_key "${dataset}" <<<"${existing_key}"; then
 		error "given key does not unlock ${dataset}"

--- a/src/zfs/clevis-zfs-unbind
+++ b/src/zfs/clevis-zfs-unbind
@@ -1,39 +1,42 @@
 #!/bin/bash
-set -euo pipefail
+set -eu
 
 . clevis-zfs-common
 
-SUMMARY="Unbinds a ZFS dataset (remove clevis)"
+SUMMARY="Unbinds a label from a ZFS dataset"
 
 
 
 function usage() {
 	cat >&2 <<-USAGE_END
-		Usage: clevis zfs unbind [-k KEY] -d DEV
+		Usage: clevis zfs unbind [-k KEY] -d DATASET -l LABEL
 
 		$SUMMARY:
 
-		  -d DEV  The zfs dataset on which to perform binding
+		  -d DATASET  The zfs dataset on which to perform unbinding
+		  -l LABEL    The label to unbind
 
-		  -k KEY  Non-interactively read zfs password from KEY file
-		  -k -    Non-interactively read zfs password from standard input
+		  -k KEY      Non-interactively read zfs password from KEY file
+		  -k -        Non-interactively read zfs password from standard input
 
 	USAGE_END
 }
 
 
 function main() {
-	if [ $# -eq 1 -a "${1:-}" == "--summary" ]; then
+	if [ $# -eq 1 ] && [ "${1:-}" == "--summary" ]; then
 		echo "$SUMMARY"
 		exit 0
 	fi
 
-	local dataset=
-	local key=
-	while getopts ":hfd:k:" o; do
+	local dataset
+	local key
+	local label
+	while getopts ":hfd:k:l:" o; do
 		case "$o" in
 		d) dataset="$OPTARG";;
 		k) key="$OPTARG";;
+		l) label="$OPTARG";;
 		*) error "unrecognized argument: -${OPTARG}";;
 		esac
 	done
@@ -46,15 +49,16 @@ function main() {
 		error "dataset is not bound with clevis: ${dataset}"
 	fi
 
+	local existing_key
 	echo >&2 "Loading existing key... "
-	local existing_key="$(load_key "${dataset}" "${key}")"
+	existing_key="$(read_key "${dataset}" "${key}")"
 
 	if ! zfs_test_key "${dataset}" <<<"${existing_key}"; then
 		error "given key does not unlock ${dataset}"
 	fi
 
 	echo >&2 -n 'wiping clevis data... '
-	zfs_wipe_clevis_data "${dataset}"
+	zfs_wipe_clevis_data "${dataset}" "${label}"
 	echo >&2 'ok'
 }
 main "${@}"

--- a/src/zfs/clevis-zfs-unlock
+++ b/src/zfs/clevis-zfs-unlock
@@ -81,6 +81,6 @@ function testing() {
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-	. clevis-zfs-common
+	. @libexecdir@/clevis-zfs-common
 	main "${@}"
 fi

--- a/src/zfs/clevis-zfs-unlock
+++ b/src/zfs/clevis-zfs-unlock
@@ -1,22 +1,20 @@
 #!/bin/bash
 set -euo pipefail
 
-SUMMARY="Unlock a ZFS dataset using the saved clevis data"
+SUMMARY="Unlock a ZFS dataset using the saved Clevis data"
 
 function usage() {
 	cat >&2 <<-USAGE_END
-		Usage: clevis zfs unlock [-n] [-k KEY] -d DATASET PIN CFG
+		Usage: clevis zfs unlock [-t] [-l LABEL] -d DATASET
 
 		$SUMMARY:
 
-		  -t          Test the clevis configuration without unlocking
-		  -d DATASET  The zfs dataset to unlock
+		  -t          Test the Clevis configuration without unlocking
+		  -d DATASET  The ZFS dataset to unlock
 		  -l LABEL    Use only this label to unlock (defaults to trying all labels)
 
 	USAGE_END
 }
-
-
 
 function main() {
 	if [ $# -eq 1 ] && [ "${1:-}" == "--summary" ]; then
@@ -27,25 +25,26 @@ function main() {
 	local dataset
 	local test_only=''
 	local label=''
-	while getopts ":d:l:t" o; do
+	while getopts "h:d:l:t" o; do
 		case "$o" in
-		d) dataset="$OPTARG" ;;
-		t) test_only=' (test)' ;;
-		l) label="$OPTARG" ;;
-		*) error "unrecognized argument: -${OPTARG}" ;;
+		h) usage; exit 0;;
+		d) dataset="$OPTARG";;
+		t) test_only=' (test)';;
+		l) label="$OPTARG";;
+		*) error "unrecognized argument: -${OPTARG}";;
 		esac
 	done
 
 	if [ -z "${dataset:-""}" ]; then
-		error "did not specify a device!"
+		error "did not specify a dataset!"
 	fi
 
 	if ! zfs_is_bound "${dataset}"; then
-		error "dataset is not bound with clevis: ${dataset}"
+		error "dataset is not bound with Clevis: ${dataset}"
 	fi
 
 	if [[ -n "${label}" ]]; then
-		label="$(zfs_get_label "${dataset}" "${label}" )"
+		label="$(zfs_get_label "${dataset}" "${label}")"
 		testing -n "unlocking ${dataset} with ${label} ${test_only}... "
 		if unlock_with_label "${dataset}" "${label}" "${test_only}"; then
 			testing 'ok'

--- a/src/zfs/clevis-zfs-unlock
+++ b/src/zfs/clevis-zfs-unlock
@@ -10,8 +10,8 @@ function usage() {
 		$SUMMARY:
 
 		  -t          Test the clevis configuration without unlocking
-
 		  -d DATASET  The zfs dataset to unlock
+		  -l LABEL    Use only this label to unlock (defaults to trying all labels): TODO
 
 	USAGE_END
 }
@@ -23,11 +23,13 @@ function main() {
 	fi
 
 	local dataset
-	local test_only='false'
-	while getopts ":d:t" o; do
+	local test_only=''
+	local label=''
+	while getopts ":d:l:t" o; do
 		case "$o" in
 		d) dataset="$OPTARG" ;;
-		t) test_only='true' ;;
+		t) test_only=' (test)' ;;
+		l) label="$OPTARG" ;;
 		*) error "unrecognized argument: -${OPTARG}" ;;
 		esac
 	done
@@ -42,23 +44,22 @@ function main() {
 
 	local clevis_data password
 
-	echo >&2 -n "loading clevis data from ${dataset}... "
-	clevis_data="$(zfs_get_clevis_data "${dataset}")"
-	password="$(clevis decrypt <<<"${clevis_data}")"
-	echo >&2 'ok'
+	for label in $(zfs_get_labels "${dataset}" | tr ' ' '\n' | grep "^${label}(:|$)"); do
+		echo >&2 -n "loading clevis data from label ${label}... "
+		clevis_data="$(zfs_get_clevis_label "${dataset}" "${label}")"
+		password="$(clevis decrypt <<<"${clevis_data}" || echo '' )"
+		echo >&2 'ok'
 
-	if [[ "${test_only}" == 'true' ]]; then
-		echo >&2 -n "testing key for ${dataset}... "
-		if ! zfs_test_key "${dataset}" <<<"${password}"; then
-			error "testing key for ${dataset} failed"
+		echo >&2 -n "unlocking ${dataset}${test_only}... "
+		if echo "${password}" | zfs_load_key "${dataset}" "${test_only}"; then
+			echo >&2 'ok'
+			[[ -z "${test_only}" ]] && exit 0
+		else
+			echo >&2 "failed"
+			continue
 		fi
-	else
-		echo >&2 -n "unlocking ${dataset}... "
-		if ! zfs_load_key "${dataset}" <<<"${password}"; then
-			error "could not load key for ${dataset}"
-		fi
-	fi
-	echo >&2 'ok'
+	done
+	exit 1
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then

--- a/src/zfs/clevis-zfs-unlock
+++ b/src/zfs/clevis-zfs-unlock
@@ -19,7 +19,7 @@ function usage() {
 
 
 function main() {
-	if [ $# -eq 1 -a "${1:-}" == "--summary" ]; then
+	if [ $# -eq 1 ] && [ "${1:-}" == "--summary" ]; then
 		echo "$SUMMARY"
 		exit 0
 	fi
@@ -44,8 +44,6 @@ function main() {
 		error "dataset is not bound with clevis: ${dataset}"
 	fi
 
-	local clevis_data password labels
-
 	if [[ -n "${label}" ]]; then
 		label="$(zfs_get_label "${dataset}" "${label}" )"
 		testing -n "unlocking ${dataset} with ${label} ${test_only}... "
@@ -57,6 +55,7 @@ function main() {
 			exit 1
 		fi
 	else
+		local labels
 		labels="$(zfs_get_labels "${dataset}")"
 		for label in ${labels}; do
 			testing -n "unlocking ${dataset} with ${label} ${test_only}... "
@@ -79,7 +78,7 @@ function main() {
 
 
 function testing() {
-	[[ -n "${test_only}" ]] && echo >&2 "${@}"
+	[[ -n "${test_only}" ]] && echo >&2 "${@}" || true
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then

--- a/src/zfs/clevis-zfs-unlock
+++ b/src/zfs/clevis-zfs-unlock
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -euo pipefail
+
+. clevis-zfs-common
+
+SUMMARY="Unlock a ZFS dataset using the saved clevis data"
+
+function usage() {
+	cat >&2 <<-USAGE_END
+		Usage: clevis zfs unlock [-n] [-k KEY] -d DATASET PIN CFG
+
+		$SUMMARY:
+
+		  -t          Test the clevis configuration without unlocking
+
+		  -d DATASET  The zfs dataset to unlock
+
+	USAGE_END
+}
+
+function main() {
+	if [ $# -eq 1 -a "${1:-}" == "--summary" ]; then
+		echo "$SUMMARY"
+		exit 0
+	fi
+
+	local dataset
+	local test_only='false'
+	while getopts ":d:t" o; do
+		case "$o" in
+		d) dataset="$OPTARG" ;;
+		t) test_only='true' ;;
+		*) error "unrecognized argument: -${OPTARG}" ;;
+		esac
+	done
+
+	if [ -z "${dataset:-""}" ]; then
+		error "did not specify a device!"
+	fi
+
+	if ! zfs_is_bound "${dataset}"; then
+		error "dataset is not bound with clevis: ${dataset}"
+	fi
+
+	local clevis_data password
+
+	echo >&2 -n "loading clevis data from ${dataset}... "
+	clevis_data="$(zfs_get_clevis_data "${dataset}")"
+	password="$(clevis decrypt <<<"${clevis_data}")"
+	echo >&2 'ok'
+
+	if [[ "${test_only}" == 'true' ]]; then
+		echo >&2 -n "testing key for ${dataset}... "
+		if ! zfs_test_key "${dataset}" <<<"${password}"; then
+			error "testing key for ${dataset} failed"
+		fi
+	else
+		echo >&2 -n "unlocking ${dataset}... "
+		if ! zfs_load_key "${dataset}" <<<"${clevis_data}"; then
+			error "could not load key for ${dataset}"
+		fi
+	fi
+	echo >&2 'ok'
+}
+
+main "${@}"

--- a/src/zfs/clevis-zfs-unlock
+++ b/src/zfs/clevis-zfs-unlock
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-. clevis-zfs-common
-
 SUMMARY="Unlock a ZFS dataset using the saved clevis data"
 
 function usage() {
@@ -63,4 +61,7 @@ function main() {
 	echo >&2 'ok'
 }
 
-main "${@}"
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	. clevis-zfs-common
+	main "${@}"
+fi

--- a/src/zfs/clevis-zfs-unlock
+++ b/src/zfs/clevis-zfs-unlock
@@ -11,10 +11,12 @@ function usage() {
 
 		  -t          Test the clevis configuration without unlocking
 		  -d DATASET  The zfs dataset to unlock
-		  -l LABEL    Use only this label to unlock (defaults to trying all labels): TODO
+		  -l LABEL    Use only this label to unlock (defaults to trying all labels)
 
 	USAGE_END
 }
+
+
 
 function main() {
 	if [ $# -eq 1 -a "${1:-}" == "--summary" ]; then
@@ -42,24 +44,42 @@ function main() {
 		error "dataset is not bound with clevis: ${dataset}"
 	fi
 
-	local clevis_data password
+	local clevis_data password labels
 
-	for label in $(zfs_get_labels "${dataset}" | tr ' ' '\n' | grep "^${label}(:|$)"); do
-		echo >&2 -n "loading clevis data from label ${label}... "
-		clevis_data="$(zfs_get_clevis_label "${dataset}" "${label}")"
-		password="$(clevis decrypt <<<"${clevis_data}" || echo '' )"
-		echo >&2 'ok'
-
-		echo >&2 -n "unlocking ${dataset}${test_only}... "
-		if echo "${password}" | zfs_load_key "${dataset}" "${test_only}"; then
-			echo >&2 'ok'
-			[[ -z "${test_only}" ]] && exit 0
+	if [[ -n "${label}" ]]; then
+		label="$(zfs_get_label "${dataset}" "${label}" )"
+		testing -n "unlocking ${dataset} with ${label} ${test_only}... "
+		if unlock_with_label "${dataset}" "${label}" "${test_only}"; then
+			testing 'ok'
+			exit 0
 		else
-			echo >&2 "failed"
-			continue
+			testing 'failed'
+			exit 1
 		fi
-	done
-	exit 1
+	else
+		labels="$(zfs_get_labels "${dataset}")"
+		for label in ${labels}; do
+			testing -n "unlocking ${dataset} with ${label} ${test_only}... "
+			if unlock_with_label "${dataset}" "${label}" "${test_only}"; then
+				testing 'ok'
+				[[ -z "${test_only}" ]] && exit 0 || true
+			else
+				testing "failed"
+				continue
+			fi
+		done
+	fi
+
+	if [[ -n "${test_only}" ]]; then
+		exit 0
+	else
+		exit 1
+	fi
+}
+
+
+function testing() {
+	[[ -n "${test_only}" ]] && echo >&2 "${@}"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then

--- a/src/zfs/clevis-zfs-unlock
+++ b/src/zfs/clevis-zfs-unlock
@@ -56,7 +56,7 @@ function main() {
 		fi
 	else
 		echo >&2 -n "unlocking ${dataset}... "
-		if ! zfs_load_key "${dataset}" <<<"${clevis_data}"; then
+		if ! zfs_load_key "${dataset}" <<<"${password}"; then
 			error "could not load key for ${dataset}"
 		fi
 	fi

--- a/src/zfs/meson.build
+++ b/src/zfs/meson.build
@@ -1,6 +1,21 @@
-bins += join_paths(meson.current_source_dir(), 'clevis-zfs-bind')
-bins += join_paths(meson.current_source_dir(), 'clevis-zfs-common')
-bins += join_paths(meson.current_source_dir(), 'clevis-zfs-list')
-bins += join_paths(meson.current_source_dir(), 'clevis-zfs-test')
-bins += join_paths(meson.current_source_dir(), 'clevis-zfs-unbind')
-bins += join_paths(meson.current_source_dir(), 'clevis-zfs-unlock')
+install_data(
+  [join_paths(meson.current_source_dir(), 'clevis-zfs-common')],
+  install_dir: libexecdir
+)
+
+zfs_bins = [
+  'clevis-zfs-bind',
+  'clevis-zfs-list',
+  'clevis-zfs-unbind',
+  'clevis-zfs-unlock',
+]
+foreach b : zfs_bins
+  configure_file(
+    input: b,
+    output: b,
+    install_dir: bindir,
+    configuration: data
+  )
+endforeach
+
+test('clevis-zfs-test', find_program(join_paths(meson.current_source_dir(), 'clevis-zfs-test')))

--- a/src/zfs/meson.build
+++ b/src/zfs/meson.build
@@ -1,0 +1,6 @@
+bins += join_paths(meson.current_source_dir(), 'clevis-zfs-bind')
+bins += join_paths(meson.current_source_dir(), 'clevis-zfs-common')
+bins += join_paths(meson.current_source_dir(), 'clevis-zfs-list')
+bins += join_paths(meson.current_source_dir(), 'clevis-zfs-test')
+bins += join_paths(meson.current_source_dir(), 'clevis-zfs-unbind')
+bins += join_paths(meson.current_source_dir(), 'clevis-zfs-unlock')


### PR DESCRIPTION
Supersedes #373. Description copied:

> ## Why
> 
> As I stated a while ago in #218, I would like clevis to be able to unlock ZFS datasets that have native encryption enabled. This is my attempt at adding this by storing the data in zfs properties.
> ## How
> 
> This is achieved by storing the clevis data (output of `clevis-encrypt`) in ZFS User Properties. From `zfsprops(8)`:
> 
> ```
>    User Properties
>      In addition to the standard native properties, ZFS supports arbitrary user properties.  User
>      properties have no effect on ZFS behavior, but applications or administrators can use them
>      to annotate datasets (file systems, volumes, and snapshots).
> 
>      User property names must contain a colon (":") character to distinguish them from native
>      properties.  They may contain lowercase letters, numbers, and the following punctuation
>      characters: colon (":"), dash ("-"), period ("."), and underscore ("_").  The expected
>      convention is that the property name is divided into two portions such as module:property,
>      but this namespace is not enforced by ZFS.  User property names can be at most 256
>      characters, and cannot begin with a dash ("-").
> 
>      When making programmatic use of user properties, it is strongly suggested to use a reversed
>      DNS domain name for the module component of property names to reduce the chance that two
>      independently-developed packages use the same property name for different purposes.
> 
>      The values of user properties are arbitrary strings, are always inherited, and are never
>      validated.  All of the commands that operate on properties (zfs list, zfs get, zfs set, and
>      so forth) can be used to manipulate both native properties and user properties.  Use the zfs
>      inherit command to clear a user property.  If the property is not defined in any parent
>      dataset, it is removed entirely.  Property values are limited to 8192 bytes.
> ```
> 
> ### Properties
> 
> All clevis user properties are prefixed with `latchset.clevis`
> 
>     * one property to check if a dataset is bound: `latchset.clevis:labels`, should be a space-separated list of bound labels.  or absent when unbound.
> 
>     * one or more properties to store the clevis data: `latchset.clevis.label:LABEL_NAME[-N]` where `-N` is an integer suffix when the data for label LABEL_NAME is too large for one property.
> 
> 
> If there are more than 10 properties needed, the integer will be `0`-padded to help with sorting to easily combine them when unlocking.
> 
> As noted above (at the end), the limit of the value of a user property is 8192 bytes. A simple 1-host `tang` setup will probably not go over this limit, but with a more complicated setup with `clevis-encrypt-sss`, it is possible.
> 
> Because of that, the clevis data is split in 8k chunks, and saved in multiple user-properties. These are combined upon unlock.
>
> ## "Works": (works on my machine, needs more testing)
> 
>     * binding ZFS dataset with `clevis-zfs-bind`
> 
>     * unbinding ZFS dataset with `clevis-zfs-unbind`
> 
>     * testing and unlocking ZFS dataset with `clevis-zfs-unlock`
> 
>     * splitting and combining zfs-properties (tested with a limit of 800 instead of 8000)
> 
> 
> ## To Do:
> 
>     * [ ]  manpages
> 
>     * [ ]  initramfs hooks
> 
>     * [ ]  rebinding support? (like clevis-luks-rebind)
> 
>     * [x]  Maybe: multiple "slots" support. Currently only one "slot" is available. Added label support
> 
>     * [x]  clean up commits if this is not squashed

## Further work by @lowjoel:
 * [x] Cleaned up the error messages, fixed lints reported by shellcheck
 * [x] Completed support for initramfs. This requires OpenZFS 2.2+ because of https://github.com/openzfs/zfs/commit/6e015933f88fe7ba5de45cf263028de1ee04460a. Tested on Ubuntu 24.04.
 * [x] Tested Dracut on Ubuntu 26.04.
 * [x] Did a full `clevis-zfs-bind`, `clevis-zfs-unlock` (at reboot), and `clevis-zfs-unbind`
 * [x] [PPA available](https://launchpad.net/~lowjoel/+archive/ubuntu/clevis) for Ubuntu 22.04 
 * [ ] Integrate clevis-zfs-test with Meson

Once we're happy with the code I can squash the commits to those by @techhazard and myself.