### PR TITLE
pkcs11: add missing threads dependency

### DIFF
--- a/src/pins/pkcs11/meson.build
+++ b/src/pins/pkcs11/meson.build
@@ -27,7 +27,9 @@ if pcscd.found() and pkcs11tool.found()
   ### TODO: Include man pages
   # mans += join_paths(meson.current_source_dir(), 'clevis-decrypt-pkcs11.1')
   subdir('tests')
+  threads_dep = dependency('threads', required: true)
   executable('clevis-pkcs11-afunix-socket-unlock', ['clevis-pkcs11-afunix-socket-unlock.c'],
+    dependencies: threads_dep,
     install_dir: bindir,
     install: true,
     c_args: GIT_VERSION_FLAG


### PR DESCRIPTION
Fixes the following error when building for Debian 11:

```
FAILED: src/pins/pkcs11/clevis-pkcs11-afunix-socket-unlock
cc  -o src/pins/pkcs11/clevis-pkcs11-afunix-socket-unlock src/pins/pkcs11/clevis-pkcs11-afunix-socket-unlock.p/clevis-pkcs11-afunix-socket-unlock.c.o -Wl,--as-needed -Wl,--no-undefined -Wl,-z,relro -Wl,-z,now -g -O2 -ffile-prefix-map=/usr/src/clevis-21=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2
/usr/bin/ld: src/pins/pkcs11/clevis-pkcs11-afunix-socket-unlock.p/clevis-pkcs11-afunix-socket-unlock.c.o: in function `main':
./obj-x86_64-linux-gnu/../src/pins/pkcs11/clevis-pkcs11-afunix-socket-unlock.c:270: undefined reference to `pthread_create'
/usr/bin/ld: ./obj-x86_64-linux-gnu/../src/pins/pkcs11/clevis-pkcs11-afunix-socket-unlock.c:359: undefined reference to `pthread_kill'
/usr/bin/ld: ./obj-x86_64-linux-gnu/../src/pins/pkcs11/clevis-pkcs11-afunix-socket-unlock.c:361: undefined reference to `pthread_join'
collect2: error: ld returned 1 exit status
```