### PR TITLE
Use bash instead of sh for clevis-luks-unlocker

### DIFF
--- a/src/luks/dracut/clevis/clevis-luks-unlocker
+++ b/src/luks/dracut/clevis/clevis-luks-unlocker
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -eu
 # vim: set ts=8 shiftwidth=4 softtabstop=4 expandtab smarttab colorcolumn=80:
 #


### PR DESCRIPTION
This is needed as clevis-luks-unlocker sources
clevis-luks-common-functions which requires bash due to use of `[[ ]]`.
