### PR TITLE
luks: make sure cryptsetup.target is installed

### DIFF
--- a/src/luks/dracut/clevis/module-setup.sh.in
+++ b/src/luks/dracut/clevis/module-setup.sh.in
@@ -21,7 +21,7 @@
 depends() {
     local __depends=crypt
     if dracut_module_included "systemd"; then
-        __depends=$(printf '%s systemd' "${__depends}")
+        __depends=$(printf '%s systemd-cryptsetup' "${__depends}")
     fi
     echo "${__depends}"
     return 255
@@ -32,6 +32,7 @@ install() {
         inst_multiple \
             $systemdsystemunitdir/clevis-luks-askpass.service \
             $systemdsystemunitdir/clevis-luks-askpass.path \
+            $systemdsystemunitdir/cryptsetup.target \
             @SYSTEMD_REPLY_PASS@ \
             @libexecdir@/clevis-luks-askpass
 


### PR DESCRIPTION
dracut [v103 ](https://github.com/dracut-ng/dracut-ng/releases/tag/103) introduced systemd-cryptsetup.

dracut [v104](https://github.com/dracut-ng/dracut-ng/releases/tag/104) requires systemd-cryptsetup for cryptsetup.target
(https://github.com/dracut-ng/dracut-ng/commit/ad520855113d99d7551a7ab6c19870736f72cbc4.

CC @BtbN @cornelicorn 