### PR TITLE
tpm2: fix dangling loaded session after tpm2_createpolicy

### DIFF
--- a/src/pins/tpm2/clevis-encrypt-tpm2
+++ b/src/pins/tpm2/clevis-encrypt-tpm2
@@ -223,6 +223,7 @@ if [ -n "$pcr_ids" ]; then
         exit 1
     fi
     tpm2_flushcontext -t
+    tpm2_flushcontext -l
 
     policy_options+=(-L "$TMP/pcr.policy")
 else


### PR DESCRIPTION
Clevis cleans the context regurarly from transient objects by invoking `tpm2_flushcontext -t`, but there is one case which Clevis omits. The `tpm2_createpolicy` command loads new session and this needs to be cleaned by a call to `tpm2_flushcontext -l`, see https://github.com/tpm2-software/tpm2-tools/issues/3427.

This is usually not an issue when resource manager is used (i.e. with `/dev/tpmrm0` device), but when raw TPM device `/dev/tpm0` or software TPM (swtpm) without resource manager is used, the usage of clevis (multiple calls are required) ends with the following error:

```
WARNING:esys:src/tss2-esys/api/Esys_StartAuthSession.c:390:Esys_StartAuthSession_Finish() Received TPM Error
ERROR:esys:src/tss2-esys/api/Esys_StartAuthSession.c:136:Esys_StartAuthSession() Esys Finish ErrorCode (0x00000903)
ERROR: Esys_StartAuthSession(0x903) - tpm:warn(2.0): out of memory for session contexts
ERROR: Unable to run tpm2_create
```
