### PR TITLE
build: Non-automagic pkcs11 pin support

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
 option('user', type: 'string', value: 'clevis', description: 'Unprivileged user for secure clevis operations')
 option('group', type: 'string', value: 'clevis', description: 'Unprivileged group for secure clevis operations')
 option('tpm1', type: 'feature', value: 'auto', description: 'Enable TPM 1.2 pin support')
+option('pkcs11', type: 'feature', value: 'auto', description: 'Enable PKCS11 pin support')

--- a/src/pins/pkcs11/meson.build
+++ b/src/pins/pkcs11/meson.build
@@ -1,5 +1,5 @@
-pcscd = find_program('pcscd', required: false)
-pkcs11tool = find_program('pkcs11-tool', required: false)
+pcscd = find_program('pcscd', required: get_option('pkcs11'))
+pkcs11tool = find_program('pkcs11-tool', required: get_option('pkcs11'))
 pcscd_disable_polkit = false
 git = find_program('git', required: false)
 
@@ -37,7 +37,7 @@ if pcscd.found() and pkcs11tool.found()
     install: true,
     c_args: GIT_VERSION_FLAG
   )
-else
+elif get_option('pkcs11').auto()
   warning('Will not install pkcs11 pin due to missing dependencies!')
   if not pcscd.found()
     warning('pcscd not found')


### PR DESCRIPTION
All the pins (except tpm1) use automagic detection. Most of the other pins this isn't really a problem, as their dependencies are small and/or already likely to be installed. However, the pkcs11 pin pulls in pcsc-lite (which isn't a very common package), which is turns pulls in polkit (which some people consider bloat) and all its dependencies. 

The others are either have low dependency requirements, or are highly desirable (tpm2), and can simply be made outright requirements by the packager. 