### PR TITLE
initramfs: fix killing child PIDs

### DIFF
--- a/src/initramfs-tools/scripts/local-bottom/clevis.in
+++ b/src/initramfs-tools/scripts/local-bottom/clevis.in
@@ -34,10 +34,21 @@ esac
 [ -s /run/clevis.pid ] || exit 0
 
 pid=$(cat /run/clevis.pid)
-child_pids=$(ps -o pid,ppid | awk -v pid="$pid" '$2==pid { print $1 }')
+child_pids="$({ ps -o pid,ppid 2>/dev/null || ps -l ||
+    { echo 'clevis: unable to get list of processes' >&2; exit 1; }; } |
+    awk -v pid="$pid" '
+        NR==1 {
+            for (i=1; i<=NF; i++) if ($i == "PID") pid_col = i; else if ($i == "PPID") ppid_col = i
+            if (!pid_col || !ppid_col) { print "clevis: unable to find PID and/or PPID columns in ps output" | "cat >&2"; exit 1 }
+            next
+        }
+        { if ($ppid_col == pid) print $pid_col }')"
+
 for kill_pid in $pid $child_pids; do
-	kill "$kill_pid"
+    kill "$kill_pid" 2>/dev/null
 done
+
+rm -f /run/clevis.pid
 
 # Not really worried about downing extra interfaces: they will come up
 # during the actual boot. Might make this configurable later if needed.


### PR DESCRIPTION
Ubuntu's initramfs Busybox does not support `ps -o pid,ppid`, so fallback to unpredictable `ps -l`. In any case use `awk` to find the position of PID and PPID columns and dump appropriate child PIDs. This should be hopefully bullet-proof.

Also clean-up leftover PID file.

Fixes issue [found](https://github.com/latchset/clevis/pull/462#issuecomment-2439735757) when running under Ubuntu's version of Busybox.