### PR TITLE
Add meson build option to make tpm1 pin optional

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -63,3 +63,5 @@ if a2x.found()
 else
   warning('Will not build man pages due to missing dependencies!')
 endif
+
+summary('TPM 1.2 pin', get_option('tpm1'), section: 'Features')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,3 @@
 option('user', type: 'string', value: 'clevis', description: 'Unprivileged user for secure clevis operations')
 option('group', type: 'string', value: 'clevis', description: 'Unprivileged group for secure clevis operations')
+option('tpm1', type: 'feature', value: 'auto', description: 'Enable TPM 1.2 pin support')

--- a/src/luks/dracut/meson.build
+++ b/src/luks/dracut/meson.build
@@ -1,6 +1,8 @@
 subdir('clevis')
 subdir('clevis-pin-tang')
-subdir('clevis-pin-tpm1')
+if not get_option('tpm1').disabled()
+  subdir('clevis-pin-tpm1')
+endif
 subdir('clevis-pin-tpm2')
 subdir('clevis-pin-sss')
 subdir('clevis-pin-null')

--- a/src/luks/meson.build
+++ b/src/luks/meson.build
@@ -28,11 +28,13 @@ clevis_luks_common_functions = configure_file(
   configuration: luksmeta_data
 )
 
-clevis_luks_tpm1_functions = configure_file(
-  input: 'clevis-luks-tpm1-functions.in',
-  output: 'clevis-luks-tpm1-functions',
-  configuration: data
-)
+if not get_option('tpm1').disabled()
+  clevis_luks_tpm1_functions = configure_file(
+    input: 'clevis-luks-tpm1-functions.in',
+    output: 'clevis-luks-tpm1-functions',
+    configuration: data
+  )
+endif
 
 clevis_luks_unbind = configure_file(input: 'clevis-luks-unbind.in',
                output: 'clevis-luks-unbind',
@@ -84,7 +86,9 @@ if libcryptsetup.found() and luksmeta.found()
   bins += join_paths(meson.current_source_dir(), 'clevis-luks-pass')
   mans += join_paths(meson.current_source_dir(), 'clevis-luks-pass.1')
 
-  install_data(clevis_luks_tpm1_functions, install_dir: libexecdir)
+  if not get_option('tpm1').disabled()
+    install_data(clevis_luks_tpm1_functions, install_dir: libexecdir)
+  endif
 else
   warning('Will not install LUKS support due to missing dependencies!')
 endif

--- a/src/luks/systemd/clevis-luks-askpass.service.in
+++ b/src/luks/systemd/clevis-luks-askpass.service.in
@@ -2,8 +2,8 @@
 Description=Forward Password Requests to Clevis
 Documentation=man:clevis-luks-unlockers(7)
 DefaultDependencies=no
-After=tcsd.service
-Wants=tcsd.service
+@TCSD_AFTER@
+@TCSD_WANTS@
 Before=shutdown.target
 Conflicts=shutdown.target
 

--- a/src/luks/systemd/meson.build
+++ b/src/luks/systemd/meson.build
@@ -4,7 +4,6 @@ if systemd.found() and sd_reply_pass.found()
   systemd_data.set('SYSTEMD_REPLY_PASS', sd_reply_pass.path())
 
   unitdir = systemd.get_pkgconfig_variable('systemdsystemunitdir')
-  tcsdoverridedir = join_paths(unitdir, 'tcsd.service.d')
 
   configure_file(
     input: 'clevis-luks-askpass.service.in',
@@ -39,7 +38,11 @@ if systemd.found() and sd_reply_pass.found()
 
   install_data('clevis-luks-askpass.path', install_dir: unitdir)
   install_data('clevis-luks-pkcs11-askpass.socket', install_dir: unitdir)
-  install_data('clevis-tcsd.conf', install_dir: tcsdoverridedir)
+
+  if not get_option('tpm1').disabled()
+    tcsdoverridedir = join_paths(unitdir, 'tcsd.service.d')
+    install_data('clevis-tcsd.conf', install_dir: tcsdoverridedir)
+  endif
 else
   warning('Will not install systemd support due to missing dependencies!')
 endif

--- a/src/luks/systemd/meson.build
+++ b/src/luks/systemd/meson.build
@@ -3,6 +3,14 @@ if systemd.found() and sd_reply_pass.found()
   systemd_data.merge_from(data)
   systemd_data.set('SYSTEMD_REPLY_PASS', sd_reply_pass.path())
 
+  if not get_option('tpm1').disabled()
+    systemd_data.set('TCSD_AFTER', 'After=tcsd.service')
+    systemd_data.set('TCSD_WANTS', 'Wants=tcsd.service')
+  else
+    systemd_data.set('TCSD_AFTER', '')
+    systemd_data.set('TCSD_WANTS', '')
+  endif
+
   unitdir = systemd.get_pkgconfig_variable('systemdsystemunitdir')
 
   configure_file(

--- a/src/pins/meson.build
+++ b/src/pins/meson.build
@@ -1,6 +1,8 @@
 subdir('file')
 subdir('sss')
 subdir('tang')
-subdir('tpm1')
+if not get_option('tpm1').disabled()
+  subdir('tpm1')
+endif
 subdir('tpm2')
 subdir('pkcs11')

--- a/src/pins/tpm1/meson.build
+++ b/src/pins/tpm1/meson.build
@@ -2,7 +2,7 @@ cmds = ['tpm_sealdata', 'tpm_unsealdata']
 
 all = true
 foreach cmd : cmds
-  all = all and find_program(cmd, required: false).found()
+  all = all and find_program(cmd, required: get_option('tpm1').enabled()).found()
 endforeach
 
 if all


### PR DESCRIPTION
Add a 'tpm1' feature option (auto/enabled/disabled) to allow distros to disable TPM 1.2 support at build time. When disabled, none of the tpm1 pin sources, tests, dracut modules, systemd units, or LUKS helper functions are built or installed.

The default is 'auto' which preserves existing behavior: build tpm1 if dependencies (tpm_sealdata, tpm_unsealdata) are found, skip gracefully otherwise.