### PR TITLE
initramfs: redirect 'ip route' output to null

### DIFF
--- a/src/initramfs-tools/scripts/local-bottom/clevis.in
+++ b/src/initramfs-tools/scripts/local-bottom/clevis.in
@@ -58,6 +58,6 @@ for iface in /sys/class/net/*; do
         iface=$(basename "$iface")
         ip link  set   dev "$iface" down
         ip addr  flush dev "$iface"
-        ip route flush dev "$iface"
+        ip route flush dev "$iface" > /dev/null 2>&1
     fi
 done


### PR DESCRIPTION
this silences the spurious "ipv4: FIB table does not exist" error

for more context:
https://www.mail-archive.com/netdev@vger.kernel.org/msg291638.html
https://bugzilla.ipfire.org/show_bug.cgi?id=12763

closes #506
