### PR TITLE
dracut: install chmod into initramfs

### DIFF
--- a/src/luks/dracut/clevis/module-setup.sh.in
+++ b/src/luks/dracut/clevis/module-setup.sh.in
@@ -60,6 +60,7 @@ install() {
         clevis-luks-common-functions \
         awk date ps sort touch tr \
         grep sed cut \
+        chmod \
         clevis-decrypt \
         clevis-luks-list \
         cryptsetup \


### PR DESCRIPTION
## Summary

The dracut module installs `clevis-password-unlocker` and `clevis-password-unlocker-prepare`, both of which invoke `chmod`, but `chmod` is not installed into the initramfs.

This results in the following warning during early boot on systems where `chmod` is not otherwise present in the initramfs:

```
/bin/clevis-password-unlocker-prepare: line 25: chmod: command not found
/bin/clevis-password-unlocker: line 183: chmod: command not found
```

This change adds `chmod` to the list of binaries installed by `module-setup.sh`, ensuring it is available when these scripts execute.

## Testing

Tested on Void Linux with dracut and a TPM2-bound LUKS root volume.

Before this change:

- `lsinitrd` confirmed that `chmod` was not present in the initramfs.
- The above warnings were printed during early boot.

After this change:

- `chmod` is included in the initramfs.
- The warnings disappear.
- TPM2 auto-unlock continues to work correctly.
