### PR TITLE
dracut: move the dracut module to 50 ordering (from 60)

### DIFF
--- a/src/luks/dracut/clevis-pin-null/meson.build
+++ b/src/luks/dracut/clevis-pin-null/meson.build
@@ -1,7 +1,7 @@
 dracut = dependency('dracut', required: false)
 
 if dracut.found()
-  dracutdir = dracut.get_pkgconfig_variable('dracutmodulesdir') + '/60' + meson.project_name() + '-pin-null'
+  dracutdir = dracut.get_pkgconfig_variable('dracutmodulesdir') + '/50' + meson.project_name() + '-pin-null'
 
   configure_file(
     input: 'module-setup.sh.in',

--- a/src/luks/dracut/clevis-pin-pkcs11/meson.build
+++ b/src/luks/dracut/clevis-pin-pkcs11/meson.build
@@ -1,7 +1,7 @@
 dracut = dependency('dracut', required: false)
 
 if dracut.found()
-  dracutdir = dracut.get_pkgconfig_variable('dracutmodulesdir') + '/60' + meson.project_name() + '-pin-pkcs11'
+  dracutdir = dracut.get_pkgconfig_variable('dracutmodulesdir') + '/50' + meson.project_name() + '-pin-pkcs11'
 
   configure_file(
     input: 'module-setup.sh.in',

--- a/src/luks/dracut/clevis-pin-sss/meson.build
+++ b/src/luks/dracut/clevis-pin-sss/meson.build
@@ -1,7 +1,7 @@
 dracut = dependency('dracut', required: false)
 
 if dracut.found()
-  dracutdir = dracut.get_pkgconfig_variable('dracutmodulesdir') + '/60' + meson.project_name() + '-pin-sss'
+  dracutdir = dracut.get_pkgconfig_variable('dracutmodulesdir') + '/50' + meson.project_name() + '-pin-sss'
 
   configure_file(
     input: 'module-setup.sh.in',

--- a/src/luks/dracut/clevis-pin-tang/meson.build
+++ b/src/luks/dracut/clevis-pin-tang/meson.build
@@ -1,7 +1,7 @@
 dracut = dependency('dracut', required: false)
 
 if dracut.found()
-  dracutdir = dracut.get_pkgconfig_variable('dracutmodulesdir') + '/60' + meson.project_name() + '-pin-tang'
+  dracutdir = dracut.get_pkgconfig_variable('dracutmodulesdir') + '/50' + meson.project_name() + '-pin-tang'
 
   configure_file(
     input: 'module-setup.sh.in',

--- a/src/luks/dracut/clevis-pin-tpm2/meson.build
+++ b/src/luks/dracut/clevis-pin-tpm2/meson.build
@@ -1,7 +1,7 @@
 dracut = dependency('dracut', required: false)
 
 if dracut.found()
-  dracutdir = dracut.get_pkgconfig_variable('dracutmodulesdir') + '/60' + meson.project_name() + '-pin-tpm2'
+  dracutdir = dracut.get_pkgconfig_variable('dracutmodulesdir') + '/50' + meson.project_name() + '-pin-tpm2'
 
   configure_file(
     input: 'module-setup.sh.in',

--- a/src/luks/dracut/clevis/meson.build
+++ b/src/luks/dracut/clevis/meson.build
@@ -1,7 +1,7 @@
 dracut = dependency('dracut', required: false)
 
 if dracut.found()
-  dracutdir = dracut.get_pkgconfig_variable('dracutmodulesdir') + '/60' + meson.project_name()
+  dracutdir = dracut.get_pkgconfig_variable('dracutmodulesdir') + '/50' + meson.project_name()
 
   configure_file(
     input: 'module-setup.sh.in',

--- a/src/pins/file/meson.build
+++ b/src/pins/file/meson.build
@@ -18,7 +18,7 @@ env.append('PATH',
 test('pin-file', find_program('./pin-file'), env: env)
 
 if dracut.found()
-  dracutdir = dracut.get_pkgconfig_variable('dracutmodulesdir') + '/60' + meson.project_name() + '-pin-file'
+  dracutdir = dracut.get_pkgconfig_variable('dracutmodulesdir') + '/50' + meson.project_name() + '-pin-file'
   configure_file(
     input: 'dracut.module-setup.sh.in',
     output: 'module-setup.sh',

--- a/src/pins/template/meson.build
+++ b/src/pins/template/meson.build
@@ -35,7 +35,7 @@ endif
 
 #%# dracut support
 if dracut.found()
-  dracutdir = dracut.get_pkgconfig_variable('dracutmodulesdir') + '/60' + meson.project_name() + '-pin-@pin@'
+  dracutdir = dracut.get_pkgconfig_variable('dracutmodulesdir') + '/50' + meson.project_name() + '-pin-@pin@'
 #?# In general, substituation is not needed but it's better to
 #?# stay flexible.
   configure_file(


### PR DESCRIPTION
Follow the recommended dracut module ordering for out-of-tree modules.

For dracut release v108 or later the recommended ordering for out out of tree modules is 50-59 range. The following is a section from dracut documentation:

> Not using the 50-59 range for out of tree dracut modules will likely
> lead to unintended errors in the initramfs generation process as your
> dracut module will either run too early or too late in the generation process.
> You have been warned.