### PR TITLE
ci: fix fedora 43 (rawhide) build

### DIFF
--- a/.github/workflows/install-dependencies
+++ b/.github/workflows/install-dependencies
@@ -31,6 +31,8 @@ debian:*|ubuntu:*)
 *fedora:*)
     printf 'max_parallel_downloads=10\nfastestmirror=1\n' >> /etc/dnf/dnf.conf
     dnf -y clean all
+    # Fix Fedora 43 (rawhide) build - install systemd and awk
+    dnf -y install --allowerasing systemd awk
     dnf -y --setopt=deltarpm=0 update
     dnf -y install dnf-utils jq socat cryptsetup keyutils cracklib-dicts lsof \
         opensc pcsc-lite softhsm


### PR DESCRIPTION
This fixes build on Fedora 43 (Rawhide) with missing `systemd` and `awk`:

```
Failed to resolve the transaction:
Problem: systemd-257.2-17.fc42.i686 from rawhide has inferior architecture
  - package device-mapper-1.02.204-3.fc42.x86_64 from rawhide requires systemd >= 256~rc1, but none of the providers can be installed
  - problem with installed package
  - installed package systemd-standalone-sysusers-257.2-17.fc42.x86_64 conflicts with systemd provided by systemd-257.2-17.fc42.x86_64 from rawhide
  - package systemd-257.2-17.fc42.x86_64 from rawhide conflicts with systemd-standalone-sysusers provided by systemd-standalone-sysusers-257.2-17.fc42.x86_64 from rawhide
  - package device-mapper-libs-1.02.204-3.fc42.x86_64 from rawhide requires device-mapper = 1.02.204-3.fc42, but none of the providers can be installed
  - package cryptsetup-libs-2.7.5-2.fc42.x86_64 from rawhide requires libdevmapper.so.1.02()(64bit), but none of the providers can be installed
  - package cryptsetup-libs-2.7.5-2.fc42.x86_64 from rawhide requires libdevmapper.so.1.02(Base)(64bit), but none of the providers can be installed
  - package cryptsetup-libs-2.7.5-2.fc42.x86_64 from rawhide requires libdevmapper.so.1.02(DM_1_02_197)(64bit), but none of the providers can be installed
  - package cryptsetup-libs-2.7.5-2.fc42.x86_64 from rawhide requires libdevmapper.so.1.02(DM_1_02_97)(64bit), but none of the providers can be installed
  - package cryptsetup-libs-2.7.5-2.fc42.x86_64 from rawhide requires libdevmapper.so.1.02(DM_1_02_98)(64bit), but none of the providers can be installed
  - package cryptsetup-2.7.5-2.fc42.x86_64 from rawhide requires libcryptsetup.so.12()(64bit), but none of the providers can be installed
  - package cryptsetup-2.7.5-2.fc42.x86_64 from rawhide requires libcryptsetup.so.12(CRYPTSETUP_2.0)(64bit), but none of the providers can be installed
  - package cryptsetup-2.7.5-2.fc42.x86_64 from rawhide requires libcryptsetup.so.12(CRYPTSETUP_2.4)(64bit), but none of the providers can be installed
  - package cryptsetup-2.7.5-2.fc42.x86_64 from rawhide requires libcryptsetup.so.12(CRYPTSETUP_2.7)(64bit), but none of the providers can be installed
  - package cryptsetup-2.7.5-2.fc42.x86_64 from rawhide requires libcryptsetup.so.12(CRYPTSETUP_2.6)(64bit), but none of the providers can be installed
  - conflicting requests
```