### PR TITLE
clevis-luks-askpass: allow non-block-device volumes

### DIFF
--- a/src/luks/systemd/clevis-luks-askpass.in
+++ b/src/luks/systemd/clevis-luks-askpass.in
@@ -50,7 +50,7 @@ while true; do
             esac
         done < "$question"
 
-        [ -b "${d}" ] || continue
+        [ -e "${d}" ] || continue
         [ -S "${s}" ] || continue
 
         if ! pt="$(clevis_luks_unlock_device "${d}")" || [ -z "${pt}" ]; then


### PR DESCRIPTION
Change the check on the volume that's being unlocked from -b (checks for block device) to -e (checks if file exists). This allows the code to work on LUKS volumes that are stored in normal files.

Resolves #526.