### PR TITLE
Use awk instead of cut to extract the device field from $IP

### DIFF
--- a/src/initramfs-tools/scripts/local-top/clevis.in
+++ b/src/initramfs-tools/scripts/local-top/clevis.in
@@ -221,7 +221,7 @@ clevis_all_netbootable_devices() {
 }
 
 get_specified_device() {
-    local dev="$(echo $IP | cut -d: -f6)"
+    local dev="$(echo $IP | awk -F: '{ print $6 }')"
     [ -z "$dev" ] || echo $dev
 }
 


### PR DESCRIPTION
**Description:**  
This change replaces the use of `cut -d: -f6` with `awk -F: '{ print $6 }'` when extracting the device/interface field from the `$IP` variable in the `get_specified_device()` function.

**Reason:**  
The issue with using `cut -d: -f6` is that if the `$IP` variable does not contain any `:` separator, `cut` returns the entire value of `$IP` instead of an empty string. This can cause Clevis to incorrectly interpret the whole `$IP` value as an interface name and wait for it to appear, which is not the intended behavior.

**Our Use Case**
We need to disable network configuration in the initramfs via `GRUB_CMDLINE_LINUX` (by setting `ip=none`) because we handle network setup, including VLAN interface creation, in a custom `init-premount` script within the initramfs. This approach is required since the standard initramfs network configuration does not support our VLAN setup.

However, when we set `GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX ip=none"`, Clevis incorrectly tries to wait for an interface named "none" to appear, which is not the intended behavior. The goal is to prevent initramfs from configuring the network so that our script can do it properly for VLANs, but Clevis should not interpret "none" as an actual interface name.

```
$> echo none | cut -d: -f6
none
```