### PR TITLE
dracut: fix running with pre-v103 Dracut

### DIFF
--- a/src/luks/dracut/clevis/module-setup.sh.in
+++ b/src/luks/dracut/clevis/module-setup.sh.in
@@ -21,7 +21,13 @@
 depends() {
     local __depends=crypt
     if dracut_module_included "systemd"; then
-        __depends=$(printf '%s systemd-cryptsetup' "${__depends}")
+        # Dracut v103 introduced a separate systemd-cryptsetup module
+        systemd_cryptsetup_dir=$(dracut_module_path "systemd-cryptsetup")
+        if [ -d "$systemd_cryptsetup_dir" ]; then
+            __depends=$(printf '%s systemd-cryptsetup' "${__depends}")
+        else
+            __depends=$(printf '%s systemd' "${__depends}")
+        fi
     fi
     echo "${__depends}"
     return 255
@@ -32,7 +38,6 @@ install() {
         inst_multiple \
             $systemdsystemunitdir/clevis-luks-askpass.service \
             $systemdsystemunitdir/clevis-luks-askpass.path \
-            $systemdsystemunitdir/cryptsetup.target \
             @SYSTEMD_REPLY_PASS@ \
             @libexecdir@/clevis-luks-askpass
 


### PR DESCRIPTION
Dracut v103+ moved SystemD cryptsetup code into a separate module, so detect it and when found, use it.

Clevis units do not depend on `cryptsetup.target`, so do not install it. The target `cryptsetup.target` is installed by both [90systemd-cryptsetup][1] in v103+ and [01systemd-cryptsetup][2] in v105+, so there is no need to install it by Clevis.

Fixes: #493

Note: Tested with Dracut v102 (Fedora 40) and v103 (Fedora Rawhide).

[1]: https://github.com/dracut-ng/dracut-ng/blob/3fce598fb45aa5618cdf885eb48cf327104ffcb8/modules.d/90systemd-cryptsetup/module-setup.sh#L53
[2]: https://github.com/dracut-ng/dracut-ng/blob/a2669c447bd5e0406f55efcc8c9c58be89458b08/modules.d/01systemd-cryptsetup/module-setup.sh#L54
