### PR TITLE
pkcs11: add Dracut install check

### DIFF
--- a/src/luks/dracut/clevis-pin-pkcs11/module-setup.sh.in
+++ b/src/luks/dracut/clevis-pin-pkcs11/module-setup.sh.in
@@ -17,6 +17,13 @@
 #
 # shellcheck disable=SC2154
 #
+
+check() {
+    require_binaries pcscd pkcs11-tool clevis-decrypt-pkcs11 || return 1
+    require_binaries awk head sed socat tail tr || return 1
+    return 0
+}
+
 depends() {
     echo clevis
     return 255


### PR DESCRIPTION
The check allows installation of all Dracut files together, as it is done with Debian packaging, so that it works even without having pkcs11 pin installed.