### PR TITLE
tang: allow reading full request by socat fake http server

### DIFF
--- a/src/pins/tang/tests/tang-common-test-functions.in
+++ b/src/pins/tang/tests/tang-common-test-functions.in
@@ -220,7 +220,7 @@ run_test_server() {
     pidfile="${basedir}/tang.pid"
     portfile="${basedir}/tang.port"
 
-    "${SOCAT}" -v -v TCP4-LISTEN:0,reuseaddr,bind=localhost SYSTEM:"cat ${response}" &
+    "${SOCAT}" -v -v TCP4-LISTEN:0,bind=localhost "SYSTEM:cat ${response}!!OPEN:/dev/null" &
     pid=$!
 
     echo "${pid}" > "${pidfile}"


### PR DESCRIPTION
The `socat` forwards HTTP request to a script and forwards whatever the script produces to the HTTP client. The `socat` in this configuration fails occasionally. When the script is finished and there is still something to be forwarded to it, the `socat` reports a broken pipe. Fix this by explicitly configuring the read and write ends, reading from the file and writing to /dev/null.

This fixes the following build test error:

```
+ clevis encrypt tang '{"url":"localhost:44157"}' -y
> 2024/10/05 14:46:51.000039424  length=82 from=0 to=81
GET /adv/ HTTP/1.1\r
Host: localhost:44157\r
User-Agent: curl/8.6.0\r
Accept: */*\r
\r
2024/10/05 14:46:51 socat[16880] E write(5, 0x55efa9173000, 82): Broken pipe
+ echo 'Error (do_test) response: /tmp/tmp.skxEYJGb28/cases/good-01'
Error (do_test) response: /tmp/tmp.skxEYJGb28/cases/good-01
+ '[' -r /tmp/tmp.skxEYJGb28/cases/good-01.stderr ']'
+ cat /tmp/tmp.skxEYJGb28/cases/good-01.stderr
Unable to fetch advertisement: 'localhost:44157/adv/'!
+ return 1
```