### PR TITLE
pkcs11: provide key file format to openssl

### DIFF
--- a/src/pins/pkcs11/clevis-encrypt-pkcs11
+++ b/src/pins/pkcs11/clevis-encrypt-pkcs11
@@ -112,7 +112,7 @@ if ! pkcs11-tool ${slot_opt} ${module_opt} --read-object --type pubkey --id "${i
     exit 1
 fi
 
-if ! jwk_enc="$(printf '%s' "${jwk}" | openssl rsautl -encrypt -pubin \
+if ! jwk_enc="$(printf '%s' "${jwk}" | openssl rsautl -encrypt -pubin -keyform DER \
                                        -inkey "${PKEY}" 2>${ERR} \
                                      | jose b64 enc -I-)"; then
     cat "${ERR}" >&2


### PR DESCRIPTION
When built under Debian-11, the following error appears:

```
++ echo secret
++ clevis decrypt
++ clevis encrypt pkcs11 '{"uri":"pkcs11:module-path=/usr/lib/softhsm/libsofthsm2.so?pin-value=123456","mechanism":"RSA-PKCS"}'
unable to load Public Key
Unable to encrypt JWK with PKCS#11 public key
```

Fix this by telling the key file format (DER) to OpenSSL.