### PR TITLE
dracut/tang: Order clevis-luks-askpass after network-online.target and more fixes

### DIFF
--- a/src/luks/dracut/clevis-pin-tang/module-setup.sh.in
+++ b/src/luks/dracut/clevis-pin-tang/module-setup.sh.in
@@ -25,9 +25,10 @@ depends() {
 
 have_tang_bindings() {
     . clevis-luks-common-functions
-    local dev
+    local dev bindings
     for dev in $(clevis_devices_to_unlock "list-open-devices"); do
-        if clevis luks list -d "${dev}" -p | grep -qw tang; then
+        bindings="$(clevis luks list -d "${dev}" -p 2>/dev/null)" || :
+        if echo "${bindings}" | grep -qw tang; then
             return 0
         fi
     done

--- a/src/luks/dracut/clevis-pin-tang/module-setup.sh.in
+++ b/src/luks/dracut/clevis-pin-tang/module-setup.sh.in
@@ -37,6 +37,16 @@ have_tang_bindings() {
 install() {
     if [ "${hostonly_cmdline}" = "yes" ] && have_tang_bindings; then
         echo "rd.neednet=1" > "${initdir}/etc/cmdline.d/99clevis-pin-tang.conf"
+
+        if dracut_module_included "systemd"; then
+            # shellcheck disable=SC2154 # $systemdsystemunitdir is a dracut variable
+            mkdir -p "${initdir}/${systemdsystemunitdir}/clevis-luks-askpass.path.d"
+            cat > "${initdir}/${systemdsystemunitdir}/clevis-luks-askpass.path.d/network-online.conf" <<EOF
+[Unit]
+After=network-online.target
+Wants=network-online.target
+EOF
+        fi
     fi
 
     inst_multiple \

--- a/src/luks/dracut/clevis-pin-tang/module-setup.sh.in
+++ b/src/luks/dracut/clevis-pin-tang/module-setup.sh.in
@@ -27,7 +27,7 @@ have_tang_bindings() {
     . clevis-luks-common-functions
     local dev
     for dev in $(clevis_devices_to_unlock "list-open-devices"); do
-        if clevis luks list -d "${dev}" -p | grep -q tang; then
+        if clevis luks list -d "${dev}" -p | grep -qw tang; then
             return 0
         fi
     done


### PR DESCRIPTION
When Tang bindings are present, `rd.neednet=1` is set to bring up the network in the initramfs, but `clevis-luks-askpass.path` has no ordering dependency on `network-online.target`. This means systemd can activate the askpass path unit before the network is ready, causing curl to fail when contacting the Tang server:

~~~
Jun 18 10:32:39 vm-clevis10 clevis-luks-askpass[760]: Error communicating with server http://vm-tang10
~~~

Install a systemd drop-in for `clevis-luks-askpass.path` that adds `After=network-online.target` and `Wants=network-online.target`, ensuring the network is online before clevis attempts to decrypt via Tang.