### PR TITLE
remove unecessary dependency on 'network' module from 'clevis-pin-tpm1' dracut module

### DIFF
--- a/src/luks/dracut/clevis-pin-tpm1/module-setup.sh.in
+++ b/src/luks/dracut/clevis-pin-tpm1/module-setup.sh.in
@@ -83,7 +83,7 @@ check() {
 }
 
 depends() {
-    echo clevis network
+    echo clevis
     return 0
 }
 


### PR DESCRIPTION
Fixes https://github.com/latchset/clevis/issues/571