### PR TITLE
fix missing pkcs11 when libexecdir is configured

### DIFF
--- a/src/luks/dracut/clevis-pin-pkcs11/clevis-pkcs11-hook.sh.in
+++ b/src/luks/dracut/clevis-pin-pkcs11/clevis-pkcs11-hook.sh.in
@@ -21,6 +21,6 @@
 if [ ! -f /run/systemd/clevis-pkcs11.run ] && [ -d /run/systemd ];
 then
     clevis_start_pcscd_server
-    echo "" > /run/systemd/clevis-pkcs11.run
-    /usr/libexec/clevis-luks-pkcs11-askpin -d -r
+    echo "" >/run/systemd/clevis-pkcs11.run
+    @libexecdir@/clevis-luks-pkcs11-askpin -d -r
 fi

--- a/src/luks/dracut/clevis-pin-pkcs11/meson.build
+++ b/src/luks/dracut/clevis-pin-pkcs11/meson.build
@@ -10,7 +10,12 @@ if dracut.found()
     configuration: data,
   )
 
-  install_data('clevis-pkcs11-hook.sh', install_dir: dracutdir)
+  configure_file(
+    input: 'clevis-pkcs11-hook.sh.in',
+    output: 'clevis-pkcs11-hook.sh',
+    install_dir: dracutdir,
+    configuration: data,
+    )
   install_data('clevis-pkcs11-prehook.sh', install_dir: dracutdir)
 
 else

--- a/src/luks/dracut/clevis-pin-pkcs11/module-setup.sh.in
+++ b/src/luks/dracut/clevis-pin-pkcs11/module-setup.sh.in
@@ -51,8 +51,8 @@ install() {
         /etc/opensc.conf \
         /usr/lib64/ossl-modules/legacy.so \
         /lib64/libpcsclite.so.1 \
-        /usr/libexec/clevis-luks-pkcs11-askpass \
-        /usr/libexec/clevis-luks-pkcs11-askpin \
+        @libexecdir@/clevis-luks-pkcs11-askpass \
+        @libexecdir@/clevis-luks-pkcs11-askpin \
         clevis-luks-common-functions \
         clevis-pkcs11-afunix-socket-unlock \
         clevis-pkcs11-common \

--- a/src/luks/systemd/clevis-luks-pkcs11-askpass.in
+++ b/src/luks/systemd/clevis-luks-pkcs11-askpass.in
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-/usr/libexec/clevis-luks-pkcs11-askpin -r &
+@libexecdir@/clevis-luks-pkcs11-askpin -r &
 # Wait 60 seconds to attend key requests from systemd
 # If control socket starts receiving information, this time is cancelled
 clevis-pkcs11-afunix-socket-unlock -l /run/systemd/clevis-pkcs11-systemd.log -f /run/systemd/clevis-pkcs11.sock -s 60

--- a/src/luks/systemd/clevis-luks-pkcs11-askpass.service.in
+++ b/src/luks/systemd/clevis-luks-pkcs11-askpass.service.in
@@ -5,4 +5,4 @@ PartOf=clevis-luks-pkcs11-askpass.socket
 
 [Service]
 Type=simple
-ExecStart=/usr/libexec/clevis-luks-pkcs11-askpass
+ExecStart=@libexecdir@/clevis-luks-pkcs11-askpass


### PR DESCRIPTION
should resolve error in dracut installing `clevis-luks-pkcs11-askpass` & `clevis-luks-pkcs11-askpin` for distros where `libexecdir` is configured elsewhere than `/usr/libexec` (Arch et. al.)