### PR TITLE
fix: clevis-luks-list didn't show all configured bindings

### DIFF
--- a/src/luks/clevis-luks-common-functions.in
+++ b/src/luks/clevis-luks-common-functions.in
@@ -293,7 +293,7 @@ clevis_luks_process_sss_pin() {
             sss_tpm2="${sss_tpm2},${cfg}"
             ;;
         sss)
-            sss=$(echo "${cfg}" | tr -d "'")
+            sss="${sss},${cfg}"
             ;;
         esac
     done
@@ -304,7 +304,7 @@ clevis_luks_process_sss_pin() {
     fi
 
     if [ -n "${sss_tang}" ]; then
-        cfg=$(clevis_luks_join_sss_cfg "tang" "${sss_tang}")
+        cfg="${cfg},"$(clevis_luks_join_sss_cfg "tang" "${sss_tang}")
     fi
 
     if [ -n "${sss_tpm1}" ]; then
@@ -320,7 +320,7 @@ clevis_luks_process_sss_pin() {
     fi
 
     if [ -n "${sss}" ]; then
-        cfg=$(printf '%s,"sss":%s' "${cfg}" "${sss}")
+        cfg="${cfg},"$(clevis_luks_join_sss_cfg "sss" "${sss}")
     fi
 
     # Remove possible leading comma.

--- a/src/luks/tests/list-recursive-luks1
+++ b/src/luks/tests/list-recursive-luks1
@@ -38,21 +38,25 @@ CFG=$(printf '
 {
   "t": 1,
   "pins": {
-    "sss": {
-      "t": 1,
-      "pins": {
-        "sss": {
-          "t": 1,
-          "pins": {
-            "tang": [
-              {
-                "url": "ADDR","adv": "%s"
+    "sss": [
+      {
+        "t": 1,
+        "pins": {
+          "sss": [
+            {
+              "t": 1,
+              "pins": {
+                "tang": [
+                  {
+                    "url": "ADDR","adv": "%s"
+                  }
+                ]
               }
-            ]
-          }
+            }
+          ]
         }
       }
-    }
+    ]
   }
 }
 ' "${ADV}")

--- a/src/luks/tests/list-recursive-luks2
+++ b/src/luks/tests/list-recursive-luks2
@@ -38,21 +38,25 @@ CFG=$(printf '
 {
   "t": 1,
   "pins": {
-    "sss": {
-      "t": 1,
-      "pins": {
-        "sss": {
-          "t": 1,
-          "pins": {
-            "tang": [
-              {
-                "url": "ADDR","adv": "%s"
+    "sss": [
+      {
+        "t": 1,
+        "pins": {
+          "sss": [
+            {
+              "t": 1,
+              "pins": {
+                "tang": [
+                  {
+                    "url": "ADDR","adv": "%s"
+                  }
+                ]
               }
-            ]
-          }
+            }
+          ]
         }
       }
-    }
+    ]
   }
 }
 ' "${ADV}")


### PR DESCRIPTION
Previously, the value of sss was overwritten every time, so only the last entry for sss pins was displayed. Fix this by saving them all and instead of manually processing the sss pin, reuse clevis_luks_join_sss_cfg as it is used in the other functions

Fixes https://github.com/latchset/clevis/issues/505.

The test adjustments are needed since previously the command always
listed an object for sss instead of a list. This is not the way
it works for other pins, for example tang does always give you a list.

So if you apply this patch:
```diff
diff --git a/src/luks/tests/list-sss-tang-luks2 b/src/luks/tests/list-sss-tang-luks2
index 5f05696..a9dad34 100755
--- a/src/luks/tests/list-sss-tang-luks2
+++ b/src/luks/tests/list-sss-tang-luks2
@@ -36,15 +36,9 @@ PIN="sss"
 PINS="sss tang"
 CFG=$(printf '
 {
-   "t": 2,
+   "t": 1,
    "pins": {
-     "tang": [
-       {"url":"ADDR1","adv":"%s"},
-       {"url":"ADDR2","adv":"%s"},
-       {"url":"ADDR3","adv":"%s"},
-       {"url":"ADDR4","adv":"%s"},
-       {"url":"ADDR5","adv":"%s"}
-     ]
+     "tang": {"url":"ADDR1","adv":"%s"}
    }
 }
 ' "${ADV}" "${ADV}" "${ADV}" "${ADV}" "${ADV}")
```

to only have one tang config and not have it in a list, the test
`list-sss-tang-luks2` will also fail with non-matching configs even
outside of this branch. So while both formats are equivalent, we can't
reasonably determine which format was used on encryption and we should
use one format everywhere. It makes sense to adapt the more general
format that is already used for tang and tpm.