### PR TITLE
Correct LUKS hash handling

### DIFF
--- a/src/luks/clevis-luks-common-functions.in
+++ b/src/luks/clevis-luks-common-functions.in
@@ -795,6 +795,23 @@ clevis_luks_luksmeta_sync_fix() {
     luksmeta wipe -f -d "${DEV}" -s "${first_free_slot}"
 }
 
+# clevis_luks_get_hash() returns the hash algorithm used by a LUKS device.
+clevis_luks_get_hash() {
+    local DEV="${1}"
+    [ -z "${DEV}" ] && return 1
+
+    local luks_type hash
+    luks_type=$(clevis_luks_type "${DEV}") || return 1
+
+    case "${luks_type}" in
+        luks1) hash=$(cryptsetup luksDump "${DEV}" \
+                      | sed -rn 's|^Hash spec:\s+(\S+)$|\1|p');;
+        luks2) hash=$(cryptsetup luksDump "${DEV}" \
+                      | sed -rn 's|^\s+Hash:\s+(\S+)$|\1|p' | head -1);;
+    esac
+    echo "${hash}"
+}
+
 # clevis_luks_add_key() adds a new key to a key slot.
 clevis_luks_add_key() {
     local DEV="${1}"
@@ -818,6 +835,12 @@ clevis_luks_add_key() {
         input="$(printf '%s' "${NEWKEY}")"
     fi
     local pbkdf_args="--pbkdf pbkdf2 --pbkdf-force-iterations 1000"
+
+    local hash
+    hash=$(clevis_luks_get_hash "${DEV}")
+    if [ -n "${hash}" ]; then
+        pbkdf_args="${pbkdf_args} --hash ${hash}"
+    fi
 
     printf '%s' "${input}" | cryptsetup luksAddKey --force-password --batch-mode \
                                          --key-slot "${SLT}" \
@@ -858,6 +881,12 @@ clevis_luks_update_key() {
     fi
 
     local pbkdf_args="--pbkdf pbkdf2 --pbkdf-force-iterations 1000"
+
+    local hash
+    hash=$(clevis_luks_get_hash "${DEV}")
+    if [ -n "${hash}" ]; then
+        pbkdf_args="${pbkdf_args} --hash ${hash}"
+    fi
 
     if [ -n "${in_place}" ]; then
         printf '%s' "${input}" | cryptsetup luksChangeKey "${DEV}" \

--- a/src/luks/clevis-luks-common-functions.in
+++ b/src/luks/clevis-luks-common-functions.in
@@ -804,12 +804,20 @@ clevis_luks_get_hash() {
     luks_type=$(clevis_luks_type "${DEV}") || return 1
 
     case "${luks_type}" in
-        luks1) hash=$(cryptsetup luksDump "${DEV}" \
-                      | sed -rn 's|^Hash spec:\s+(\S+)$|\1|p');;
-        luks2) hash=$(cryptsetup luksDump "${DEV}" \
-                      | sed -rn 's|^\s+Hash:\s+(\S+)$|\1|p' | head -1);;
+        luks1) hash=$(cryptsetup luksDump "${DEV}" 2>/dev/null \
+                      | awk '/^Hash spec:[ \t]+/{print $3; exit}');;
+        luks2) hash=$(cryptsetup luksDump "${DEV}" 2>/dev/null \
+                      | awk '/^[[:space:]]+[0-9]+: luks/{in_slot=1}
+                             in_slot && /Hash:/{print $2; exit}');;
+        *) return 1;;
     esac
-    echo "${hash}"
+
+    # Validate: only allow alphanumeric characters, hyphens and underscores.
+    case "${hash}" in
+        *[!a-zA-Z0-9_-]*|"") return 1;;
+    esac
+
+    printf '%s\n' "${hash}"
 }
 
 # clevis_luks_add_key() adds a new key to a key slot.

--- a/src/luks/tests/bind-hash-luks1
+++ b/src/luks/tests/bind-hash-luks1
@@ -1,0 +1,64 @@
+#!/bin/bash -ex
+#
+# Copyright (c) 2026 Red Hat, Inc.
+# Author: Sergio Arroutbi <sarroutb@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+TEST=$(basename "${0}")
+. tests-common-functions
+
+. clevis-luks-common-functions
+
+on_exit() {
+    [ -d "${TMP}" ] && rm -rf "${TMP}"
+}
+
+trap 'on_exit' EXIT
+trap 'exit' ERR
+
+TMP="$(mktemp -d)"
+
+ADV="${TMP}/adv.jws"
+tang_create_adv "${TMP}" "${ADV}"
+CFG="$(printf '{"url":"foobar","adv":"%s"}' "$ADV")"
+
+# LUKS1 with sha512.
+DEV="${TMP}/luks1-device-sha512"
+new_device_hash "luks1" "${DEV}" "sha512"
+
+# Verify the device was created with sha512.
+hash_before=$(cryptsetup luksDump "${DEV}" \
+              | sed -rn 's|^Hash spec:\s+(\S+)$|\1|p')
+if [ "${hash_before}" != "sha512" ]; then
+    error "${TEST}: Device should have been formatted with sha512, got ${hash_before}."
+fi
+
+if ! clevis luks bind -f -d "${DEV}" tang "${CFG}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: Binding is expected to succeed."
+fi
+
+# Verify the clevis slot also uses sha512.
+hash_after=$(cryptsetup luksDump "${DEV}" \
+             | sed -rn 's|^Hash spec:\s+(\S+)$|\1|p')
+if [ "${hash_after}" != "sha512" ]; then
+    error "${TEST}: After binding, hash should be sha512, got ${hash_after}."
+fi
+
+# Also check individual key slot hash via clevis_luks_get_hash.
+hash_fn=$(clevis_luks_get_hash "${DEV}")
+if [ "${hash_fn}" != "sha512" ]; then
+    error "${TEST}: clevis_luks_get_hash should return sha512, got ${hash_fn}."
+fi

--- a/src/luks/tests/bind-hash-luks2
+++ b/src/luks/tests/bind-hash-luks2
@@ -1,0 +1,70 @@
+#!/bin/bash -ex
+#
+# Copyright (c) 2026 Red Hat, Inc.
+# Author: Sergio Arroutbi <sarroutb@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+TEST=$(basename "${0}")
+. tests-common-functions
+
+. clevis-luks-common-functions
+
+on_exit() {
+    [ -d "${TMP}" ] && rm -rf "${TMP}"
+}
+
+trap 'on_exit' EXIT
+trap 'exit' ERR
+
+TMP="$(mktemp -d)"
+
+ADV="${TMP}/adv.jws"
+tang_create_adv "${TMP}" "${ADV}"
+CFG="$(printf '{"url":"foobar","adv":"%s"}' "$ADV")"
+
+# LUKS2 with sha512.
+DEV="${TMP}/luks2-device-sha512"
+if ! luks2_supported; then
+    skip_test "LUKS2 is not supported."
+fi
+
+new_device_hash "luks2" "${DEV}" "sha512"
+
+# Verify the device was created with sha512.
+hash_before=$(cryptsetup luksDump "${DEV}" \
+              | sed -rn 's|^\s+Hash:\s+(\S+)$|\1|p' | head -1)
+if [ "${hash_before}" != "sha512" ]; then
+    error "${TEST}: Device should have been formatted with sha512, got ${hash_before}."
+fi
+
+if ! clevis luks bind -f -d "${DEV}" tang "${CFG}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: Binding is expected to succeed."
+fi
+
+# After binding, check that the new clevis slot also uses sha512.
+# For LUKS2, we check the hash of the clevis key slot (slot 1).
+# LUKS2 luksDump format lists slots as "  1: luks2", not "Key Slot 1".
+hash_slot1=$(cryptsetup luksDump "${DEV}" \
+             | awk '/^[[:space:]]+1: luks/{found=1} found && /Hash:/{print $2; exit}')
+if [ "${hash_slot1}" != "sha512" ]; then
+    error "${TEST}: Clevis slot hash should be sha512, got ${hash_slot1}."
+fi
+
+# Also check via clevis_luks_get_hash.
+hash_fn=$(clevis_luks_get_hash "${DEV}")
+if [ "${hash_fn}" != "sha512" ]; then
+    error "${TEST}: clevis_luks_get_hash should return sha512, got ${hash_fn}."
+fi

--- a/src/luks/tests/edit-hash-luks1
+++ b/src/luks/tests/edit-hash-luks1
@@ -1,0 +1,95 @@
+#!/bin/bash -ex
+#
+# Copyright (c) 2026 Red Hat, Inc.
+# Author: Sergio Arroutbi <sarroutb@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+TEST=$(basename "${0}")
+. tests-common-functions
+
+. clevis-luks-common-functions
+
+on_exit() {
+    local d
+    for d in "${TMP}" "${TMP2}"; do
+        [ ! -d "${d}" ] && continue
+        tang_stop "${d}"
+        rm -rf "${d}"
+    done
+}
+
+trap 'on_exit' EXIT
+trap 'on_exit' ERR
+
+TMP="$(mktemp -d)"
+
+tang_run "${TMP}"
+port=$(tang_get_port "${TMP}")
+
+url="http://localhost:${port}"
+
+cfg=$(printf '{"url":"%s"}' "${url}")
+
+# LUKS1 with sha512.
+DEV="${TMP}/luks1-device-sha512"
+new_device_hash "luks1" "${DEV}" "sha512"
+
+# Verify the device was created with sha512.
+hash_before=$(cryptsetup luksDump "${DEV}" \
+              | sed -rn 's|^Hash spec:\s+(\S+)$|\1|p')
+if [ "${hash_before}" != "sha512" ]; then
+    error "${TEST}: Device should have been formatted with sha512, got ${hash_before}."
+fi
+
+if ! clevis luks bind -y -d "${DEV}" tang "${cfg}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: Bind should have succeeded."
+fi
+
+# Verify hash is still sha512 after binding.
+hash_after_bind=$(cryptsetup luksDump "${DEV}" \
+                  | sed -rn 's|^Hash spec:\s+(\S+)$|\1|p')
+if [ "${hash_after_bind}" != "sha512" ]; then
+    error "${TEST}: After binding, hash should be sha512, got ${hash_after_bind}."
+fi
+
+# Now let's have another tang instance running and change the config to use
+# the new one.
+TMP2="$(mktemp -d)"
+tang_run "${TMP2}"
+port2=$(tang_get_port "${TMP2}")
+new_url="http://localhost:${port2}"
+new_cfg=$(printf '{"url":"%s"}' "${new_url}")
+
+if ! clevis luks edit -d "${DEV}" -s 1 -c "${new_cfg}"; then
+    error "${TEST}: edit should have succeeded."
+fi
+
+# Verify hash is still sha512 after edit.
+hash_after_edit=$(cryptsetup luksDump "${DEV}" \
+                  | sed -rn 's|^Hash spec:\s+(\S+)$|\1|p')
+if [ "${hash_after_edit}" != "sha512" ]; then
+    error "${TEST}: After edit, hash should be sha512, got ${hash_after_edit}."
+fi
+
+# Also check via clevis_luks_get_hash.
+hash_fn=$(clevis_luks_get_hash "${DEV}")
+if [ "${hash_fn}" != "sha512" ]; then
+    error "${TEST}: clevis_luks_get_hash should return sha512, got ${hash_fn}."
+fi
+
+# Make sure we can still unlock the device.
+if ! clevis_luks_unlock_device "${DEV}" >/dev/null; then
+    error "${TEST}: we should have been able to unlock the device"
+fi

--- a/src/luks/tests/edit-hash-luks2
+++ b/src/luks/tests/edit-hash-luks2
@@ -1,0 +1,100 @@
+#!/bin/bash -ex
+#
+# Copyright (c) 2026 Red Hat, Inc.
+# Author: Sergio Arroutbi <sarroutb@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+TEST=$(basename "${0}")
+. tests-common-functions
+
+. clevis-luks-common-functions
+
+on_exit() {
+    local d
+    for d in "${TMP}" "${TMP2}"; do
+        [ ! -d "${d}" ] && continue
+        tang_stop "${d}"
+        rm -rf "${d}"
+    done
+}
+
+trap 'on_exit' EXIT
+trap 'on_exit' ERR
+
+TMP="$(mktemp -d)"
+
+# LUKS2.
+if ! luks2_supported; then
+    skip_test "LUKS2 is not supported."
+fi
+
+tang_run "${TMP}"
+port=$(tang_get_port "${TMP}")
+
+url="http://localhost:${port}"
+
+cfg=$(printf '{"url":"%s"}' "${url}")
+
+# LUKS2 with sha512.
+DEV="${TMP}/luks2-device-sha512"
+new_device_hash "luks2" "${DEV}" "sha512"
+
+# Verify the device was created with sha512.
+hash_before=$(cryptsetup luksDump "${DEV}" \
+              | sed -rn 's|^\s+Hash:\s+(\S+)$|\1|p' | head -1)
+if [ "${hash_before}" != "sha512" ]; then
+    error "${TEST}: Device should have been formatted with sha512, got ${hash_before}."
+fi
+
+if ! clevis luks bind -y -d "${DEV}" tang "${cfg}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: Bind should have succeeded."
+fi
+
+# Verify the clevis slot (slot 1) uses sha512 after binding.
+hash_after_bind=$(cryptsetup luksDump "${DEV}" \
+                  | awk '/^[[:space:]]+1: luks/{found=1} found && /Hash:/{print $2; exit}')
+if [ "${hash_after_bind}" != "sha512" ]; then
+    error "${TEST}: After binding, clevis slot hash should be sha512, got ${hash_after_bind}."
+fi
+
+# Now let's have another tang instance running and change the config to use
+# the new one.
+TMP2="$(mktemp -d)"
+tang_run "${TMP2}"
+port2=$(tang_get_port "${TMP2}")
+new_url="http://localhost:${port2}"
+new_cfg=$(printf '{"url":"%s"}' "${new_url}")
+
+if ! clevis luks edit -d "${DEV}" -s 1 -c "${new_cfg}"; then
+    error "${TEST}: edit should have succeeded."
+fi
+
+# Verify the clevis slot (slot 1) still uses sha512 after edit.
+hash_after_edit=$(cryptsetup luksDump "${DEV}" \
+                  | awk '/^[[:space:]]+1: luks/{found=1} found && /Hash:/{print $2; exit}')
+if [ "${hash_after_edit}" != "sha512" ]; then
+    error "${TEST}: After edit, clevis slot hash should be sha512, got ${hash_after_edit}."
+fi
+
+# Also check via clevis_luks_get_hash.
+hash_fn=$(clevis_luks_get_hash "${DEV}")
+if [ "${hash_fn}" != "sha512" ]; then
+    error "${TEST}: clevis_luks_get_hash should return sha512, got ${hash_fn}."
+fi
+
+# Make sure we can still unlock the device.
+if ! clevis_luks_unlock_device "${DEV}" >/dev/null; then
+    error "${TEST}: we should have been able to unlock the device"
+fi

--- a/src/luks/tests/get-hash-luks1
+++ b/src/luks/tests/get-hash-luks1
@@ -1,0 +1,94 @@
+#!/bin/bash -ex
+#
+# Copyright (c) 2026 Red Hat, Inc.
+# Author: Sergio Arroutbi <sarroutb@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+TEST=$(basename "${0}")
+. tests-common-functions
+
+. clevis-luks-common-functions
+
+on_exit() {
+    [ -d "${TMP}" ] && rm -rf "${TMP}"
+}
+
+trap 'on_exit' EXIT
+trap 'exit' ERR
+
+TMP="$(mktemp -d)"
+
+# Test 1: clevis_luks_get_hash with empty argument should fail.
+if clevis_luks_get_hash ""; then
+    error "${TEST}: clevis_luks_get_hash should fail with empty argument."
+fi
+
+# Test 2: clevis_luks_get_hash with non-existent device should fail.
+if clevis_luks_get_hash "/dev/nonexistent-device-XYZ"; then
+    error "${TEST}: clevis_luks_get_hash should fail with non-existent device."
+fi
+
+# Test 3: LUKS1 device with default hash (sha256) — verify correct extraction.
+DEV="${TMP}/luks1-device-sha256"
+new_device_hash "luks1" "${DEV}" "sha256"
+
+hash=$(clevis_luks_get_hash "${DEV}")
+if [ "${hash}" != "sha256" ]; then
+    error "${TEST}: expected sha256, got '${hash}'."
+fi
+
+# Test 4: LUKS1 device with sha512 — verify correct extraction.
+DEV="${TMP}/luks1-device-sha512"
+new_device_hash "luks1" "${DEV}" "sha512"
+
+hash=$(clevis_luks_get_hash "${DEV}")
+if [ "${hash}" != "sha512" ]; then
+    error "${TEST}: expected sha512, got '${hash}'."
+fi
+
+# Test 5: LUKS1 device with sha384 — verify correct extraction.
+DEV="${TMP}/luks1-device-sha384"
+new_device_hash "luks1" "${DEV}" "sha384"
+
+hash=$(clevis_luks_get_hash "${DEV}")
+if [ "${hash}" != "sha384" ]; then
+    error "${TEST}: expected sha384, got '${hash}'."
+fi
+
+# Test 6: LUKS1 device with sha1 — verify correct extraction.
+DEV="${TMP}/luks1-device-sha1"
+new_device_hash "luks1" "${DEV}" "sha1"
+
+hash=$(clevis_luks_get_hash "${DEV}")
+if [ "${hash}" != "sha1" ]; then
+    error "${TEST}: expected sha1, got '${hash}'."
+fi
+
+# Test 7: LUKS1 device with ripemd160 — verify correct extraction.
+DEV="${TMP}/luks1-device-ripemd160"
+new_device_hash "luks1" "${DEV}" "ripemd160"
+
+hash=$(clevis_luks_get_hash "${DEV}")
+if [ "${hash}" != "ripemd160" ]; then
+    error "${TEST}: expected ripemd160, got '${hash}'."
+fi
+
+# Test 8: clevis_luks_get_hash with a non-LUKS file should fail.
+DEV="${TMP}/not-a-luks-device"
+fallocate -l64M "${DEV}" 2>/dev/null \
+    || dd if=/dev/zero of="${DEV}" bs=1M count=64 status=none
+if clevis_luks_get_hash "${DEV}"; then
+    error "${TEST}: clevis_luks_get_hash should fail on a non-LUKS file."
+fi

--- a/src/luks/tests/get-hash-luks2
+++ b/src/luks/tests/get-hash-luks2
@@ -1,0 +1,92 @@
+#!/bin/bash -ex
+#
+# Copyright (c) 2026 Red Hat, Inc.
+# Author: Sergio Arroutbi <sarroutb@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+TEST=$(basename "${0}")
+. tests-common-functions
+
+. clevis-luks-common-functions
+
+if ! luks2_supported; then
+    skip_test "LUKS2 is not supported."
+fi
+
+on_exit() {
+    [ -d "${TMP}" ] && rm -rf "${TMP}"
+}
+
+trap 'on_exit' EXIT
+trap 'exit' ERR
+
+TMP="$(mktemp -d)"
+
+# Test 1: LUKS2 device with default hash (sha256) — verify correct extraction.
+DEV="${TMP}/luks2-device-sha256"
+new_device_hash "luks2" "${DEV}" "sha256"
+
+hash=$(clevis_luks_get_hash "${DEV}")
+if [ "${hash}" != "sha256" ]; then
+    error "${TEST}: expected sha256, got '${hash}'."
+fi
+
+# Test 2: LUKS2 device with sha512 — verify correct extraction.
+DEV="${TMP}/luks2-device-sha512"
+new_device_hash "luks2" "${DEV}" "sha512"
+
+hash=$(clevis_luks_get_hash "${DEV}")
+if [ "${hash}" != "sha512" ]; then
+    error "${TEST}: expected sha512, got '${hash}'."
+fi
+
+# Test 3: LUKS2 device with sha384 — verify correct extraction.
+DEV="${TMP}/luks2-device-sha384"
+new_device_hash "luks2" "${DEV}" "sha384"
+
+hash=$(clevis_luks_get_hash "${DEV}")
+if [ "${hash}" != "sha384" ]; then
+    error "${TEST}: expected sha384, got '${hash}'."
+fi
+
+# Test 4: LUKS2 — verify we get keyslot hash, not digest hash.
+# Create device with sha512. The digest section uses sha256 by default.
+# Our function must return the keyslot hash (sha512), not the digest hash.
+DEV="${TMP}/luks2-device-keyslot-check"
+new_device_hash "luks2" "${DEV}" "sha512"
+
+# Verify that the digest section does contain a different hash.
+digest_hash=$(cryptsetup luksDump "${DEV}" \
+              | awk '/^Digests:/{in_digest=1} in_digest && /Hash:/{print $2; exit}')
+
+keyslot_hash=$(clevis_luks_get_hash "${DEV}")
+if [ "${keyslot_hash}" != "sha512" ]; then
+    error "${TEST}: keyslot hash should be sha512, got '${keyslot_hash}'."
+fi
+
+# If the digest hash differs, this confirms we are targeting the right section.
+if [ -n "${digest_hash}" ] && [ "${digest_hash}" != "sha512" ]; then
+    echo "${TEST}: confirmed digest hash (${digest_hash}) differs from" \
+         "keyslot hash (${keyslot_hash}) — extraction targets correct section."
+fi
+
+# Test 5: LUKS2 with sha1 — verify correct extraction.
+DEV="${TMP}/luks2-device-sha1"
+new_device_hash "luks2" "${DEV}" "sha1"
+
+hash=$(clevis_luks_get_hash "${DEV}")
+if [ "${hash}" != "sha1" ]; then
+    error "${TEST}: expected sha1, got '${hash}'."
+fi

--- a/src/luks/tests/get-hash-validation
+++ b/src/luks/tests/get-hash-validation
@@ -1,0 +1,77 @@
+#!/bin/bash -ex
+#
+# Copyright (c) 2026 Red Hat, Inc.
+# Author: Sergio Arroutbi <sarroutb@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test the hash validation used in clevis_luks_get_hash().
+# This test does not require root or LUKS devices — it exercises the
+# validation logic directly.
+
+TEST=$(basename "${0}")
+. tests-common-functions
+
+# is_valid_hash() mirrors the validation logic in clevis_luks_get_hash():
+#   case "${hash}" in *[!a-zA-Z0-9_-]*|"") return 1;; esac
+is_valid_hash() {
+    local hash="${1}"
+    case "${hash}" in
+        *[!a-zA-Z0-9_-]*|"") return 1;;
+    esac
+    return 0
+}
+
+# Test valid hashes — these must pass validation.
+for h in sha256 sha512 sha384 sha1 sha224 ripemd160 \
+         SHA256 SHA512 whirlpool blake2b-256 sha3_256; do
+    if ! is_valid_hash "${h}"; then
+        error "${TEST}: valid hash '${h}' was rejected."
+    fi
+done
+
+# Test invalid hashes — injection attempts and malformed values.
+# Each is tested individually to handle special characters safely.
+
+if is_valid_hash 'sha256; rm -rf /'; then
+    error "${TEST}: 'sha256; rm -rf /' should be rejected (semicolon)."
+fi
+
+if is_valid_hash 'sha256$(reboot)'; then
+    error "${TEST}: 'sha256\$(reboot)' should be rejected (command substitution)."
+fi
+
+if is_valid_hash 'sha256`reboot`'; then
+    error "${TEST}: 'sha256\`reboot\`' should be rejected (backticks)."
+fi
+
+if is_valid_hash 'sha256 --force'; then
+    error "${TEST}: 'sha256 --force' should be rejected (space)."
+fi
+
+if is_valid_hash 'sha256|cat /etc/shadow'; then
+    error "${TEST}: 'sha256|cat /etc/shadow' should be rejected (pipe)."
+fi
+
+if is_valid_hash 'sha256&bg_cmd'; then
+    error "${TEST}: 'sha256&bg_cmd' should be rejected (ampersand)."
+fi
+
+if is_valid_hash '--hash sha256'; then
+    error "${TEST}: '--hash sha256' should be rejected (space)."
+fi
+
+if is_valid_hash ''; then
+    error "${TEST}: empty string should be rejected."
+fi

--- a/src/luks/tests/meson.build
+++ b/src/luks/tests/meson.build
@@ -69,6 +69,9 @@ test('edit-tang-luks1', find_program('edit-tang-luks1'), env: env, timeout: 150)
 test('backup-restore-luks1', find_program('backup-restore-luks1'), env: env, timeout: 60)
 test('pass-tang-luks1', find_program('pass-tang-luks1'), env: env, timeout: 60)
 test('bind-luks1-avoid-luksmeta-corruption', find_program('bind-luks1-avoid-luksmeta-corruption'), env: env, timeout: 60)
+test('bind-hash-luks1', find_program('bind-hash-luks1'), env: env)
+test('regen-hash-luks1', find_program('regen-hash-luks1'), env: env, timeout: 60)
+test('edit-hash-luks1', find_program('edit-hash-luks1'), env: env, timeout: 60)
 
 # LUKS2 tests go here, and they get included if we get support for it, based
 # on the cryptsetup version.
@@ -99,6 +102,9 @@ if luksmeta_data.get('OLD_CRYPTSETUP') == '0'
 
   test('backup-restore-luks2', find_program('backup-restore-luks2'), env: env, timeout: 120)
   test('pass-tang-luks2', find_program('pass-tang-luks2'), env: env, timeout: 60)
+  test('bind-hash-luks2', find_program('bind-hash-luks2'), env: env, timeout: 60)
+  test('regen-hash-luks2', find_program('regen-hash-luks2'), env: env, timeout: 60)
+  test('edit-hash-luks2', find_program('edit-hash-luks2'), env: env, timeout: 60)
 endif
 
 test('unlock-arbitrary-parameter', find_program('unlock-arbitrary-parameter'), env: env)

--- a/src/luks/tests/meson.build
+++ b/src/luks/tests/meson.build
@@ -72,6 +72,8 @@ test('bind-luks1-avoid-luksmeta-corruption', find_program('bind-luks1-avoid-luks
 test('bind-hash-luks1', find_program('bind-hash-luks1'), env: env)
 test('regen-hash-luks1', find_program('regen-hash-luks1'), env: env, timeout: 60)
 test('edit-hash-luks1', find_program('edit-hash-luks1'), env: env, timeout: 60)
+test('get-hash-luks1', find_program('get-hash-luks1'), env: env, timeout: 60)
+test('get-hash-validation', find_program('get-hash-validation'), env: env)
 
 # LUKS2 tests go here, and they get included if we get support for it, based
 # on the cryptsetup version.
@@ -105,6 +107,7 @@ if luksmeta_data.get('OLD_CRYPTSETUP') == '0'
   test('bind-hash-luks2', find_program('bind-hash-luks2'), env: env, timeout: 60)
   test('regen-hash-luks2', find_program('regen-hash-luks2'), env: env, timeout: 60)
   test('edit-hash-luks2', find_program('edit-hash-luks2'), env: env, timeout: 60)
+  test('get-hash-luks2', find_program('get-hash-luks2'), env: env, timeout: 60)
 endif
 
 test('unlock-arbitrary-parameter', find_program('unlock-arbitrary-parameter'), env: env)

--- a/src/luks/tests/regen-hash-luks1
+++ b/src/luks/tests/regen-hash-luks1
@@ -73,10 +73,10 @@ if [ "${enabled}" -ne 1 ]; then
     error "${TEST}: we should have only one slot enabled (${enabled})."
 fi
 
+SLT=1
 old_key=$(clevis_luks_unlock_device_by_slot "${DEV}" "${SLT}")
 
 # Now let's try regen.
-SLT=1
 if ! clevis luks regen -q -d "${DEV}" -s "${SLT}"; then
     error "${TEST}: clevis luks regen failed"
 fi

--- a/src/luks/tests/regen-hash-luks1
+++ b/src/luks/tests/regen-hash-luks1
@@ -1,0 +1,101 @@
+#!/bin/bash -x
+#
+# Copyright (c) 2026 Red Hat, Inc.
+# Author: Sergio Arroutbi <sarroutb@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+TEST="${0}"
+. tests-common-functions
+. clevis-luks-common-functions
+
+function on_exit() {
+    [ -d "${TMP}" ] || return 0
+    tang_stop "${TMP}"
+    rm -rf "${TMP}"
+}
+
+trap 'on_exit' EXIT
+
+TMP=$(mktemp -d)
+
+tang_run "${TMP}"
+port=$(tang_get_port "${TMP}")
+
+url="http://localhost:${port}"
+adv="${TMP}/adv"
+tang_get_adv "${port}" "${adv}"
+
+cfg=$(printf '{"url":"%s","adv":"%s"}' "$url" "$adv")
+
+# LUKS1 with sha512.
+DEV="${TMP}/luks1-device-sha512"
+new_device_hash "luks1" "${DEV}" "sha512"
+
+# Verify the device was created with sha512.
+hash_before=$(cryptsetup luksDump "${DEV}" \
+              | sed -rn 's|^Hash spec:\s+(\S+)$|\1|p')
+if [ "${hash_before}" != "sha512" ]; then
+    error "${TEST}: Device should have been formatted with sha512, got ${hash_before}."
+fi
+
+if ! clevis luks bind -f -d "${DEV}" tang "${cfg}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: Bind should have succeeded."
+fi
+
+# Verify hash is still sha512 after binding.
+hash_after_bind=$(cryptsetup luksDump "${DEV}" \
+                  | sed -rn 's|^Hash spec:\s+(\S+)$|\1|p')
+if [ "${hash_after_bind}" != "sha512" ]; then
+    error "${TEST}: After binding, hash should be sha512, got ${hash_after_bind}."
+fi
+
+# Now let's remove the initial passphrase.
+if ! cryptsetup luksRemoveKey --batch-mode "${DEV}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: error removing the default password from ${DEV}."
+fi
+
+# Making sure we have a single slot enabled.
+enabled=$(clevis_luks_used_slots "${DEV}" | wc -l)
+if [ "${enabled}" -ne 1 ]; then
+    error "${TEST}: we should have only one slot enabled (${enabled})."
+fi
+
+old_key=$(clevis_luks_unlock_device_by_slot "${DEV}" "${SLT}")
+
+# Now let's try regen.
+SLT=1
+if ! clevis luks regen -q -d "${DEV}" -s "${SLT}"; then
+    error "${TEST}: clevis luks regen failed"
+fi
+
+new_key=$(clevis_luks_unlock_device_by_slot "${DEV}" "${SLT}")
+
+if [ "${old_key}" = "${new_key}" ]; then
+    error "${TEST}: the passphrases should be different"
+fi
+
+# Verify hash is still sha512 after regen.
+hash_after_regen=$(cryptsetup luksDump "${DEV}" \
+                   | sed -rn 's|^Hash spec:\s+(\S+)$|\1|p')
+if [ "${hash_after_regen}" != "sha512" ]; then
+    error "${TEST}: After regen, hash should be sha512, got ${hash_after_regen}."
+fi
+
+# Also check via clevis_luks_get_hash.
+hash_fn=$(clevis_luks_get_hash "${DEV}")
+if [ "${hash_fn}" != "sha512" ]; then
+    error "${TEST}: clevis_luks_get_hash should return sha512, got ${hash_fn}."
+fi

--- a/src/luks/tests/regen-hash-luks2
+++ b/src/luks/tests/regen-hash-luks2
@@ -1,0 +1,106 @@
+#!/bin/bash -x
+#
+# Copyright (c) 2026 Red Hat, Inc.
+# Author: Sergio Arroutbi <sarroutb@redhat.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+TEST="${0}"
+. tests-common-functions
+. clevis-luks-common-functions
+
+function on_exit() {
+    [ -d "${TMP}" ] || return 0
+    tang_stop "${TMP}"
+    rm -rf "${TMP}"
+}
+
+trap 'on_exit' EXIT
+
+TMP=$(mktemp -d)
+
+# LUKS2.
+if ! luks2_supported; then
+    skip_test "LUKS2 is not supported."
+fi
+
+tang_run "${TMP}"
+port=$(tang_get_port "${TMP}")
+
+url="http://localhost:${port}"
+adv="${TMP}/adv"
+tang_get_adv "${port}" "${adv}"
+
+cfg=$(printf '{"url":"%s","adv":"%s"}' "$url" "$adv")
+
+# LUKS2 with sha512.
+DEV="${TMP}/luks2-device-sha512"
+new_device_hash "luks2" "${DEV}" "sha512"
+
+# Verify the device was created with sha512.
+hash_before=$(cryptsetup luksDump "${DEV}" \
+              | sed -rn 's|^\s+Hash:\s+(\S+)$|\1|p' | head -1)
+if [ "${hash_before}" != "sha512" ]; then
+    error "${TEST}: Device should have been formatted with sha512, got ${hash_before}."
+fi
+
+if ! clevis luks bind -f -d "${DEV}" tang "${cfg}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: Bind should have succeeded."
+fi
+
+# Verify the clevis slot (slot 1) also uses sha512 after binding.
+hash_after_bind=$(cryptsetup luksDump "${DEV}" \
+                  | awk '/^[[:space:]]+1: luks/{found=1} found && /Hash:/{print $2; exit}')
+if [ "${hash_after_bind}" != "sha512" ]; then
+    error "${TEST}: After binding, clevis slot hash should be sha512, got ${hash_after_bind}."
+fi
+
+# Now let's remove the initial passphrase.
+if ! cryptsetup luksRemoveKey --batch-mode "${DEV}" <<< "${DEFAULT_PASS}"; then
+    error "${TEST}: error removing the default password from ${DEV}."
+fi
+
+# Making sure we have a single slot enabled.
+enabled=$(clevis_luks_used_slots "${DEV}" | wc -l)
+if [ "${enabled}" -ne 1 ]; then
+    error "${TEST}: we should have only one slot enabled (${enabled})."
+fi
+
+old_key=$(clevis_luks_unlock_device_by_slot "${DEV}" "${SLT}")
+
+# Now let's try regen.
+SLT=1
+if ! clevis luks regen -q -d "${DEV}" -s "${SLT}"; then
+    error "${TEST}: clevis luks regen failed"
+fi
+
+new_key=$(clevis_luks_unlock_device_by_slot "${DEV}" "${SLT}")
+
+if [ "${old_key}" = "${new_key}" ]; then
+    error "${TEST}: the passphrases should be different"
+fi
+
+# Verify the clevis slot (slot 1) still uses sha512 after regen.
+hash_after_regen=$(cryptsetup luksDump "${DEV}" \
+                   | awk '/^[[:space:]]+1: luks/{found=1} found && /Hash:/{print $2; exit}')
+if [ "${hash_after_regen}" != "sha512" ]; then
+    error "${TEST}: After regen, clevis slot hash should be sha512, got ${hash_after_regen}."
+fi
+
+# Also check via clevis_luks_get_hash.
+hash_fn=$(clevis_luks_get_hash "${DEV}")
+if [ "${hash_fn}" != "sha512" ]; then
+    error "${TEST}: clevis_luks_get_hash should return sha512, got ${hash_fn}."
+fi

--- a/src/luks/tests/regen-hash-luks2
+++ b/src/luks/tests/regen-hash-luks2
@@ -78,10 +78,10 @@ if [ "${enabled}" -ne 1 ]; then
     error "${TEST}: we should have only one slot enabled (${enabled})."
 fi
 
+SLT=1
 old_key=$(clevis_luks_unlock_device_by_slot "${DEV}" "${SLT}")
 
 # Now let's try regen.
-SLT=1
 if ! clevis luks regen -q -d "${DEV}" -s "${SLT}"; then
     error "${TEST}: clevis luks regen failed"
 fi

--- a/src/luks/tests/regen-inplace-luks1
+++ b/src/luks/tests/regen-inplace-luks1
@@ -60,10 +60,10 @@ if [ "${enabled}" -ne 1 ]; then
     error "${TEST}: we should have only one slot enabled (${enabled})."
 fi
 
+SLT=1
 old_key=$(clevis_luks_unlock_device_by_slot "${DEV}" "${SLT}")
 
 # Now let's try regen.
-SLT=1
 if ! clevis luks regen -q -d "${DEV}" -s "${SLT}"; then
     error "${TEST}: clevis luks regen failed"
 fi

--- a/src/luks/tests/regen-inplace-luks2
+++ b/src/luks/tests/regen-inplace-luks2
@@ -60,10 +60,10 @@ if [ "${enabled}" -ne 1 ]; then
     error "${TEST}: we should have only one slot enabled (${enabled})."
 fi
 
+SLT=1
 old_key=$(clevis_luks_unlock_device_by_slot "${DEV}" "${SLT}")
 
 # Now let's try regen.
-SLT=1
 if ! clevis luks regen -q -d "${DEV}" -s "${SLT}"; then
     error "${TEST}: clevis luks regen failed"
 fi

--- a/src/luks/tests/tests-common-functions.in
+++ b/src/luks/tests/tests-common-functions.in
@@ -76,6 +76,30 @@ new_device() {
     cp -f "${DEV}" "${DEV_CACHED}"
 }
 
+# Creates a new LUKS1 or LUKS2 device with a specific hash algorithm.
+new_device_hash() {
+    local LUKS="${1}"
+    local DEV="${2}"
+    local HASH="${3}"
+    local PASS="${4}"
+
+    # Some builders fail if the cryptsetup steps are not ran as root, so let's
+    # skip the test now if not running as root.
+    if [ "$(id -u)" != 0 ]; then
+        skip_test "WARNING: You must be root to run this test; test skipped."
+    fi
+
+    # Using a default password, if none has been provided.
+    if [ -z "${PASS}" ]; then
+        PASS="${DEFAULT_PASS}"
+    fi
+
+    fallocate -l64M "${DEV}"
+    cryptsetup luksFormat --type "${LUKS}" --hash "${HASH}" --pbkdf pbkdf2 \
+        --pbkdf-force-iterations 1000 --key-size 512 --batch-mode \
+        --force-password "${DEV}" <<< "${PASS}"
+}
+
 # Creates a new LUKS1 or LUKS2 device to be used, using a keyfile.
 new_device_keyfile() {
     local LUKS="${1}"

--- a/src/luks/tests/tests-common-functions.in
+++ b/src/luks/tests/tests-common-functions.in
@@ -94,7 +94,8 @@ new_device_hash() {
         PASS="${DEFAULT_PASS}"
     fi
 
-    fallocate -l64M "${DEV}"
+    fallocate -l64M "${DEV}" 2>/dev/null \
+        || dd if=/dev/zero of="${DEV}" bs=1M count=64 status=none
     cryptsetup luksFormat --type "${LUKS}" --hash "${HASH}" --pbkdf pbkdf2 \
         --pbkdf-force-iterations 1000 --key-size 512 --batch-mode \
         --force-password "${DEV}" <<< "${PASS}"


### PR DESCRIPTION
When a LUKS device is formatted with a non-default hash algorithm (e.g. sha512), clevis operations that add or update key slots (bind, regen, edit) did not pass the original hash to cryptsetup, causing new slots to silently default to sha256.
    
Add clevis_luks_get_hash() to extract the device's hash algorithm from the LUKS header (supports both LUKS1 "Hash spec:" and LUKS2 "Hash:" fields). Use it in clevis_luks_add_key() and clevis_luks_update_key() to pass --hash to cryptsetup, preserving the original hash algorithm.
    
Add unit tests for bind, regen and edit operations on both LUKS1 and LUKS2 devices formatted with sha512, verifying the hash is preserved through each operation.
