### PR TITLE
dracut: fix some portability issues in non-systemd environments

### DIFF
--- a/src/luks/dracut/clevis/meson.build
+++ b/src/luks/dracut/clevis/meson.build
@@ -5,7 +5,7 @@ if dracut.found()
 
   dracut_data = configuration_data()
   dracut_data.merge_from(data)
-  dracut_data.set('SYSTEMD_REPLY_PASS', sd_reply_pass.path())
+  dracut_data.set('SYSTEMD_REPLY_PASS', sd_reply_pass.found() ? sd_reply_pass.path() : '')
 
   configure_file(
     input: 'module-setup.sh.in',

--- a/src/luks/dracut/clevis/module-setup.sh.in
+++ b/src/luks/dracut/clevis/module-setup.sh.in
@@ -52,6 +52,7 @@ install() {
         inst_script "$moddir"/clevis-password-unlocker-prepare /bin/clevis-password-unlocker-prepare
         inst_multiple \
             clevis-luks-unlock \
+            chmod \
             blkid
     fi
 


### PR DESCRIPTION
Fixes some issues I ran into when trying to use Clevis in Void Linux:
- Missing `chmod` install in my init environment but is used by unlocker scripts.
- `systemd-reply-password` path was required during build time. It falls back to empty string since it's not used with the dracut hooks path.

Thanks.