### PR TITLE
CentOS Stream 8 test build fix

### DIFF
--- a/.github/workflows/install-dependencies
+++ b/.github/workflows/install-dependencies
@@ -39,6 +39,12 @@ debian:*|ubuntu:*)
     ;;
 
 *centos:*)
+    if [[ "${DISTRO}" ==  *":stream8" ]]; then
+        # See https://serverfault.com/a/1161847/917943
+        sed -i 's/mirror.centos.org/vault.centos.org/g' /etc/yum.repos.d/*.repo
+        sed -i 's/^#.*baseurl=http/baseurl=http/g' /etc/yum.repos.d/*.repo
+        sed -i 's/^mirrorlist=http/#mirrorlist=http/g' /etc/yum.repos.d/*.repo
+    fi
     yum -y clean all
     yum -y --setopt=deltarpm=0 update
     yum install -y yum-utils


### PR DESCRIPTION
This fixes build on CentOS Stream 8 after mirrorlist.centos.org vanished.